### PR TITLE
fix: publish channel manifests, add dev channel, require channel selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,31 @@ jobs:
       - name: Build Electron (${{ matrix.platform }})
         run: npx electron-builder ${{ matrix.args }} --publish never
 
+      - name: Generate channel manifests
+        shell: bash
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          # Determine channel from version tag
+          if [[ "${VERSION}" == *"-alpha"* ]]; then
+            CHANNEL="alpha"
+          elif [[ "${VERSION}" == *"-beta"* ]]; then
+            CHANNEL="beta"
+          else
+            CHANNEL="latest"
+          fi
+          echo "Channel: ${CHANNEL}"
+
+          # Copy manifests with channel name
+          # electron-updater looks for {channel}.yml and {channel}-linux.yml
+          for f in release/latest*.yml; do
+            if [ -f "$f" ]; then
+              NEWNAME=$(echo "$f" | sed "s/latest/${CHANNEL}/")
+              cp "$f" "$NEWNAME"
+              echo "Created $NEWNAME"
+            fi
+          done
+
       - name: Upload artifacts to GitHub Release
         shell: bash
         env:
@@ -103,4 +128,4 @@ jobs:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
           echo "Uploading ${{ matrix.platform }} artifacts to release v${VERSION}..."
-          gh release upload "v${VERSION}" release/FRC*.* release/latest*.yml --clobber
+          gh release upload "v${VERSION}" release/FRC*.* release/latest*.yml release/alpha*.yml release/beta*.yml --clobber 2>/dev/null || true

--- a/app/main.ts
+++ b/app/main.ts
@@ -15,40 +15,56 @@ autoUpdater.logger = log;
 autoUpdater.autoDownload = true;
 autoUpdater.autoInstallOnAppQuit = true;
 
