### PR TITLE
fix(compras): persistir texto de búsqueda en diálogo Añadir Item [FD-146]

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
@@ -47,11 +47,13 @@ export interface AddEditItemDialogData {
   isEdit: boolean;
   pedido: Pedido;
   item?: PedidoItem;
+  lastSearchText?: string;
 }
 
 export interface AddEditItemDialogResult {
   item: PedidoItem;
   action: "save" | "cancel";
+  lastSearchText?: string;
 }
 
 export interface DistribucionItem {
@@ -275,8 +277,9 @@ export class AddEditItemDialogComponent implements OnInit {
   }
 
   private initializeForm(): void {
+    const initialSearch = (!this.data.isEdit && this.data.lastSearchText) ? this.data.lastSearchText : "";
     this.itemForm = this.formBuilder.group({
-      productoSearch: [""], // Campo de búsqueda de producto
+      productoSearch: [initialSearch],
       producto: [null, [Validators.required]],
       presentacion: [null, [Validators.required]],
       cantidadSolicitada: [0, [Validators.required, Validators.min(0.01)]], // Cantidad en unidades base (calculada desde distribuciones)
@@ -389,7 +392,11 @@ export class AddEditItemDialogComponent implements OnInit {
           }
         }
       } else {
-        // Si no hay producto, el foco ya está en el input de búsqueda
+        // Si no hay producto, el foco está en el input de búsqueda
+        if (!this.data.isEdit && this.data.lastSearchText) {
+          this.productoInput?.nativeElement.focus();
+          this.productoInput?.nativeElement.select();
+        }
       }
     }, 300);
   }
@@ -1030,6 +1037,7 @@ export class AddEditItemDialogComponent implements OnInit {
             const result: AddEditItemDialogResult = {
               item: itemResult,
               action: "save",
+              lastSearchText: this.itemForm.get("productoSearch")?.value || "",
             };
 
             this.dialogRef.close(result);
@@ -1060,6 +1068,7 @@ export class AddEditItemDialogComponent implements OnInit {
     const result: AddEditItemDialogResult = {
       item: {} as PedidoItem,
       action: "cancel",
+      lastSearchText: this.itemForm.get("productoSearch")?.value || "",
     };
     this.dialogRef.close(result);
   }

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -218,6 +218,9 @@ export class GestionComprasComponent
   // Current pedido instance
   currentPedido: Pedido | null = null;
 
+  // Último texto de búsqueda en el diálogo Añadir Item (persiste dentro de la misma sesión de gestión)
+  private lastItemSearchText = '';
+
   // Pedido resumen from backend (for edit mode)
   pedidoResumen: PedidoResumen | null = null;
 
@@ -585,9 +588,12 @@ export class GestionComprasComponent
     this.loadingPedido = false;
     this.currentPedido = null;
     this.pedidoResumen = null;
-    
+
     // Limpiar conjunto de tabs cargados
     this.loadedTabs.clear();
+
+    // Limpiar último texto de búsqueda de ítem
+    this.lastItemSearchText = '';
   }
 
   /**
@@ -599,6 +605,7 @@ export class GestionComprasComponent
       return;
     }
 
+    this.lastItemSearchText = '';
     this.loadingPedido = true;
 
     // Cargar pedido, ítems y etapa actual en paralelo
@@ -1952,6 +1959,7 @@ export class GestionComprasComponent
       pedido: this.currentPedido as Pedido,
       isEdit: false,
       title: "Añadir Nuevo Ítem al Pedido",
+      lastSearchText: this.lastItemSearchText,
     };
 
     const dialogRef = this.dialog.open(AddEditItemDialogComponent, {
@@ -1962,6 +1970,9 @@ export class GestionComprasComponent
     });
 
     dialogRef.afterClosed().subscribe((result: AddEditItemDialogResult) => {
+      if (result?.lastSearchText !== undefined) {
+        this.lastItemSearchText = result.lastSearchText;
+      }
       if (result && result.action === "save") {
         // Actualizar localmente el monto total del pedido
         if (this.isEditMode && result.item) {


### PR DESCRIPTION
## Qué cambió

Implementa la persistencia del último texto de búsqueda en el diálogo **Añadir Item** (Compras → Gestión de Compras → tab "Items del Pedido") entre aperturas consecutivas dentro de la misma sesión del pedido.

### Cambios en `add-edit-item-dialog.component.ts`
- `AddEditItemDialogData`: agrega campo opcional `lastSearchText?: string`
- `AddEditItemDialogResult`: agrega campo opcional `lastSearchText?: string`
- `initializeForm()`: inicializa `productoSearch` con `lastSearchText` cuando no es modo edición
- `setInitialFocus()`: si hay texto pre-cargado, hace focus y selecciona todo el texto del input de búsqueda (permite escribir encima o presionar Enter para reusar)
- `onSave()` / `onCancel()`: retornan el valor actual de `productoSearch` en `lastSearchText` del resultado

### Cambios en `gestion-compras.component.ts`
- Agrega campo privado `lastItemSearchText = ''`
- `onAddItem()`: pasa `lastSearchText: this.lastItemSearchText` al abrir el diálogo
- `afterClosed()` de `onAddItem()`: captura `result.lastSearchText` (tanto al guardar como al cancelar)
- `setupNuevaCompraState()` y `loadPedidoExistente()`: resetean `lastItemSearchText` al cambiar de pedido

### Comportamiento sin afectar
- `onEditItem()`: usa `isEdit: true`, el diálogo ignora `lastSearchText` en ese caso
- `onOpenAddItemDialogWithProduct()`: no pasa `lastSearchText` → comportamiento actual sin cambios

## Cómo testear

1. Ir a **Compras → Gestión de Compras**, abrir o crear un pedido
2. Tab "Items del Pedido" → clic **Añadir Item**
3. Escribir "COCA" en el campo "Buscar Producto", buscar y seleccionar un producto, guardar
4. Volver a clic **Añadir Item** → el campo debe mostrar "COCA" completamente seleccionado
5. Verificar que presionar Enter o hacer clic en buscar reusa el término
6. Verificar que escribir directamente reemplaza "COCA"
7. Cancelar el diálogo y volver a abrir → debe conservar el último texto escrito
8. Navegar a otro pedido y abrir el diálogo → campo debe estar vacío

**Regresiones a verificar:**
- `onEditItem()`: al editar un ítem existente, el campo muestra la descripción del producto (NO el último buscado)
- `onOpenAddItemDialogWithProduct()`: el diálogo abre con el producto preseleccionado, campo de búsqueda vacío

## Impacto en DB

Ninguno. Cambio puramente de UI/estado en memoria.

## Riesgo de rollback

**Bajo.** Todos los campos agregados son opcionales (`?`). Si se revierte, el comportamiento vuelve exactamente al estado anterior (campo siempre vacío al abrir).

## Nota sobre build check

`npm run check` no pudo ejecutarse en el entorno CI (node_modules no instalados). Los cambios son mínimos y tipados correctamente (TypeScript strict): campos opcionales en interfaces existentes, operador `?.` en accesos a `nativeElement`. Requiere verificación de AOT antes de mergear.

Closes #38
Jira: [FD-146](https://frcsistemasinformaticos.atlassian.net/browse/FD-146)

---
_Generated by [Claude Code](https://claude.ai/code/session_0133KZCSw6okRUWvWFvcXfak)_