### PR TITLE
fix(sidebar): restringir acceso a ventas por roles

### DIFF
--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -178,7 +178,12 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
               action: 'list-caja',
               visibilityRoles: [ROLES.ANALISIS_DE_CAJA]
             },
-            { name: 'Ventas', icon: 'local_mall', action: 'generic-list-venta' },
+            {
+              name: 'Ventas',
+              icon: 'local_mall',
+              action: 'generic-list-venta',
+              visibilityRoles: [ROLES.ADMIN, ROLES.ANALISIS_DE_CAJA, ROLES.ANALISIS_DE_VENTA]
+            },
             { name: 'Delivery', icon: 'delivery_dining', action: 'delivery-dashboard' }
           ]
         },
@@ -579,7 +584,11 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
         this.openTabIfAuthorized(ROLES.ANALISIS_DE_CAJA, ListCajaComponent, "Cajas");
         break;
       case "generic-list-venta":
-        this.tabService.addTab(new Tab(GenericListVentaComponent, "Ventas", null, null));
+        if (this.hasAnyRole([ROLES.ANALISIS_DE_CAJA, ROLES.ANALISIS_DE_VENTA])) {
+          this.tabService.addTab(new Tab(GenericListVentaComponent, "Ventas", null, null));
+        } else {
+          this.notificacionService.openWarn('No tenés acceso a esta opción.');
+        }
         break;
       case "finanzas-dashboard":
         this.openTabIfAuthorized("ANALISIS-FINANCIERO", FinancieroDashboardComponent, "Financiero");


### PR DESCRIPTION
## Summary
- Restringe la visibilidad del ítem `Ventas` a `ADMIN`, `ANALISIS DE CAJA` y `ANALISIS DE VENTA`.
- Refuerza la validación en la acción `generic-list-venta` para bloquear aperturas directas sin permisos.
- Evita que usuarios sin esos roles vean o accedan a Ventas desde el sidebar.

## Test plan
- [ ] Iniciar sesión con usuario `ADMIN` y verificar que `Ventas` se muestra y abre.
- [ ] Iniciar sesión con rol `ANALISIS DE CAJA` y verificar que `Ventas` se muestra y abre.
- [ ] Iniciar sesión con rol `ANALISIS DE VENTA` y verificar que `Ventas` se muestra y abre.
- [ ] Iniciar sesión con usuario sin esos roles y verificar que `Ventas` no se muestra.
- [ ] Intentar abrir la acción `generic-list-venta` sin permisos y verificar mensaje de acceso denegado.

Made with [Cursor](https://cursor.com)