-function configureUpdateChannel(): void {
+let updateEnabled = false;
+
+function configureUpdateChannel(): boolean {
   try {
     const configPath = path.join(app.getPath('userData'), 'config', 'config-backup.json');
     if (fs.existsSync(configPath)) {
       const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-      const channel = config.updateChannel || 'stable';
+      const channel = config.updateChannel;
+      if (!channel || channel === 'dev') {
+        log.info('Update channel not configured or set to dev, auto-update disabled');
+        updateEnabled = false;
+        return false;
+      }
       log.info(`Update channel from config: ${channel}`);
-      applyUpdateChannel(channel);
+      return applyUpdateChannel(channel);
     } else {
-      log.info('No config file found, defaulting to stable channel');
-      applyUpdateChannel('stable');
+      log.info('No config file found, auto-update disabled until configured');
+      updateEnabled = false;
+      return false;
     }
   } catch (e) {
     log.error('Error reading update channel config:', e);
-    applyUpdateChannel('stable');
+    updateEnabled = false;
+    return false;
   }
 }
 
-function applyUpdateChannel(channel: string): void {
+function applyUpdateChannel(channel: string): boolean {
   switch (channel) {
     case 'alpha':
       autoUpdater.allowPrerelease = true;
       autoUpdater.channel = 'alpha';
+      updateEnabled = true;
       break;
     case 'beta':
       autoUpdater.allowPrerelease = true;
       autoUpdater.channel = 'beta';
+      updateEnabled = true;
       break;
-    default:
+    case 'stable':
       autoUpdater.allowPrerelease = false;
       autoUpdater.channel = 'latest';
+      updateEnabled = true;
+      break;
+    default:
+      updateEnabled = false;
       break;
   }
-  log.info(`Auto-updater configured: channel=${autoUpdater.channel}, allowPrerelease=${autoUpdater.allowPrerelease}`);
+  log.info(`Auto-updater configured: channel=${channel}, enabled=${updateEnabled}, allowPrerelease=${autoUpdater.allowPrerelease}`);
+  return updateEnabled;
 }
 
 interface PrinterConfig {
@@ -239,7 +255,9 @@ ipcMain.on('get-config-file', (event: any, arg: any) => {
 
 ipcMain.on('set-update-channel', (event: any, channel: string) => {
   log.info(`Update channel changed to: ${channel}`);
-  applyUpdateChannel(channel);
+  if (applyUpdateChannel(channel)) {
+    autoUpdater.checkForUpdatesAndNotify();
+  }
 })
 
 ipcMain.on('reiniciar', (event: any, arg: any) => {
@@ -916,12 +934,15 @@ try {
     });
 
     if (!isDev) {
-      configureUpdateChannel();
-      autoUpdater.checkForUpdatesAndNotify();
-      setInterval(() => {
-        log.info('Buscando actualizacion...');
+      if (configureUpdateChannel()) {
         autoUpdater.checkForUpdatesAndNotify();
-      }, 5 * 60 * 1000); // cada 5 minutos
+        setInterval(() => {
+          if (updateEnabled) {
+            log.info('Buscando actualizacion...');
+            autoUpdater.checkForUpdatesAndNotify();
+          }
+        }, 5 * 60 * 1000); // cada 5 minutos
+      }
     }
 
     autoUpdater.on('update-available', () => {

--- a/src/app/shared/components/configuracion-dialog/configuracion-dialog.component.html
+++ b/src/app/shared/components/configuracion-dialog/configuracion-dialog.component.html
@@ -70,11 +70,13 @@
 
     <mat-form-field>
       <mat-label>Canal de Actualización</mat-label>
-      <mat-select formControlName="updateChannel">
+      <mat-select formControlName="updateChannel" required>
         <mat-option value="stable">Estable (Producción)</mat-option>
         <mat-option value="beta">Beta (Pre-producción)</mat-option>
         <mat-option value="alpha">Alpha (Desarrollo)</mat-option>
+        <mat-option value="dev">Desarrollo (Sin actualizaciones)</mat-option>
       </mat-select>
+      <mat-error *ngIf="configForm.get('updateChannel').invalid">Obligatorio</mat-error>
       <mat-hint>Determina qué versiones recibe esta máquina</mat-hint>
     </mat-form-field>
   </form>

--- a/src/app/shared/components/configuracion-dialog/configuracion-dialog.component.ts
+++ b/src/app/shared/components/configuracion-dialog/configuracion-dialog.component.ts
@@ -31,7 +31,7 @@ export class ConfiguracionDialogComponent implements OnInit {
       facturaPrinter: [this.data.printers?.factura || ''],
       modo: [this.data.modo],
       isLocal: [this.data.isLocal !== undefined ? this.data.isLocal : true],
-      updateChannel: [this.data.updateChannel || 'stable']
+      updateChannel: [this.data.updateChannel || null, Validators.required]
     });
   }
 

--- a/src/app/shared/services/configuracion.service.ts
+++ b/src/app/shared/services/configuracion.service.ts
@@ -5,7 +5,7 @@ import { catchError, map, tap, switchMap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { ConfiguracionDialogComponent } from '../components/configuracion-dialog/configuracion-dialog.component';
 
-export type UpdateChannel = 'stable' | 'beta' | 'alpha';
+export type UpdateChannel = 'stable' | 'beta' | 'alpha' | 'dev';
 
 export interface ConfiguracionSistema {
   serverIp: string;
@@ -47,7 +47,7 @@ const DEFAULT_CONFIG: ConfiguracionSistema = {
   pdvId: null,
   isConfigured: false,
   isLocal: true,
-  updateChannel: 'stable' as UpdateChannel
+  updateChannel: null
 };
 
 const LEGACY_KEYS = {


### PR DESCRIPTION
## Summary
- Release workflow generates channel-specific manifests (alpha.yml, beta.yml) from latest.yml
- Auto-update disabled until a channel is explicitly configured
- Add 'Desarrollo' channel option (disables auto-update entirely)
- Channel selection is required in configuration dialog
- Default channel is null (no updates until user configures it)

## Test plan
- [ ] CI passes
- [ ] Machine with channel=alpha detects alpha releases via alpha.yml manifest
- [ ] Machine with channel=dev does not check for updates
- [ ] New install without channel configured does not auto-update