### PR TITLE
fix(ci): handle artifact filenames with spaces in release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,13 +128,13 @@ jobs:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
           echo "Uploading ${{ matrix.platform }} artifacts to release v${VERSION}..."
-          # Collect all files to upload (avoid glob expansion failures)
-          FILES=""
-          for f in release/FRC*.* release/latest*.yml release/alpha*.yml release/beta*.yml; do
-            [ -f "$f" ] && FILES="$FILES $f"
+          # Collect files individually (handles filenames with spaces)
+          FILES=()
+          for f in release/*.exe release/*.AppImage release/*.yml release/*.blockmap; do
+            [ -f "$f" ] && FILES+=("$f")
           done
-          if [ -n "$FILES" ]; then
-            gh release upload "v${VERSION}" $FILES --clobber
+          if [ ${#FILES[@]} -gt 0 ]; then
+            gh release upload "v${VERSION}" "${FILES[@]}" --clobber
           else
             echo "WARNING: No artifacts found to upload!"
             exit 1


### PR DESCRIPTION
## Summary
- Fix release upload failing because `artifactName: "FRC Setup.${ext}"` has a space
- Switch from string concatenation to bash array for proper quoting of filenames
- Use generic globs (`*.exe`, `*.AppImage`, `*.yml`, `*.blockmap`) instead of `FRC*.*`

## Context
alpha.12 release failed on the upload step with `no matches found for release/FRC`. The previous glob `release/FRC*.*` doesn't match `release/FRC Setup.exe` due to the space.

## Test plan
- [ ] Merge and verify alpha release builds and uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)