### PR TITLE
fix: guard native notifications with isSupported check

### DIFF
--- a/app/installer.nsh
+++ b/app/installer.nsh
@@ -1,34 +1,5 @@
 !macro customInit
-  ; Cerrar la app si esta corriendo antes de instalar
+  ; Close the app if running before installing
   ExecWait 'taskkill /F /IM "FRC.exe" /T'
-  Sleep 3000
-
-  ; Forzar borrado del directorio de instalacion anterior para evitar "archivo en uso"
-  ; Leer ruta de instalacion desde el registro usando el GUID actual
-  ReadRegStr $0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{9978E2AA-8509-4830-A1C2-88A34BB1D7BF}" "InstallLocation"
-  ${If} $0 != ""
-    RMDir /r "$0"
-    Sleep 1000
-  ${EndIf}
-
-  ; Fallback: borrar por ruta por defecto si el registro no tiene la entrada
-  ${If} $0 == ""
-    RMDir /r "$PROGRAMFILES64\FRC"
-    RMDir /r "$PROGRAMFILES\FRC"
-    Sleep 1000
-  ${EndIf}
-
-  ; Desinstalar version anterior registrada con GUID "FRC" (antes de la migracion a UUID)
-  ; electron-builder puede haber registrado la clave con o sin llaves
-  ReadRegStr $0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{FRC}" "UninstallString"
-  ${If} $0 != ""
-    ExecWait '"$0" /S'
-    Sleep 2000
-  ${EndIf}
-
-  ReadRegStr $0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\FRC" "UninstallString"
-  ${If} $0 != ""
-    ExecWait '"$0" /S'
-    Sleep 2000
-  ${EndIf}
+  Sleep 2000
 !macroend

--- a/app/main.ts
+++ b/app/main.ts
@@ -121,6 +121,11 @@ export async function createWindow(): Promise<BrowserWindow> {
   ipcMain.on('SHOW_NATIVE_NOTIFICATION', (event: any, notification: any) => {
 
     try {
+      if (!Notification.isSupported()) {
+        log.warn('Native notifications not supported on this system, skipping');
+        return;
+      }
+
       const title = notification?.notification?.title ||
         notification?.data?.title ||
         'FRC Sistemas Integrados';
@@ -154,7 +159,7 @@ export async function createWindow(): Promise<BrowserWindow> {
       nativeNotification.show();
 
     } catch (error) {
-      // Silent notification error
+      log.warn('Error showing native notification:', error);
     }
   });
 

--- a/app/main.ts
+++ b/app/main.ts
@@ -962,14 +962,19 @@ try {
       const version = event.version || 'desconocida';
       const dialogOpts: MessageBoxOptions = {
         type: 'info',
-        buttons: ['Reiniciar', 'Mas tarde'],
+        buttons: ['Cerrar y actualizar', 'Mas tarde'],
         title: 'Actualizacion disponible',
         message: `Version ${version}`,
-        detail: 'Una actualizacion fue descargada. Reinicie para instalarla.',
+        detail: 'Una actualizacion fue descargada. Al cerrar la aplicacion se instalara automaticamente.',
       };
 
       dialog.showMessageBox(dialogOpts).then((returnValue) => {
-        if (returnValue.response === 0) autoUpdater.quitAndInstall();
+        if (returnValue.response === 0) {
+          // Don't use quitAndInstall() - it causes NSIS to uninstall before reinstalling,
+          // which can leave orphaned shortcuts. Instead, quit normally and let
+          // autoInstallOnAppQuit handle the installation on next launch.
+          app.quit();
+        }
       });
     });
 


### PR DESCRIPTION
Prevents process freeze on Linux without D-Bus notification daemon. Also serves as test for alpha.10 auto-update.