### PR TITLE
feat: add update management dialog

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -265,6 +265,25 @@ ipcMain.on('set-update-channel', (event: any, channel: string) => {
   }
 })
 
+ipcMain.on('check-for-update-manual', () => {
+  if (!updateEnabled) {
+    if (win) win.webContents.send('update-status', 'Auto-update desactivado. Configure un canal primero.');
+    return;
+  }
+  autoUpdater.checkForUpdates().then(result => {
+    if (!result || !result.updateInfo) {
+      if (win) win.webContents.send('update-status', 'Ya tiene la ultima version.');
+    }
+  }).catch(err => {
+    log.error('Error checking for updates:', err);
+    if (win) win.webContents.send('update-status', `Error: ${err.message}`);
+  });
+})
+
+ipcMain.on('open-update-dialog', () => {
+  if (win) win.webContents.send('open-update-dialog');
+})
+
 ipcMain.on('reiniciar', (event: any, arg: any) => {
   relaunchElectron()
 })
@@ -923,11 +942,18 @@ try {
           ],
         },
         {
-          role: 'about',
-          label: "Sobre",
+          label: "Actualizacion",
           submenu: [
             {
-              label: app.getVersion(),
+              label: `Version: ${app.getVersion()}`,
+              enabled: false,
+            },
+            { type: 'separator' },
+            {
+              label: 'Gestionar actualizaciones...',
+              click() {
+                if (win) win.webContents.send('open-update-dialog');
+              }
             },
           ],
         }
@@ -950,12 +976,14 @@ try {
       }
     }
 
