### PR TITLE
feat(productos): implementar cambio de familia y previsualizacion de …

### DIFF
--- a/src/app/modules/productos/producto/edit-producto/producto.component.html
+++ b/src/app/modules/productos/producto/edit-producto/producto.component.html
@@ -22,8 +22,10 @@
         >
           <img
             [src]="imagenPrincipal"
+            [frcPrevisualizarImagen]="imagenPrincipal"
+            matTooltip="Ver imagen"
             alt="imagen principal mini"
-            style="width: 100px; height: 100px; object-fit: contain; border-radius: 50%"
+            style="width: 100px; height: 100px; object-fit: contain; border-radius: 50%; cursor: pointer;"
           />
         </div>
       </div>
@@ -43,11 +45,22 @@
         fxLayoutAlign="space-around start"
         style="width: 100%"
       >
+        <div fxFlex style="text-align: start; color: #f57c00">Familia:</div>
+        <div fxFlex style="text-align: right">
+          {{ selectedFamilia?.nombre }}
+        </div>
+      </div>
+      <div
+        fxLayout="column"
+        fxLayoutAlign="space-around start"
+        style="width: 100%"
+      >
         <div fxFlex style="text-align: start; color: #f57c00">Subfamilia:</div>
         <div fxFlex style="text-align: right">
           {{ selectedSubfamilia?.nombre }}
         </div>
       </div>
+      
       <div
         fxLayout="row"
         fxLayoutAlign="space-around start"
@@ -305,8 +318,16 @@
                   <mat-menu #menu="matMenu">
                     <button
                       mat-menu-item
+                      (click)="onCambiarFamilia()"
+                    >
+                    <mat-icon>autorenew</mat-icon>
+                      Cambiar
+                    </button>
+                    <button
+                      mat-menu-item
                       (click)="onEditFamilia(item, itemIndex)"
                     >
+                    <mat-icon>edit</mat-icon>
                       Editar
                     </button>
                     <button
@@ -314,6 +335,7 @@
                       (click)="onDeleteFamilia(item, itemIndex)"
                       style="color: red"
                     >
+                    <mat-icon>delete</mat-icon>
                       Eliminar
                     </button>
                   </mat-menu>
@@ -420,7 +442,7 @@
       [completed]="selectedSubfamilia?.id != null"
     >
       <form [formGroup]="categoriaControl" style="width: 100%; height: 100%">
-        <ng-template matStepLabel>Familia</ng-template>
+        <ng-template matStepLabel>Subfamilia</ng-template>
         <div
           table
           style="height: 100%; background-color: rgb(70, 70, 70)"
@@ -564,8 +586,16 @@
                   <mat-menu #menu="matMenu">
                     <button
                       mat-menu-item
+                      (click)="onCambiarSubfamilia()"
+                    >
+                    <mat-icon>autorenew</mat-icon>
+                      Cambiar
+                    </button>
+                    <button
+                      mat-menu-item
                       (click)="onEditSubfamilia(item, itemIndex)"
                     >
+                    <mat-icon>edit</mat-icon>
                       Editar
                     </button>
                     <button
@@ -573,6 +603,7 @@
                       (click)="onDeleteSubfamilia(item, itemIndex)"
                       style="color: red"
                     >
+                    <mat-icon>delete</mat-icon>
                       Eliminar
                     </button>
                   </mat-menu>

--- a/src/app/modules/productos/producto/edit-producto/producto.component.ts
+++ b/src/app/modules/productos/producto/edit-producto/producto.component.ts
@@ -89,6 +89,9 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { PageInfo } from "../../../../app.component";
 import { dateToString } from "../../../../commons/core/utils/dateUtils";
 import { ProductoDuplicadoDialogComponent } from "../producto-duplicado-dialog.component";
