### PR TITLE
feat(menu): condicionar apertura de buscador global

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -279,7 +279,7 @@ export class AppComponent implements OnInit, OnDestroy {
         this.keyPressed = "Control";
         break;
       case " ":
-        if (this.keyPressed == "Control")
+        if (this.keyPressed == "Control" && this.matDialog.openDialogs.length === 0)
           this.matDialog.open(SearchBarDialogComponent, {
             data: null,
             width: "50%",


### PR DESCRIPTION
### Qué resuelve
Se ha condicionado la ejecución del atajo de teclado Ctrl + Espacio para evitar que el buscador global se abra cuando ya existe un diálogo activo en la aplicación. Esto resuelve problemas de superposición visual y conflictos de enfoque que ocurrían al disparar el buscador sobre diálogos de login, configuración o formularios de edición.

### Cómo probarlo

1. Escenario 1 (Sin diálogos): En la pantalla principal de la aplicación, presiona Ctrl + Espacio. El buscador global debe abrirse normalmente.
2. Escenario 2 (Con diálogo activo): Abre cualquier diálogo (por ejemplo, el menú de configuración o un diálogo de confirmación). Intenta presionar Ctrl + Espacio. El buscador no debe mostrarse.
3. Escenario 3 (Re-activación): Cierra el diálogo activo y presiona nuevamente Ctrl + Espacio. El buscador debe volver a funcionar correctamente.

Impacto DB
Ninguno. Los cambios son puramente de lógica en el frontend (UI/UX).

Riesgo
Bajo. El cambio se limita exclusivamente a una validación adicional en el gestor global de eventos de teclado (app.component.ts) y no altera la lógica de negocio ni el funcionamiento interno de los componentes de búsqueda.