### PR TITLE
feat(ventas): generar reporte venta

### DIFF
--- a/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.html
+++ b/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.html
@@ -1,9 +1,11 @@
-
 <div style="width: 100%; height: 100%;" fxLayout="column">
-  <h4 style="text-align: center; margin: 0;">Buscador de ventas</h4>
   <app-generic-list
     (filtrar)="onFiltrarConReset()"
     (resetFiltro)="onResetFiltro()"
+    [isCustom]="true"
+    (customFunction)="onGenerarReporte()"
+    [disableCustom]="isGenerarReporteDisabled"
+    customName="Generar Reporte"
     style="width: 100%; height: 100%;"
   >
     <div filtros>

--- a/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.ts
+++ b/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.ts
@@ -49,8 +49,8 @@ export class GenericListVentaComponent implements OnInit {
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
 
-  @Input()
-  data: Tab;
+  @Input() data: Tab;
+  @Input() isGenerarReporteDisabled: boolean = true;
 
   today = new Date();
   selectedCliente: Cliente;
@@ -210,6 +210,7 @@ export class GenericListVentaComponent implements OnInit {
           this.ventaDataSource.data = res.getContent;
           this.onObservado(this.ventaDataSource.data);
           this.ventaDataSource.data = [...this.ventaDataSource.data];
+          this.isGenerarReporteDisabled = !res.getContent || res.getContent.length === 0;
         }
       });
   }
@@ -258,6 +259,7 @@ export class GenericListVentaComponent implements OnInit {
     this.conAumentoControl.setValue(false);
     this.fechaInicioControl.setValue(null);
     this.conDescuentoControl.setValue(false);
+    this.isGenerarReporteDisabled = true;
   }
 
   getTotales(venta: Venta) {
@@ -439,5 +441,28 @@ export class GenericListVentaComponent implements OnInit {
             });
         }
       });
+  }
+
+  onGenerarReporte() {
+    let fechaInicio = this.fechaInicioControl.value != null ?
+      this.fechaInicioControl.value?.toISOString().slice(0, 10) : null;
+    let fechaFin = this.fechaFinControl.value != null ?
+      this.fechaFinControl.value?.toISOString().slice(0, 10) : null;
+
+    this.ventaService.onReporteGenericVentas(
+      this.idVentaControl.value,
+      null,
+      this.sucursalControl.value,
+      this.formaPagoControl.value,
+      this.estadoControl.value,
+      this.modoControl.value,
+      this.monedaControl.value?.id,
+      this.conDescuentoControl.value,
+      this.conAumentoControl.value,
+      this.conObsControl.value,
+      this.selectedCliente?.id,
+      fechaInicio,
+      fechaFin
+    );
   }
 }

--- a/src/app/modules/operaciones/venta/graphql/graphql-query.ts
+++ b/src/app/modules/operaciones/venta/graphql/graphql-query.ts
@@ -438,3 +438,39 @@ export const ventasGenericFilterQuery = gql`
     }
   }
 `;
+
+export const reporteGenericVentasQuery = gql`
+  query (
+    $idVenta: ID
+    $idCaja: ID
+    $sucId: ID
+    $formaPago: ID
+    $estado: VentaEstado
+    $isDelivery: Boolean
+    $monedaId: Int
+    $conDescuento: Boolean
+    $conAumento: Boolean
+    $conObservacion: Boolean
+    $clienteId: ID
+    $fechaInicio: String
+    $fechaFin: String
+    $usuarioId: ID
+  ) {
+    data: reporteGenericVentas(
+      idVenta: $idVenta
+      idCaja: $idCaja
+      sucId: $sucId
+      formaPago: $formaPago
+      estado: $estado
+      isDelivery: $isDelivery
+      monedaId: $monedaId
+      conDescuento: $conDescuento
+      conAumento: $conAumento
+      conObservacion: $conObservacion
+      clienteId: $clienteId
+      fechaInicio: $fechaInicio
+      fechaFin: $fechaFin
+      usuarioId: $usuarioId
+    )
+  }
+`;