+import { FamiliasSearchGQL } from "../../familia/graphql/familiasSearch";
+import { SubfamiliasSearchGQL } from "../../sub-familia/graphql/subfamiliasSearch";
+import { SearchListDialogComponent, SearchListtDialogData, TableData } from "../../../../shared/components/search-list-dialog/search-list-dialog.component";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -245,7 +248,10 @@ export class ProductoComponent implements OnInit, OnDestroy {
     private copyToClipService: Clipboard,
     private presentacionService: PresentacionService,
     private changeDetectorRefs: ChangeDetectorRef,
-    private cargandoDialog: CargandoDialogService
+    private cargandoDialog: CargandoDialogService,
+    private familiasSearchGQL: FamiliasSearchGQL,
+    private subfamiliasSearchGQL: SubfamiliasSearchGQL,
+    private notificacionService: NotificacionSnackbarService
   ) {
     if (dialogData != null) {
       this.isDialog = dialogData.isDialog;
@@ -484,7 +490,12 @@ export class ProductoComponent implements OnInit, OnDestroy {
   }
 
   onProductoSave() {
-    if (this.selectedProducto != null && !this.datosGeneralesControl.dirty) {
+    let subfamiliaCambiada = false;
+    if (this.selectedProducto?.subfamilia?.id != this.selectedSubfamilia?.id) {
+      subfamiliaCambiada = true;
+    }
+    
+    if (this.selectedProducto != null && !this.datosGeneralesControl.dirty && !subfamiliaCambiada) {
       //nada
     } else {
       const {
@@ -554,6 +565,7 @@ export class ProductoComponent implements OnInit, OnDestroy {
           if (res != null) {
             this.selectedProducto = res;
             this.stepper.next();
+            this.notificacionService.openSucess("Producto guardado correctamente", 4);
           } else {
             this.stepper.previous();
             setTimeout(() => {
@@ -618,6 +630,86 @@ export class ProductoComponent implements OnInit, OnDestroy {
     setTimeout(() => {
       this.stepper.next();
     }, 500);
+  }
+
+  onCambiarFamilia() {
+    const tableData: TableData[] = [
+      { id: 'id', nombre: 'ID' },
+      { id: 'nombre', nombre: 'Nombre' },
+    ];
+    const dialogData: SearchListtDialogData = {
+      query: this.familiasSearchGQL,
+      tableData,
+      titulo: 'Cambiar Familia',
+      search: true,
+      inicialSearch: true,
+      paginator: true,
+      searchFieldName: 'texto',
+      queryData: {
+        texto: '',
+        page: 0,
+        size: 15,
+      },
+    };
+    this.matDialog
+      .open(SearchListDialogComponent, {
+        data: dialogData,
+        width: '60%',
+        height: '80%',
+      })
+      .afterClosed()
+      .pipe(untilDestroyed(this))
+      .subscribe((res: Familia) => {
+        if (res != null && res.id != null) {
+          this.onFamiliaSelect(res);
+          this.familiaDataSource.data = [res];
+          this.selectedSubfamilia = null;
+          this.subfamiliaDataSource.data = [];
+          this.nextFamilia();
+        }
+      });
+  }
+
+  onCambiarSubfamilia() {
+    const tableData: TableData[] = [
+      { id: 'id', nombre: 'ID' },
+      { id: 'nombre', nombre: 'Nombre' },
+    ];
+    const dialogData: SearchListtDialogData = {
+      query: this.subfamiliasSearchGQL,
+      tableData,
+      titulo: 'Cambiar Subfamilia',
+      search: true,
+      inicialSearch: true,
+      paginator: true,
+      searchFieldName: 'texto',
+      queryData: {
+        familiaId: this.selectedFamilia?.id,
+        texto: '',
+        page: 0,
+        size: 15,
+      },
+    };
+    this.matDialog
+      .open(SearchListDialogComponent, {
+        data: dialogData,
+        width: '60%',
+        height: '80%',
+      })
+      .afterClosed()
+      .pipe(untilDestroyed(this))
+      .subscribe((res: Subfamilia) => {
+        if (res != null && res.id != null) {
+          this.onSubfamiliaSelect(res);
+          this.subfamiliaDataSource.data = [res];
+        }
+      });
+  }
+
+  onEditarFamilia() {
+    if(this.stepper){
+      this.stepper.selectedIndex = 0;
+    }
   }
 
   seleccionarSubfamilia(tipo) {
@@ -903,7 +995,7 @@ export class ProductoComponent implements OnInit, OnDestroy {
     this.matDialog
       .open(AdicionarPresentacionComponent, {
         data,
-        width: "50%",
+        width: "25%",
         disableClose: true,
       })
       .afterClosed()


### PR DESCRIPTION
### ¿Qué resuelve?
Este Pull Request incluye varias mejoras enfocadas en la experiencia de usuario y corrección de flujos en la edición de productos:
- Cambio Múltiple de Jerarquía: Anteriormente, al editar un producto existente, la tabla ocultaba las demás familias/subfamilias e impedía al usuario cambiar la clasificación original. Se añadieron opciones "Cambiar" a los menú desplegables (los tres puntos) que abren un buscador integrado (SearchListDialogComponent) capaz de recargar la lista de la BD por GraphQL permitiendo realizar reemplazos precisos.
- Corrección del flujo de guardado: Se reparó un bug en onProductoSave() que provocaba que, si se cambiaba la subfamilia pero no se editaba manual el formulario general, la aplicación no guardase el progreso, ya que esperaba un formulario "sucio" (dirty).
**Mejoras UX/UI:**
- Se sumó un toast de confirmación (notificacionService.openSucess) notificando al usuario del guardado seguro en la BD.
- La imagen en el apartado "Resumen" ahora posee el cursor pointer y aprovecha la directiva [frcPrevisualizarImagen]. Al darle clic, expande la imagen en un modal para previsualizar sus detalles sin salir de la configuración del producto.
### ¿Cómo probarlo?
**Flujo de Cambio de Familia:**
- Ve a la vista de "Lista de Productos" y pon a editar un producto que ya tenga asignada una Familia y Subfamilia.
- En el Paso 1 (Familia), haz clic en el menú desplegable (los tres puntos de la fila seleccionada) y pulsa Cambiar.
- Busca una nueva Familia distinta, y haz clic para seleccionarla. Comprueba que la pantalla salte al Paso 2 con la tabla vacía pidiéndote una correspondencia obligatoria de la nueva "Subfamilia".
**Guardado:**
- Haz "Cambiar" en ambas y no toques ninguno de los textos y configuraciones del formato. Presiona Guardar. Verás cómo la alerta de "Producto guardado correctamente" salta con éxito.
**Previsualización visual:**
- Sitúate sobre el Resumen del Producto (panel izquierdo), lleva el puntero sobre la imagen redonda miniatura y haz clic.
- La directiva debería ampliar la resolución de la foto principal en el centro de tu pantalla.
### Impacto DB (Base de datos)
- Nulo / Transparente: La tabla no ha sufrido cambios estructurales en la base de datos (Backend). El impacto solo recae en el origen de las mutaciones, ya que este cambio le da al front-end la capacidad de actualizar el FK de subfamiliaId sobre los registros existentes en la tabla producto con seguridad al validar dependencias.
### Riesgo
- Bajo: La mayoría de los cambios se enfocan en UI (diálogos, previsualización, toast). A nivel lógico, solo se agregó una validación de id en la operación de guardado para un Edge Case, y se reutilizaron las consultas nativas (FamiliasSearchGQL, SubfamiliasSearchGQL y SearchListDialogComponent) ya operacionales y estabilizadas en la aplicación.