### PR TITLE
fix(compras): persistir texto de búsqueda original en diálogo Añadir Item

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
@@ -87,6 +87,7 @@ export class AddEditItemDialogComponent implements OnInit {
   itemForm: FormGroup;
 
   // Product data
+  private originalSearchText = '';
   selectedProducto: Producto | null = null;
   presentacionesDisponibles: Presentacion[] = [];
 
@@ -278,6 +279,7 @@ export class AddEditItemDialogComponent implements OnInit {
 
   private initializeForm(): void {
     const initialSearch = (!this.data.isEdit && this.data.lastSearchText) ? this.data.lastSearchText : "";
+    this.originalSearchText = initialSearch;
     this.itemForm = this.formBuilder.group({
       productoSearch: [initialSearch],
       producto: [null, [Validators.required]],
@@ -626,6 +628,7 @@ export class AddEditItemDialogComponent implements OnInit {
   // Product search functionality similar to edit-transferencia.component.ts
   onSearchProducto(): void {
     const searchText = this.itemForm.get("productoSearch")?.value || "";
+    this.originalSearchText = searchText;
 
     const dialogData: PdvSearchProductoData = {
       texto: searchText,
@@ -1037,7 +1040,7 @@ export class AddEditItemDialogComponent implements OnInit {
             const result: AddEditItemDialogResult = {
               item: itemResult,
               action: "save",
-              lastSearchText: this.itemForm.get("productoSearch")?.value || "",
+              lastSearchText: this.originalSearchText,
             };
 
             this.dialogRef.close(result);
@@ -1068,7 +1071,7 @@ export class AddEditItemDialogComponent implements OnInit {
     const result: AddEditItemDialogResult = {
       item: {} as PedidoItem,
       action: "cancel",
-      lastSearchText: this.itemForm.get("productoSearch")?.value || "",
+      lastSearchText: this.originalSearchText,
     };
     this.dialogRef.close(result);
   }


### PR DESCRIPTION
## Summary
- Corrige bug del auto-agent (PR #39 / FD-146) donde se persistía `producto.descripcion` ("COCA COLA 500 ML") en vez del texto de búsqueda original ("COCA")
- Agrega variable `originalSearchText` que captura el texto antes de que `onProductoSelected` sobreescriba `productoSearch`

## Cambios
- `originalSearchText`: nueva propiedad privada
- `initializeForm()`: inicializa con `lastSearchText` si viene de apertura anterior
- `onSearchProducto()`: guarda el texto antes de abrir el diálogo de búsqueda
- `onSave()` / `onCancel()`: retornan `originalSearchText` en vez de leer `productoSearch`

## Test plan
- [ ] Abrir diálogo Añadir Item, escribir "COCA", buscar, seleccionar producto, guardar
- [ ] Reabrir diálogo → debe mostrar "COCA" (no "COCA COLA 500 ML")
- [ ] Texto debe estar seleccionado al abrir
- [ ] Cancelar y reabrir → sigue mostrando "COCA"
- [ ] Editar item existente → no afectado

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>