-    autoUpdater.on('update-available', () => {
+    autoUpdater.on('update-available', (info) => {
       log.info('Actualizacion disponible, descargando...');
+      if (win) win.webContents.send('update-status', `Descargando version ${info.version}...`);
     });
 
     autoUpdater.on('update-not-available', () => {
       log.info('No existen actualizaciones disponibles.');
+      if (win) win.webContents.send('update-status', 'Ya tiene la ultima version.');
     });
 
     autoUpdater.on('update-downloaded', (event: UpdateDownloadedEvent) => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,6 +27,7 @@ import { DialogoNuevasFuncionesComponent } from "./shared/components/dialogo-nue
 import { GraphqlConnectionService, connectionStatusSub } from "./shared/services/graphql-connection.service";
 import { ConfirmDialogComponent } from "./shared/components/confirm-dialog/confirm-dialog.component";
 import { NotificacionesTableroService } from "./modules/notificaciones/services/notificaciones-tablero.service";
+import { UpdateDialogComponent } from "./shared/components/update-dialog/update-dialog.component";
 
 export class Pageable {
   getPageNumber: number;
@@ -117,6 +118,19 @@ export class AppComponent implements OnInit, OnDestroy {
       .subscribe(config => {
         this.graphqlService.reconnectWebSockets();
       });
+
+    // Listen for update dialog open request from Electron menu
+    try {
+      const isElectron = window && typeof window['require'] === 'function';
+      if (isElectron) {
+        const { ipcRenderer } = window['require']('electron');
+        ipcRenderer.on('open-update-dialog', () => {
+          this.matDialog.open(UpdateDialogComponent, {
+            width: '450px',
+          });
+        });
+      }
+    } catch (e) { }
     this.configService.isConfigured()
       .pipe(untilDestroyed(this))
       .subscribe((isSystemConfigured) => {

--- a/src/app/shared/components/update-dialog/update-dialog.component.html
+++ b/src/app/shared/components/update-dialog/update-dialog.component.html
@@ -1,0 +1,43 @@
+<h2 mat-dialog-title>Actualizaciones</h2>
+<mat-dialog-content fxLayout="column" fxLayoutGap="16px">
+
+  <div fxLayout="row" fxLayoutAlign="space-between center">
+    <span class="label">Version actual</span>
+    <span class="value">{{ currentVersion }}</span>
+  </div>
+
+  <div fxLayout="row" fxLayoutAlign="space-between center">
+    <span class="label">Canal</span>
+    <span class="value">{{ getChannelLabel() }}</span>
+  </div>
+
+  <mat-divider></mat-divider>
+
+  <mat-form-field>
+    <mat-label>Cambiar canal</mat-label>
+    <mat-select [value]="currentChannel" (selectionChange)="onChannelChange($event.value)">
+      <mat-option value="stable">Estable (Produccion)</mat-option>
+      <mat-option value="beta">Beta (Pre-produccion)</mat-option>
+      <mat-option value="alpha">Alpha (Desarrollo)</mat-option>
+      <mat-option value="dev">Desarrollo (Sin actualizaciones)</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="16px">
+    <button mat-raised-button color="primary"
+            [disabled]="checkingForUpdate || !autoUpdateEnabled"
+            (click)="checkForUpdate()">
+      <mat-icon>refresh</mat-icon>
+      {{ checkingForUpdate ? 'Buscando...' : 'Buscar actualizacion' }}
+    </button>
+  </div>
+
+  <div *ngIf="updateStatus" class="status-message">
+    {{ updateStatus }}
+  </div>
+
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onClose()">CERRAR</button>
+</mat-dialog-actions>

--- a/src/app/shared/components/update-dialog/update-dialog.component.scss
+++ b/src/app/shared/components/update-dialog/update-dialog.component.scss
@@ -1,0 +1,16 @@
+.label {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.value {
+  font-family: monospace;
+  font-size: 14px;
+}
+
+.status-message {
+  padding: 8px 12px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 13px;
+}

--- a/src/app/shared/components/update-dialog/update-dialog.component.ts
+++ b/src/app/shared/components/update-dialog/update-dialog.component.ts
@@ -1,0 +1,86 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { ConfiguracionService, UpdateChannel } from '../../services/configuracion.service';
+
+@Component({
+  selector: 'app-update-dialog',
+  templateUrl: './update-dialog.component.html',
+  styleUrls: ['./update-dialog.component.scss']
+})
+export class UpdateDialogComponent implements OnInit, OnDestroy {
+  currentVersion: string = '';
+  currentChannel: UpdateChannel = null;
+  autoUpdateEnabled: boolean = true;
+  checkingForUpdate: boolean = false;
+  updateStatus: string = '';
+
+  private ipcRenderer: any = null;
+  private isElectron: boolean = false;
+
+  constructor(
+    private dialogRef: MatDialogRef<UpdateDialogComponent>,
+    private configService: ConfiguracionService
+  ) {
+    this.isElectron = window && typeof window['require'] === 'function';
+    if (this.isElectron) {
+      try {
+        this.ipcRenderer = window['require']('electron').ipcRenderer;
+      } catch (e) { }
+    }
+  }
+
+  ngOnInit(): void {
+    // Get current version from Electron
+    if (this.ipcRenderer) {
+      this.currentVersion = this.ipcRenderer.sendSync('get-app-version');
+    }
+
+    // Get current channel from config
+    const config = this.configService.getConfig();
+    this.currentChannel = config.updateChannel;
+    this.autoUpdateEnabled = config.updateChannel !== 'dev' && config.updateChannel !== null;
+
+    // Listen for update events from main process
+    if (this.ipcRenderer) {
+      this.ipcRenderer.on('update-status', this.onUpdateStatus);
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.ipcRenderer) {
+      this.ipcRenderer.removeListener('update-status', this.onUpdateStatus);
+    }
+  }
+
+  private onUpdateStatus = (_event: any, status: string) => {
+    this.checkingForUpdate = false;
+    this.updateStatus = status;
+  }
+
+  checkForUpdate(): void {
+    if (!this.ipcRenderer) return;
+    this.checkingForUpdate = true;
+    this.updateStatus = '';
+    this.ipcRenderer.send('check-for-update-manual');
+  }
+
+  onChannelChange(channel: UpdateChannel): void {
+    this.currentChannel = channel;
+    this.autoUpdateEnabled = channel !== 'dev' && channel !== null;
+    this.configService.updateConfig({ updateChannel: channel });
+  }
+
+  getChannelLabel(): string {
+    switch (this.currentChannel) {
+      case 'stable': return 'Estable (Produccion)';
+      case 'beta': return 'Beta (Pre-produccion)';
+      case 'alpha': return 'Alpha (Desarrollo)';
+      case 'dev': return 'Desarrollo (Sin actualizaciones)';
+      default: return 'No configurado';
+    }
+  }
+
+  onClose(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -59,6 +59,7 @@ import { EnumToStringPipe } from '../commons/core/utils/pipes/enum-to-string';
 import { A11yModule } from '@angular/cdk/a11y';
 import { ConfiguracionFullDialogComponent } from './components/configuracion-full-dialog/configuracion-full-dialog.component';
 import { ConfiguracionDialogComponent } from './components/configuracion-dialog/configuracion-dialog.component';
+import { UpdateDialogComponent } from './components/update-dialog/update-dialog.component';
 import { SideMiniVariantComponent } from './components/side-mini-variant/side-mini-variant.component';
 import { CellFormatPipe } from '../commons/core/pipes/cell-format.pipe';
 import { NotificationBoardComponent } from '../modules/notificaciones/components/notification-board/notification-board.component';
@@ -107,6 +108,7 @@ export const options: Partial<IConfig> | (() => Partial<IConfig>) = null;
     DataDisplayComponent,
     ConfiguracionFullDialogComponent,
     ConfiguracionDialogComponent,
+    UpdateDialogComponent,
     SideMiniVariantComponent,
     CellFormatPipe
   ],


### PR DESCRIPTION
## Summary
- New 'Actualizacion' menu in Electron menu bar showing current version
- Update dialog with: version actual, canal actual, cambiar canal, buscar actualizacion manual
- IPC communication between main process and Angular for status updates

## Test plan
- [ ] CI passes
- [ ] Menu shows in Electron bar with correct version
- [ ] Dialog opens and shows current version + channel
- [ ] Manual update check works
- [ ] Channel change takes effect immediately