### PR TITLE
fix(compras): corregir rechazo items y mejorar resumen nota recepcion

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.html
@@ -167,6 +167,14 @@
                     <span class="info-label">Monto Total:</span>
                     <span class="info-value">{{ montoTotalComputed | number:'1.0-2' }}</span>
                   </div>
+                  <div class="info-item" *ngIf="tieneItemsRechazados">
+                    <span class="info-label">Monto Rechazado:</span>
+                    <span class="info-value monto-rechazado">- {{ montoRechazadoComputed | number:'1.0-2' }}</span>
+                  </div>
+                  <div class="info-item" *ngIf="tieneItemsRechazados">
+                    <span class="info-label">Monto Final:</span>
+                    <span class="info-value monto-final">{{ montoFinalComputed | number:'1.0-2' }}</span>
+                  </div>
                   <div class="info-item">
                     <span class="info-label">Estado:</span>
                     <mat-chip [ngClass]="estadoChipClass">

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.scss
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.scss
@@ -153,24 +153,35 @@ mat-dialog-content {
                 .info-label {
                   color: #f57c00;
                   font-weight: 600;
-                  font-size: 12px;
+                  font-size: 14px;
                 }
 
                 .info-value {
                   color: #ffffff;
                   font-weight: 500;
-                  font-size: 12px;
-                  
+                  font-size: 14px;
+
                   &.boolean-value {
                     font-weight: 600;
-                    
+
                     &.true {
                       color: #4caf50;
                     }
-                    
+
                     &.false {
                       color: #f44336;
                     }
+                  }
+
+                  &.monto-rechazado {
+                    color: #f44336;
+                    font-weight: 600;
+                  }
+
+                  &.monto-final {
+                    color: #4caf50;
+                    font-weight: 700;
+                    font-size: 16px;
                   }
                 }
 

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.ts
@@ -92,6 +92,10 @@ export class AddEditNotaRecepcionDialogComponent implements OnInit, AfterViewIni
   // Propiedades computadas para el card informativo
   totalItemsComputed: number = 0;
   montoTotalComputed: number = 0;
+  montoParcialComputed: number = 0;
+  montoRechazadoComputed: number = 0;
+  montoFinalComputed: number = 0;
+  tieneItemsRechazados: boolean = false;
   estadoDisplayName: string = '';
   estadoChipClass: string = '';
   pagadoDisplayText: string = '';
@@ -465,9 +469,17 @@ export class AddEditNotaRecepcionDialogComponent implements OnInit, AfterViewIni
     // Total items
     this.totalItemsComputed = this.itemsDataSource.data.length;
     
-    // Monto total
-    this.montoTotalComputed = this.itemsDataSource.data.reduce((total, item) => 
+    // Monto total y breakdown por estado
+    this.montoTotalComputed = this.itemsDataSource.data.reduce((total, item) =>
       total + (item.cantidadEnNota * item.precioUnitarioEnNota), 0);
+
+    this.montoRechazadoComputed = this.itemsDataSource.data
+      .filter(item => item.estado === 'RECHAZADO')
+      .reduce((total, item) => total + (item.cantidadEnNota * item.precioUnitarioEnNota), 0);
+
+    this.montoParcialComputed = this.montoTotalComputed - this.montoRechazadoComputed;
+    this.montoFinalComputed = this.montoParcialComputed;
+    this.tieneItemsRechazados = this.montoRechazadoComputed > 0;
     
     // Estado display name
     const estadoValue = this.notaRecepcionForm.get('estado')?.value;

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/distribute-nota-recepcion-item-dialog/distribute-nota-recepcion-item-dialog.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/distribute-nota-recepcion-item-dialog/distribute-nota-recepcion-item-dialog.component.html
@@ -197,7 +197,8 @@
             <div
               *ngFor="
                 let distribucion of distribucionesComputed;
-                let i = index
+                let i = index;
+                trackBy: trackByIndex
               "
               [formGroupName]="i"
               class="distribucion-item"

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/rechazar-item-dialog/rechazar-item-dialog.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/rechazar-item-dialog/rechazar-item-dialog.component.html
@@ -92,7 +92,6 @@
               [max]="notaPreseleccionada ? cantidadMaxima : cantidadPendiente"
               step="0.01"
               (keydown)="onCantidadKeydown($event)"
-              [readonly]="hasItemToReject"
             />
             <mat-hint *ngIf="cantidadEnUnidadesBaseComputed > 0">
               = {{ cantidadEnUnidadesBaseComputed | number:'1.0-2' }} unidades base

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/rechazar-item-dialog/rechazar-item-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/rechazar-item-dialog/rechazar-item-dialog.component.ts
@@ -307,7 +307,17 @@ export class RechazarItemDialogComponent implements OnInit {
     let notaRecepcionItem: NotaRecepcionItem;
 
     if (this.itemToReject) {
-      // Si hay un ítem específico a rechazar, actualizar el ítem existente
+      const cantidadOriginal = this.itemToReject.cantidadEnNota || 0;
+      const cantidadARechazar = this.cantidadEnUnidadesBaseComputed;
+      const esRechazoParcial = cantidadARechazar < cantidadOriginal;
+
+      if (esRechazoParcial) {
+        // Rechazo parcial: reducir cantidad del ítem original y crear nuevo ítem RECHAZADO
+        this.procesarRechazoParcial(formValue, cantidadOriginal, cantidadARechazar);
+        return;
+      }
+
+      // Rechazo total: marcar el ítem existente como RECHAZADO
       notaRecepcionItem = Object.assign(new NotaRecepcionItem(), this.itemToReject);
       notaRecepcionItem.estado = NotaRecepcionItemEstado.RECHAZADO;
       notaRecepcionItem.motivoRechazo = formValue.motivoRechazo;
@@ -342,6 +352,50 @@ export class RechazarItemDialogComponent implements OnInit {
         this.guardarItemYRechazarDistribuciones(notaRecepcionItem);
       }
     }
+  }
+
+  private procesarRechazoParcial(formValue: any, cantidadOriginal: number, cantidadARechazar: number): void {
+    // 1. Actualizar el ítem original con la cantidad restante
+    const itemOriginal = Object.assign(new NotaRecepcionItem(), this.itemToReject);
+    itemOriginal.cantidadEnNota = cantidadOriginal - cantidadARechazar;
+
+    this.pedidoService.onSaveNotaRecepcionItem(itemOriginal.toInput())
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => {
+          // 2. Crear nuevo ítem RECHAZADO con la cantidad rechazada
+          const itemRechazado = new NotaRecepcionItem();
+          itemRechazado.notaRecepcion = this.itemToReject.notaRecepcion;
+          itemRechazado.pedidoItem = this.itemToReject.pedidoItem;
+          itemRechazado.producto = this.itemToReject.producto;
+          itemRechazado.presentacionEnNota = this.presentacionSeleccionada || this.itemToReject.presentacionEnNota;
+          itemRechazado.cantidadEnNota = cantidadARechazar;
+          itemRechazado.precioUnitarioEnNota = this.itemToReject.precioUnitarioEnNota;
+          itemRechazado.esBonificacion = this.itemToReject.esBonificacion || false;
+          itemRechazado.vencimientoEnNota = this.itemToReject.vencimientoEnNota;
+          itemRechazado.observacion = formValue.observaciones;
+          itemRechazado.estado = NotaRecepcionItemEstado.RECHAZADO;
+          itemRechazado.motivoRechazo = formValue.motivoRechazo;
+
+          this.pedidoService.onSaveNotaRecepcionItem(itemRechazado.toInput())
+            .pipe(untilDestroyed(this))
+            .subscribe({
+              next: (itemGuardado) => {
+                this.finalizarRechazo(itemGuardado);
+              },
+              error: (error) => {
+                console.error('Error al crear ítem rechazado parcial:', error);
+                this.notificacionService.openAlgoSalioMal('Error al crear el ítem de rechazo parcial');
+                this.isLoading = false;
+              }
+            });
+        },
+        error: (error) => {
+          console.error('Error al actualizar ítem original:', error);
+          this.notificacionService.openAlgoSalioMal('Error al actualizar el ítem original');
+          this.isLoading = false;
+        }
+      });
   }
 
   private crearNuevaNotaYGuardarItem(notaRecepcionItem: NotaRecepcionItem, esNotaRechazo: boolean = false): void {
@@ -407,12 +461,18 @@ export class RechazarItemDialogComponent implements OnInit {
   private rechazarDistribucionesDelItem(itemId: number): void {
     // Rechazar todas las distribuciones del ítem
     const promesasRechazo = this.distribucionesDelItem.map(distribucion => {
-      distribucion.estado = 'RECHAZADO';
-      distribucion.fechaRechazo = new Date();
-      distribucion.motivoRechazo = 'ITEM_RECHAZADO';
-      distribucion.observacion = 'Rechazado automáticamente al rechazar el ítem';
-      
-      return this.pedidoService.onSaveNotaRecepcionItemDistribucion(distribucion.toInput()).toPromise();
+      // Construir input manualmente porque distribucion es un plain object del backend
+      const input = {
+        id: distribucion.id,
+        notaRecepcionItemId: distribucion.notaRecepcionItem?.id || itemId,
+        sucursalInfluenciaId: distribucion.sucursalInfluencia?.id || null,
+        sucursalEntregaId: distribucion.sucursalEntrega?.id,
+        cantidad: distribucion.cantidad,
+        creadoEn: distribucion.creadoEn,
+        usuarioId: distribucion.usuario?.id || null
+      };
+
+      return this.pedidoService.onSaveNotaRecepcionItemDistribucion(input as any).toPromise();
     });
 
     Promise.all(promesasRechazo)

--- a/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.ts
@@ -617,15 +617,14 @@ export class RecepcionMercaderiaComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (pageInfo) => {
           if (pageInfo && pageInfo.getContent && pageInfo.getContent.length > 0) {
-            // Usar directamente los datos del backend
-            let items = pageInfo.getContent.map((item: any) => {
-              // Los datos ya vienen con los campos de recepción física del backend
-              // No necesitamos conversión adicional
-              return item;
-            });
+            // Usar directamente los datos del backend, filtrando ítems rechazados documentalmente
+            let items = pageInfo.getContent.filter((item: any) =>
+              item.estado !== 'RECHAZADO'
+            );
 
-            // Paginación backend-driven: el total debe venir del backend para que el paginator sea correcto
-            this.itemsTotalElements = pageInfo.getTotalElements || 0;
+            // Paginación: ajustar total descontando rechazados
+            const rechazadosCount = (pageInfo.getContent.length || 0) - items.length;
+            this.itemsTotalElements = (pageInfo.getTotalElements || 0) - rechazadosCount;
 
             this.items = items;
           } else {
@@ -2593,9 +2592,10 @@ export class RecepcionMercaderiaComponent implements OnInit, OnDestroy {
           return;
         }
 
-        // Filtrar solo items con estado PENDIENTE o PARCIAL (recepcionables)
-        const itemsRecepcionables = pageInfo.getContent.filter((item: any) => 
-          item.estadoRecepcion === 'PENDIENTE' || item.estadoRecepcion === 'PARCIAL'
+        // Filtrar solo items recepcionables: excluir rechazados documentalmente y solo PENDIENTE/PARCIAL
+        const itemsRecepcionables = pageInfo.getContent.filter((item: any) =>
+          item.estado !== 'RECHAZADO' &&
+          (item.estadoRecepcion === 'PENDIENTE' || item.estadoRecepcion === 'PARCIAL')
         );
 
         if (itemsRecepcionables.length === 0) {


### PR DESCRIPTION
## Summary
- **Fix TypeError** `distribucion.toInput is not a function` — backend returns plain objects, not class instances; built input manually
- **Rechazo parcial** de ítems habilitado — cantidad editable, se divide en 2 ítems (original reducido + nuevo RECHAZADO)
- **Resumen mejorado** en nota de recepción: muestra Monto Total, Monto Rechazado (rojo) y Monto Final (verde) cuando hay ítems rechazados
- **Font size** del resumen incrementado de 12px a 14px para mejor legibilidad
- **Fix focus loss** en diálogo de distribución al borrar input — agregado `trackBy: trackByIndex` al `*ngFor`
- **Filtro ítems rechazados** en Recepción Física — ítems con `estado === 'RECHAZADO'` (rechazo documental) ya no aparecen en la tabla ni en "Verificar todos"

## Test plan
- [ ] Rechazar un ítem completamente desde nota de recepción → debe marcarse como RECHAZADO
- [ ] Rechazar parcialmente un ítem → debe dividirse en 2 ítems (activo con cantidad reducida + rechazado)
- [ ] Verificar que el resumen muestre Monto Rechazado y Monto Final cuando hay ítems rechazados
- [ ] Verificar que ítems rechazados NO aparezcan en tab Recepción Física
- [ ] En diálogo distribución, borrar un número del input → verificar que el foco NO se pierde
- [ ] "Verificar todos" en Recepción Física no debe incluir ítems rechazados documentalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)