### PR TITLE
fix: enable prerelease detection in auto-updater

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -14,6 +14,7 @@ const { setup: setupPushReceiver } = require('@superhuman/electron-push-receiver
 autoUpdater.logger = log;
 autoUpdater.autoDownload = true;
 autoUpdater.autoInstallOnAppQuit = true;
+autoUpdater.allowPrerelease = true;
 
 interface PrinterConfig {
   id: number;


### PR DESCRIPTION
Without allowPrerelease=true, electron-updater ignores alpha/beta releases.