### PR TITLE
feat: add update channel selector to configuration dialog

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -14,7 +14,42 @@ const { setup: setupPushReceiver } = require('@superhuman/electron-push-receiver
 autoUpdater.logger = log;
 autoUpdater.autoDownload = true;
 autoUpdater.autoInstallOnAppQuit = true;
-autoUpdater.allowPrerelease = true;
+
+function configureUpdateChannel(): void {
+  try {
+    const configPath = path.join(app.getPath('userData'), 'config', 'config-backup.json');
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      const channel = config.updateChannel || 'stable';
+      log.info(`Update channel from config: ${channel}`);
+      applyUpdateChannel(channel);
+    } else {
+      log.info('No config file found, defaulting to stable channel');
+      applyUpdateChannel('stable');
+    }
+  } catch (e) {
+    log.error('Error reading update channel config:', e);
+    applyUpdateChannel('stable');
+  }
+}
+
+function applyUpdateChannel(channel: string): void {
+  switch (channel) {
+    case 'alpha':
+      autoUpdater.allowPrerelease = true;
+      autoUpdater.channel = 'alpha';
+      break;
+    case 'beta':
+      autoUpdater.allowPrerelease = true;
+      autoUpdater.channel = 'beta';
+      break;
+    default:
+      autoUpdater.allowPrerelease = false;
+      autoUpdater.channel = 'latest';
+      break;
+  }
+  log.info(`Auto-updater configured: channel=${autoUpdater.channel}, allowPrerelease=${autoUpdater.allowPrerelease}`);
+}
 
 interface PrinterConfig {
   id: number;
@@ -200,6 +235,11 @@ export async function createWindow(): Promise<BrowserWindow> {
 
 ipcMain.on('get-config-file', (event: any, arg: any) => {
   console.log(arg)
+})
+
+ipcMain.on('set-update-channel', (event: any, channel: string) => {
+  log.info(`Update channel changed to: ${channel}`);
+  applyUpdateChannel(channel);
 })
 
 ipcMain.on('reiniciar', (event: any, arg: any) => {
@@ -876,6 +916,7 @@ try {
     });
 
     if (!isDev) {
+      configureUpdateChannel();
       autoUpdater.checkForUpdatesAndNotify();
       setInterval(() => {
         log.info('Buscando actualizacion...');

--- a/src/app/shared/components/configuracion-dialog/configuracion-dialog.component.html
+++ b/src/app/shared/components/configuracion-dialog/configuracion-dialog.component.html
@@ -67,6 +67,16 @@
     </mat-form-field>
     
     <mat-checkbox formControlName="isLocal">Usar Servidor Local</mat-checkbox>
+
+    <mat-form-field>
+      <mat-label>Canal de Actualización</mat-label>
+      <mat-select formControlName="updateChannel">
+        <mat-option value="stable">Estable (Producción)</mat-option>
+        <mat-option value="beta">Beta (Pre-producción)</mat-option>
+        <mat-option value="alpha">Alpha (Desarrollo)</mat-option>
+      </mat-select>
+      <mat-hint>Determina qué versiones recibe esta máquina</mat-hint>
+    </mat-form-field>
   </form>
 </mat-dialog-content>
 

--- a/src/app/shared/components/configuracion-dialog/configuracion-dialog.component.ts
+++ b/src/app/shared/components/configuracion-dialog/configuracion-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { ConfiguracionSistema, ConfiguracionService } from '../../services/configuracion.service';
+import { ConfiguracionSistema, ConfiguracionService, UpdateChannel } from '../../services/configuracion.service';
 
 @Component({
   selector: 'app-configuracion-dialog',
@@ -30,7 +30,8 @@ export class ConfiguracionDialogComponent implements OnInit {
       ticketPrinter: [this.data.printers?.ticket || ''],
       facturaPrinter: [this.data.printers?.factura || ''],
       modo: [this.data.modo],
-      isLocal: [this.data.isLocal !== undefined ? this.data.isLocal : true]
+      isLocal: [this.data.isLocal !== undefined ? this.data.isLocal : true],
+      updateChannel: [this.data.updateChannel || 'stable']
     });
   }
 
@@ -49,6 +50,7 @@ export class ConfiguracionDialogComponent implements OnInit {
         precios: formValue.precios,
         modo: formValue.modo,
         isLocal: formValue.isLocal,
+        updateChannel: formValue.updateChannel,
         printers: {
           ticket: formValue.ticketPrinter,
           factura: formValue.facturaPrinter
@@ -81,6 +83,7 @@ export class ConfiguracionDialogComponent implements OnInit {
       precios: formValue.precios || this.data.precios,
       modo: formValue.modo || this.data.modo,
       isLocal: formValue.isLocal !== undefined ? formValue.isLocal : this.data.isLocal,
+      updateChannel: formValue.updateChannel || this.data.updateChannel || 'stable',
       printers: {
         ticket: formValue.ticketPrinter || this.data.printers?.ticket || '',
         factura: formValue.facturaPrinter || this.data.printers?.factura || ''

--- a/src/app/shared/services/configuracion.service.ts
+++ b/src/app/shared/services/configuracion.service.ts
@@ -581,7 +581,8 @@ export class ConfiguracionService {
           modo: localStorage.getItem(LEGACY_KEYS.modo) || 'NOT',
           pdvId: parseInt(localStorage.getItem(LEGACY_KEYS.pdvId) || '1', 10),
           isConfigured: false,
-          isLocal: true
+          isLocal: true,
+          updateChannel: DEFAULT_CONFIG.updateChannel
         };
 
         // Save the migrated config
@@ -629,6 +630,7 @@ export class ConfiguracionService {
             pdvId: response.pdvId ?? DEFAULT_CONFIG.pdvId,
             isConfigured: false, // Always mark as not configured since it's from a file
             isLocal: response.isLocal ?? DEFAULT_CONFIG.isLocal,
+            updateChannel: response.updateChannel || DEFAULT_CONFIG.updateChannel,
             printers: {
               ticket: response.printers?.ticket || DEFAULT_CONFIG.printers.ticket,
               factura: response.printers?.factura || DEFAULT_CONFIG.printers.factura
@@ -653,7 +655,8 @@ export class ConfiguracionService {
             modo: response.modo || DEFAULT_CONFIG.modo,
             pdvId: response.pdvId ?? DEFAULT_CONFIG.pdvId,
             isConfigured: false,
-            isLocal: response.isLocal ?? DEFAULT_CONFIG.isLocal
+            isLocal: response.isLocal ?? DEFAULT_CONFIG.isLocal,
+            updateChannel: DEFAULT_CONFIG.updateChannel
           };
         }
 

--- a/src/app/shared/services/configuracion.service.ts
+++ b/src/app/shared/services/configuracion.service.ts
@@ -5,6 +5,8 @@ import { catchError, map, tap, switchMap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { ConfiguracionDialogComponent } from '../components/configuracion-dialog/configuracion-dialog.component';
 
+export type UpdateChannel = 'stable' | 'beta' | 'alpha';
+
 export interface ConfiguracionSistema {
   serverIp: string;
   serverPort: string;
@@ -20,6 +22,7 @@ export interface ConfiguracionSistema {
   pdvId: number;
   isConfigured: boolean;
   isLocal: boolean;
+  updateChannel: UpdateChannel;
 }
 
 import { environment } from '../../../environments/environment';
@@ -43,7 +46,8 @@ const DEFAULT_CONFIG: ConfiguracionSistema = {
   modo: 'NOT',
   pdvId: null,
   isConfigured: false,
-  isLocal: true
+  isLocal: true,
+  updateChannel: 'stable' as UpdateChannel
 };
 
 const LEGACY_KEYS = {
@@ -305,6 +309,7 @@ export class ConfiguracionService {
       pdvId: config.pdvId ?? DEFAULT_CONFIG.pdvId,
       isConfigured: config.isConfigured ?? DEFAULT_CONFIG.isConfigured,
       isLocal: config.isLocal ?? DEFAULT_CONFIG.isLocal,
+      updateChannel: config.updateChannel || DEFAULT_CONFIG.updateChannel,
       printers: {
         ticket: config.printers?.ticket || DEFAULT_CONFIG.printers.ticket,
         factura: config.printers?.factura || DEFAULT_CONFIG.printers.factura
@@ -535,6 +540,17 @@ export class ConfiguracionService {
       // Update the BehaviorSubject
       this.config = validConfig;
       this.configChanged.next(validConfig);
+
+      // Notify Electron main process of channel change
+      try {
+        const isElectron = window && typeof window['require'] === 'function';
+        if (isElectron) {
+          const { ipcRenderer } = window['require']('electron');
+          ipcRenderer.send('set-update-channel', validConfig.updateChannel || 'stable');
+        }
+      } catch (e) {
+        console.warn('Could not notify main process of update channel change:', e);
+      }
     } catch (e) {
       console.error('Error saving configuration:', e);
     }


### PR DESCRIPTION
## Summary
- Add `updateChannel` field to `ConfiguracionSistema` interface (stable/beta/alpha)
- Add dropdown selector in configuration dialog
- Main process reads channel from config file at startup
- IPC handler allows runtime channel changes without restart
- Default: `stable` (only receives stable releases)

## Test plan
- [ ] CI passes
- [ ] After merge, set channel to alpha on test machine and verify it detects alpha releases
- [ ] Set channel to stable and verify it ignores prereleases