### PR TITLE
feat(ventas): integrar busqueda de cajero con funcionario en reporte …

### DIFF
--- a/src/app/modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component.ts
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component.ts
@@ -32,6 +32,8 @@ import { UsuarioSearchGQL } from "../../../../personas/usuarios/graphql/usuarioS
 import { Subfamilia } from "../../../../productos/sub-familia/sub-familia.model";
 import { SubfamiliasSearchGQL } from "../../../../productos/sub-familia/graphql/subfamiliasSearch";
 import { SearchSubfamiliaByDescripcionGQL } from "../../../../productos/sub-familia/graphql/searchByDescripcion";
+import { FuncionarioSearchGQL } from "../../../../personas/funcionarios/graphql/funcionarioSearch";
+import { Funcionario } from "../../../../personas/funcionarios/funcionario.model";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -98,7 +100,7 @@ export class LucroPorProductoComponent implements OnInit {
     private dialog: MatDialog,
     private notificacionService: NotificacionSnackbarService,
     private personaService: PersonaService,
-    private usuarioSearch: UsuarioSearchGQL,
+    private funcionarioSearch: FuncionarioSearchGQL,
     private usuarioService: UsuarioService,
     private searchSubfamilia: SearchSubfamiliaByDescripcionGQL,
     private matDialog: MatDialog
@@ -349,7 +351,7 @@ export class LucroPorProductoComponent implements OnInit {
   onBuscarCajero() {
     let data: SearchListtDialogData = {
       titulo: "Buscar Cajero",
-      query: this.usuarioSearch,
+      query: this.funcionarioSearch,
       tableData: [
         { id: "id", nombre: "Id", width: "10%" },
         { id: "nickname", nombre: "Nombre", width: "90%" },
@@ -367,22 +369,28 @@ export class LucroPorProductoComponent implements OnInit {
       })
       .afterClosed()
       .pipe(untilDestroyed(this))
-      .subscribe((res: Usuario) => {
+      .subscribe((res: Funcionario) => {
         if (res != null) {
-          this.usuarioService
-            .onGetUsuario(res.id)
-            .pipe(untilDestroyed(this))
-            .subscribe((resUsuario) => {
-              if (resUsuario != null) {
-                this.selectedUsuario = resUsuario;
-                this.buscarCajeroControl.setValue(res.id + " - " + res.nickname);
-              } else {
-                this.notificacionService.openWarn(
-                  "No posee usuario registrado"
-                );
-                this.buscadorCajeroInput.nativeElement.select();
-              }
-            });
+          if (res.persona?.id) {
+            this.usuarioService
+              .onGetUsuarioPorPersonaId(res.persona.id)
+              .pipe(untilDestroyed(this))
+              .subscribe((resUsuario) => {
+                if (resUsuario != null) {
+                  this.selectedUsuario = resUsuario;
+                  this.buscarCajeroControl.setValue(res.id + " - " + res.nickname);
+                } else {
+                  this.notificacionService.openWarn(
+                    "Nombre de usuario no encontrado"
+                  );
+                  this.buscadorCajeroInput.nativeElement.select();
+                }
+              });
+          } else {
+            this.notificacionService.openWarn(
+              "El funcionario seleccionado no tiene una persona asociada"
+            );
+          }
         }
       });
   }


### PR DESCRIPTION
- Qué resuelve: Búsqueda por funcionario en el componente de lucro por producto.
- Cómo probarlo: Accede al componente de lucro por producto y selecciona el filtro de 'Buscar Cajero', debería de aparecer únicamente los funcionarios registrados en la base de datos.
- Impacto DB: Ninguno.
- Riesgo: Bajo