### PR TITLE
fix(ci): skip manifest copy when channel is latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,13 +120,17 @@ jobs:
 
           # Copy manifests with channel name
           # electron-updater looks for {channel}.yml and {channel}-linux.yml
-          for f in release/latest*.yml; do
-            if [ -f "$f" ]; then
-              NEWNAME=$(echo "$f" | sed "s/latest/${CHANNEL}/")
-              cp "$f" "$NEWNAME"
-              echo "Created $NEWNAME"
-            fi
-          done
+          if [ "${CHANNEL}" != "latest" ]; then
+            for f in release/latest*.yml; do
+              if [ -f "$f" ]; then
+                NEWNAME=$(echo "$f" | sed "s/latest/${CHANNEL}/")
+                cp "$f" "$NEWNAME"
+                echo "Created $NEWNAME"
+              fi
+            done
+          else
+            echo "Channel is latest — manifests already have correct names, skipping copy"
+          fi
 
       - name: Upload artifacts to GitHub Release
         shell: bash


### PR DESCRIPTION
## Summary
- Fix stable release workflow failure: when channel is `latest`, `sed s/latest/latest/` produces the same filename, causing `cp` to fail with "are the same file"
- Skip the copy loop entirely for `latest` channel since manifests already have the correct name

## Root cause
Run [#24888170119](https://github.com/GabFrank/frc-sistemas-integrados-angular/actions/runs/24888170119) failed at step "Generate channel manifests" on the Linux build:
```
cp: 'release/latest-linux.yml' and 'release/latest-linux.yml' are the same file
```

## Test plan
- [ ] Merge to develop → CI release triggers with `-alpha` suffix → copy loop runs normally (alpha channel)
- [ ] Promote to release/beta → CI release with `-beta` suffix → copy loop runs normally (beta channel)
- [ ] Promote to master → CI release without suffix → copy loop skipped, manifests uploaded as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)