--- a/src/app/modules/operaciones/venta/graphql/reporteGenericVentas.ts
+++ b/src/app/modules/operaciones/venta/graphql/reporteGenericVentas.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { reporteGenericVentasQuery } from './graphql-query';
+
+export interface Response {
+  data: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ReporteGenericVentasGQL extends Query<Response> {
+  document = reporteGenericVentasQuery;
+}

--- a/src/app/modules/operaciones/venta/venta.service.ts
+++ b/src/app/modules/operaciones/venta/venta.service.ts
@@ -38,6 +38,11 @@ import {
 import { DeliveryInput } from "../delivery/graphql/delivery-input.model";
 import { ConfiguracionService } from "../../../shared/services/configuracion.service";
 import { VentasGenericFilterGQL } from "./graphql/ventasGenericFilter";
+import { ReporteGenericVentasGQL } from "./graphql/reporteGenericVentas";
+import { ReporteService } from "../../reportes/reporte.service";
+import { TabService } from "../../../layouts/tab/tab.service";
+import { Tab } from "../../../layouts/tab/tab.model";
+import { ReportesComponent } from "../../reportes/reportes/reportes.component";
 
 @UntilDestroy({ checkProperties: true })
 @Injectable({
@@ -68,7 +73,10 @@ export class VentaService {
     private ventaItemPorId: VentaItemPorIdGQL,
     private saveVentaDelivery: SaveVentaDeliveryGQL,
     private configService: ConfiguracionService,
-    private ventasGenericFilter: VentasGenericFilterGQL
+    private ventasGenericFilter: VentasGenericFilterGQL,
+    private reporteGenericVentas: ReporteGenericVentasGQL,
+    private reporteService: ReporteService,
+    private tabService: TabService
   ) { }
 
   // $venta:VentaInput!, $venteItemList: [VentaItemInput], $cobro: CobroInput, $cobroDetalleList: [CobroDetalleInput]
@@ -262,6 +270,53 @@ export class VentaService {
       fechaInicio,
       fechaFin
     }, servidor);
+  }
+
+  onReporteGenericVentas(
+    idVenta?: number,
+    idCaja?: number,
+    sucId?: number,
+    formaPago?: number,
+    estado?: string,
+    isDelivery?: boolean,
+    monedaId?: number,
+    conDescuento?: boolean,
+    conAumento?: boolean,
+    conObservacion?: boolean,
+    clienteId?: number,
+    fechaInicio?: string,
+    fechaFin?: string,
+    servidor = true
+  ) {
+    this.genericService
+      .onCustomQuery(
+        this.reporteGenericVentas,
+        {
+          idVenta,
+          idCaja,
+          sucId,
+          formaPago,
+          estado,
+          isDelivery,
+          monedaId,
+          conDescuento,
+          conAumento,
+          conObservacion,
+          clienteId,
+          fechaInicio,
+          fechaFin,
+          usuarioId: this.mainService?.usuarioActual?.id
+        },
+        servidor
+      )
+      .subscribe((res: string) => {
+        if (res != null) {
+          this.reporteService.onAdd('Reporte de Ventas ' + Date.now(), res);
+          this.tabService.addTab(
+            new Tab(ReportesComponent, 'Reportes', null, null)
+          );
+        }
+      });
   }
 
   onGetPorId(id, sucId?, silentLoad?, servidor = true): Observable<Venta> {


### PR DESCRIPTION
### ¿Qué resuelve?
Este PR completa la funcionalidad para generar Reportes de Ventas en formato PDF desde la pantalla del buscador (GenericListVentaComponent). Resuelve la necesidad de obtener un consolidado visual de las ventas según los filtros aplicados en la tabla.

**Cambios principales**
- Se agregó el botón de "Generar Reporte" en la interfaz del componente app-generic-list.
- Se implementó lógica dinámica para deshabilitar automáticamente el botón cuando la tabla de resultados se encuentra vacía o al realizar un reset de filtros, mejorando la UX y previniendo la generación de reportes en blanco.

###  ¿Cómo probarlo?
- Ingresar al sistema y navegar a la sección de Ventas.
- Verificar que al cargar la pantalla (sin datos), el botón de "Generar Reporte" no se visualiza.
- Realizar una búsqueda genérica para cargar registros en la tabla y comprobar que el botón aparece automáticamente.
- Hacer clic en "Limpiar Filtro" y verificar que el botón desaparece de nuevo.

 ### Impacto DB
- Ninguno. No se realizaron migraciones ni alteraciones estructurales en la base de datos. Solo se ejecutan consultas de lectura preexistentes (selects) a través de GraphQL para resolver entidades como Cliente o Moneda.
### Riesgo
- Bajo: Los cambios son exclusivamente condicionales en la vista y no afectan al flujo de creación ni manipulación de ventas.