### PR TITLE
feat(productos): cambio de rol para crear productos

### DIFF
--- a/src/app/modules/productos/producto/list-producto/list-producto.component.ts
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.ts
@@ -397,7 +397,7 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
   }
 
   updatePermisos() {
-    this.isAdicionarEnabled = this.mainService.usuarioActual?.roles?.includes(ROLES.ADMIN) || false;
+    this.isAdicionarEnabled = this.mainService.usuarioActual?.roles?.includes(ROLES.EDITAR_PRODUCTOS) || false;
   }
 
   onAjustarStock(producto: Producto) {


### PR DESCRIPTION
### Qué resuelve
En este PR se cambió el rol [ADMIN] al rol [EDITAR_PRODUCTOS] para crear productos o más bien para habilitar la opción de 'Adicionar'. Una problemática hallada era cuando un usuario necesitaba la opción de crear productos pero solamente se podía crear mediante el rol [ADMIN] que habilitaba otras características que el usuario no debería de tener. Con este cambio ese problema ya no ocurre.

### Como probarlo

1. Tener el rol [EDITAR_PRODUCTOS]
2. Ir al módulo de productos
3. En la ventana de Lista de Productos se podrá apreciar el botón 'Adicionar +' ya habilitado.

### Impacto DB
- Ninguno: Este cambio solo afecta al frontend con el manejo de roles y la habilitación de una funcionalidad.

### Riesgo
- Bajo: No corre ningún riesgo de afectar a algún componente del sistema.