### PR TITLE
feat(compras): sidebar info producto + indicador cambio precio

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.html
@@ -39,366 +39,438 @@
           </mat-form-field>
         </div>
 
-        <!-- Producto seleccionado display -->
-        <div class="selected-product-display" *ngIf="productoSelectedComputed">
-          <mat-card class="product-card">
-            <mat-card-content
-              style="
-                display: flex;
-                flex-direction: row;
-                padding-top: 0px;
-                padding-bottom: 0px;
-              "
-            >
-              <div class="product-info" style="flex: 90%">
-                <strong
-                  >{{ itemForm.get("producto")?.value?.id }} -
-                  {{ itemForm.get("producto")?.value?.descripcion }}</strong
-                >
-                <span class="product-code"
-                  >({{
-                    itemForm.get("producto")?.value?.codigoPrincipal
-                  }})</span
-                >
-              </div>
-              <div class="clear-icon-button" style="flex: 10%">
-                <button
-                  mat-icon-button
-                  (click)="onClearProducto()"
-                  color="primary"
-                >
-                  <mat-icon>clear</mat-icon>
-                </button>
-              </div>
-            </mat-card-content>
-          </mat-card>
-        </div>
+        <!-- Two-column layout: sidebar + form content -->
+        <div class="content-area" [class.has-product]="productoSelectedComputed">
 
-        <!-- Fila 2: Presentación, Precios y Bonificación -->
-        <div class="form-row" *ngIf="productoSelectedComputed">
-          <mat-form-field appearance="outline">
-            <mat-label>Presentación</mat-label>
-            <mat-select
-              #presentacionSelect
-              formControlName="presentacion"
-              (keydown)="onPresentacionKeydown($event)"
-              (closed)="onPresentacionClosed()"
-            >
-              <mat-option
-                *ngFor="let presentacion of presentacionesDisponibles"
-                [value]="presentacion"
-              >
-              <!-- show only cantidad -->
-                {{ presentacion.cantidad }}
-              </mat-option>
-            </mat-select>
-            <mat-error
-              *ngIf="itemForm.get('presentacion')?.hasError('required')"
-            >
-              Debe seleccionar una presentación
-            </mat-error>
-          </mat-form-field>
-
-          <mat-form-field appearance="outline">
-            <mat-label>Precio por Presentación</mat-label>
-            <input
-              matInput
-              #precioPorPresentacionInput
-              type="text"
-              currencyMask
-              [options]="selectedCurrencyOptions"
-              formControlName="precioUnitarioPorPresentacion"
-              [readonly]="isBonificacionComputed"
-              (keydown)="onPrecioPorPresentacionKeydown($event)"
-              matTooltip="Se actualiza automáticamente al cambiar precio unitario"
-            />
-            <span matPrefix>{{ selectedCurrencyPrefix }}</span>
-            <mat-error
-              *ngIf="
-                itemForm.get('precioUnitarioPorPresentacion')?.hasError('min')
-              "
-            >
-              El precio no puede ser negativo
-            </mat-error>
-          </mat-form-field>
-
-          <mat-form-field appearance="outline">
-            <mat-label>Precio Unitario</mat-label>
-            <input
-              matInput
-              #precioUnitarioInput
-              type="text"
-              currencyMask
-              [options]="selectedCurrencyOptions"
-              formControlName="precioUnitarioSolicitado"
-              [readonly]="isBonificacionComputed"
-              (keydown)="onPrecioUnitarioKeydown($event)"
-              (blur)="onPrecioUnitarioBlur()"
-              matTooltip="Precio por unidad individual del producto"
-            />
-            <span matPrefix>{{ selectedCurrencyPrefix }}</span>
-            <mat-error
-              *ngIf="itemForm.get('precioUnitarioSolicitado')?.hasError('min')"
-            >
-              El precio no puede ser negativo
-            </mat-error>
-          </mat-form-field>
-
-          <div class="checkbox-container">
-            <mat-checkbox
-              #bonificacionCheckbox
-              formControlName="esBonificacion"
-              class="bonificacion-checkbox"
-              (keydown)="onBonificacionKeydown($event)"
-              matTooltip="Los ítems marcados como bonificación tendrán precio 0"
-            >
-              Es Bonificación
-            </mat-checkbox>
-          </div>
-        </div>
-
-        <!-- Fila 3: Distribuciones por Sucursales (MODO COMPLETO) -->
-        <div class="distribuciones-section" *ngIf="productoSelectedComputed && presentacionSelectedComputed && distribucionModo === 'COMPLETA'">
-          <div class="distribuciones-header">
-            <h4>Distribución por Sucursales</h4>
-            <button
-              mat-icon-button
-              color="primary"
-              (click)="onAddDistribucion()"
-              matTooltip="Agregar distribución"
-              type="button"
-            >
-              <mat-icon>add</mat-icon>
-            </button>
+          <!-- LEFT: Product Info Sidebar -->
+          <div class="product-sidebar" *ngIf="productoSelectedComputed">
+            <div class="sidebar-image-container">
+              <img
+                [src]="selectedProducto?.imagenPrincipal || 'assets/no-image.png'"
+                [frcPrevisualizarImagen]="selectedProducto?.imagenPrincipal || 'assets/no-image.png'"
+                class="sidebar-product-image"
+                matTooltip="Ver imagen"
+              />
+            </div>
+            <div class="sidebar-nombre">{{ selectedProducto?.descripcion }}</div>
+            <div class="sidebar-codigo" *ngIf="selectedProducto?.codigoPrincipal">
+              <mat-icon class="sidebar-icon">qr_code</mat-icon>
+              {{ selectedProducto?.codigoPrincipal }}
+            </div>
+            <div class="sidebar-info-row">
+              <span class="sidebar-label">IVA:</span>
+              <span>{{ selectedProducto?.iva }}%</span>
+            </div>
+            <div class="sidebar-info-row" *ngIf="selectedProducto?.costo?.costoMedio">
+              <span class="sidebar-label">Costo Medio:</span>
+              <span>{{ selectedProducto?.costo?.costoMedio | number:'1.0-0' }} {{ selectedCurrencyPrefix }}</span>
+            </div>
+            <div class="sidebar-precios-section" *ngIf="presentacionesDisponibles.length > 0">
+              <div class="sidebar-section-title">Precios de Venta</div>
+              <table class="sidebar-precios-table">
+                <thead><tr><th>Pres.</th><th>Precio</th></tr></thead>
+                <tbody>
+                  <tr *ngFor="let p of presentacionesDisponibles">
+                    <td>{{ p.cantidad }}</td>
+                    <td>{{ p.precioPrincipal?.precio != null ? (p.precioPrincipal.precio | number:'1.0-0') : 'N/A' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
 
-          <!-- Tabla de distribuciones -->
-          <div class="distribuciones-table-container" *ngIf="distribucionesItems.length > 0">
-            <table mat-table [dataSource]="distribucionesDataSource" class="distribuciones-table">
-              <!-- Sucursal Influencia Column -->
-              <ng-container matColumnDef="sucursalInfluencia">
-                <th mat-header-cell *matHeaderCellDef style="text-align: left;">Sucursal Influencia</th>
-                <td mat-cell *matCellDef="let item; let i = index" style="text-align: left;">
-                  {{ item.sucursalInfluencia?.nombre }}
-                </td>
-              </ng-container>
+          <!-- RIGHT: Form content -->
+          <div class="form-right-column">
 
-              <!-- Sucursal Entrega Column -->
-              <ng-container matColumnDef="sucursalEntrega">
-                <th mat-header-cell *matHeaderCellDef style="text-align: left;">Suc de Entrega</th>
-                <td mat-cell *matCellDef="let item; let i = index" style="text-align: left;">
-                  <mat-form-field appearance="outline" class="sucursal-entrega-field">
-                    <mat-select
-                      [formControl]="getDistribucionControl(i, 'sucursalEntregaId')"
-                      (selectionChange)="onCantidadPedirBlur(i)"
+            <!-- Producto seleccionado display -->
+            <div class="selected-product-display" *ngIf="productoSelectedComputed">
+              <mat-card class="product-card">
+                <mat-card-content
+                  style="
+                    display: flex;
+                    flex-direction: row;
+                    padding-top: 0px;
+                    padding-bottom: 0px;
+                  "
+                >
+                  <div class="product-info" style="flex: 90%">
+                    <strong
+                      >{{ itemForm.get("producto")?.value?.id }} -
+                      {{ itemForm.get("producto")?.value?.descripcion }}</strong
                     >
-                      <mat-option
-                        *ngFor="let sucursal of getSucursalesEntregaDisponibles()"
-                        [value]="sucursal.id"
-                      >
-                        {{ sucursal.nombre }}
-                      </mat-option>
-                    </mat-select>
-                    <mat-error
-                      *ngIf="getDistribucionControl(i, 'sucursalEntregaId')?.hasError('required')"
+                    <span class="product-code"
+                      >({{
+                        itemForm.get("producto")?.value?.codigoPrincipal
+                      }})</span
                     >
-                      Requerido
-                    </mat-error>
-                  </mat-form-field>
-                </td>
-              </ng-container>
-
-              <!-- Stock Actual Column -->
-              <ng-container matColumnDef="stockActual">
-                <th mat-header-cell *matHeaderCellDef>Stock Actual</th>
-                <td mat-cell *matCellDef="let item; let i = index" class="stock-cell">
-                  <div *ngIf="item.stockActualLoading" class="loading-container">
-                    <mat-spinner diameter="20"></mat-spinner>
                   </div>
-                  <div *ngIf="!item.stockActualLoading" class="cantidad-display">
-                    <div class="cantidad-presentacion">{{ getCantidadPorPresentacion(item.stockActual) | number : "1.0-2" }}</div>
-                    <div class="cantidad-unidades">({{ item.stockActual | number : "1.0-2" }} unidades)</div>
-                  </div>
-                </td>
-              </ng-container>
-
-              <!-- Cantidad Sugerida Column -->
-              <ng-container matColumnDef="cantidadSugerida">
-                <th mat-header-cell *matHeaderCellDef>Cant. Sugerida</th>
-                <td mat-cell *matCellDef="let item; let i = index">
-                  <span *ngIf="item.cantidadSugeridaLoading">Calculando...</span>
-                  <div *ngIf="!item.cantidadSugeridaLoading" class="cantidad-display">
-                    <div class="cantidad-presentacion">{{ getCantidadPorPresentacion(item.cantidadSugerida) | number : "1.0-2" }}</div>
-                    <div class="cantidad-unidades">({{ item.cantidadSugerida | number : "1.0-2" }} unidades)</div>
-                  </div>
-                </td>
-              </ng-container>
-
-              <!-- Cantidad a Pedir Column -->
-              <ng-container matColumnDef="cantidadPedir">
-                <th mat-header-cell *matHeaderCellDef>Cantidad a Pedir</th>
-                <td mat-cell *matCellDef="let item; let i = index">
-                  <mat-form-field appearance="outline" class="cantidad-input-field">
-                    <input
-                      matInput
-                      type="number"
-                      step="0.01"
-                      min="0"
-                      [formControl]="getDistribucionControl(i, 'cantidadPedir')"
-                      (focus)="onCantidadInputFocus(getDistribucionControl(i, 'cantidadPedir'))"
-                      (keydown)="onCantidadPedirKeydown($event, i)"
-                      (blur)="onCantidadPedirBlur(i)"
-                      [attr.data-index]="i"
-                      class="cantidad-pedir-input"
-                    />
-                    <mat-error
-                      *ngIf="getDistribucionControl(i, 'cantidadPedir')?.hasError('required')"
+                  <div class="clear-icon-button" style="flex: 10%">
+                    <button
+                      mat-icon-button
+                      (click)="onClearProducto()"
+                      color="primary"
                     >
-                      Requerido
-                    </mat-error>
-                    <mat-error
-                      *ngIf="getDistribucionControl(i, 'cantidadPedir')?.hasError('min')"
-                    >
-                      No puede ser negativo
-                    </mat-error>
-                  </mat-form-field>
-                </td>
-              </ng-container>
+                      <mat-icon>clear</mat-icon>
+                    </button>
+                  </div>
+                </mat-card-content>
+              </mat-card>
+            </div>
 
-              <!-- Acciones Column -->
-              <ng-container matColumnDef="acciones">
-                <th mat-header-cell *matHeaderCellDef>Acciones</th>
-                <td mat-cell *matCellDef="let item; let i = index">
-                  <button
-                    mat-icon-button
-                    color="warn"
-                    (click)="onRemoveDistribucion(i)"
-                    matTooltip="Eliminar distribución"
-                    type="button"
+            <!-- Fila 2: Presentación, Precios y Bonificación -->
+            <div class="form-row" *ngIf="productoSelectedComputed">
+              <mat-form-field appearance="outline">
+                <mat-label>Presentación</mat-label>
+                <mat-select
+                  #presentacionSelect
+                  formControlName="presentacion"
+                  (keydown)="onPresentacionKeydown($event)"
+                  (closed)="onPresentacionClosed()"
+                >
+                  <mat-option
+                    *ngFor="let presentacion of presentacionesDisponibles"
+                    [value]="presentacion"
                   >
-                    <mat-icon>delete</mat-icon>
-                  </button>
-                </td>
-              </ng-container>
+                    {{ presentacion.cantidad }}
+                  </mat-option>
+                </mat-select>
+                <mat-error
+                  *ngIf="itemForm.get('presentacion')?.hasError('required')"
+                >
+                  Debe seleccionar una presentación
+                </mat-error>
+              </mat-form-field>
 
-              <tr mat-header-row *matHeaderRowDef="distribucionesDisplayedColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: distribucionesDisplayedColumns"></tr>
-            </table>
-          </div>
-
-          <!-- Mensaje cuando no hay distribuciones -->
-          <div class="no-distribuciones-message" *ngIf="distribucionesItems.length === 0">
-            <p>No hay distribuciones configuradas. Haga clic en el botón "+" para agregar una.</p>
-          </div>
-
-          <!-- Total de cantidad -->
-          <div class="cantidad-total-display" *ngIf="distribucionesItems.length > 0">
-            <mat-card class="total-card">
-              <mat-card-content>
-                <div class="total-content">
-                  <span class="total-label">Cantidad Total:</span>
-                  <span class="total-value">{{ cantidadTotalComputedText }}</span>
+              <div class="price-field-wrapper">
+                <mat-form-field appearance="outline">
+                  <mat-label>Precio por Presentación</mat-label>
+                  <input
+                    matInput
+                    #precioPorPresentacionInput
+                    type="text"
+                    currencyMask
+                    [options]="selectedCurrencyOptions"
+                    formControlName="precioUnitarioPorPresentacion"
+                    [readonly]="isBonificacionComputed"
+                    (keydown)="onPrecioPorPresentacionKeydown($event)"
+                    matTooltip="Se actualiza automáticamente al cambiar precio unitario"
+                  />
+                  <span matPrefix>{{ selectedCurrencyPrefix }}</span>
+                  <mat-error
+                    *ngIf="
+                      itemForm.get('precioUnitarioPorPresentacion')?.hasError('min')
+                    "
+                  >
+                    El precio no puede ser negativo
+                  </mat-error>
+                </mat-form-field>
+                <div class="precio-anterior-hint" *ngIf="presentacionSelectedComputed && precioHaCambiadoComputed && !isBonificacionComputed">
+                  Precio anterior: {{ (precioOriginal * (itemForm.get('presentacion')?.value?.cantidad || 1)) | number:'1.0-0' }} {{ selectedCurrencyPrefix }}
                 </div>
-                <div class="total-error" *ngIf="hasCantidadTotalError">
-                  <mat-icon color="warn">warning</mat-icon>
-                  <span>La cantidad total debe ser mayor a 0</span>
-                </div>
-              </mat-card-content>
-            </mat-card>
-          </div>
-        </div>
+              </div>
 
-        <!-- Fila 3: Distribución (MODO SIMPLIFICADO) -->
-        <div class="distribuciones-section simplified" *ngIf="productoSelectedComputed && presentacionSelectedComputed && distribucionModo === 'SIMPLIFICADA'">
-          <div class="simplified-row">
-            <!-- Stock Total -->
-            <div class="stock-total-container" [matTooltip]="stockBreakdownTooltipComputed" matTooltipClass="multiline-tooltip">
-              <span class="label">Stock Actual (Influencia):</span>
-              <div class="cantidad-display">
-                <div class="cantidad-presentacion">{{ getCantidadPorPresentacion(stockTotalSimplificadoComputed) | number : "1.0-2" }}</div>
-                <div class="cantidad-unidades">({{ stockTotalSimplificadoComputed | number : "1.0-2" }} unidades)</div>
+              <div class="price-field-wrapper">
+                <mat-form-field appearance="outline">
+                  <mat-label>Precio Unitario</mat-label>
+                  <input
+                    matInput
+                    #precioUnitarioInput
+                    type="text"
+                    currencyMask
+                    [options]="selectedCurrencyOptions"
+                    formControlName="precioUnitarioSolicitado"
+                    [readonly]="isBonificacionComputed"
+                    (keydown)="onPrecioUnitarioKeydown($event)"
+                    (blur)="onPrecioUnitarioBlur()"
+                    matTooltip="Precio por unidad individual del producto"
+                  />
+                  <span matPrefix>{{ selectedCurrencyPrefix }}</span>
+                  <mat-error
+                    *ngIf="itemForm.get('precioUnitarioSolicitado')?.hasError('min')"
+                  >
+                    El precio no puede ser negativo
+                  </mat-error>
+                </mat-form-field>
+                <div class="precio-anterior-hint" *ngIf="presentacionSelectedComputed && precioHaCambiadoComputed && !isBonificacionComputed">
+                  Precio anterior: {{ precioOriginal | number:'1.0-0' }} {{ selectedCurrencyPrefix }}
+                </div>
+              </div>
+
+              <div class="checkbox-container">
+                <mat-checkbox
+                  #bonificacionCheckbox
+                  formControlName="esBonificacion"
+                  class="bonificacion-checkbox"
+                  (keydown)="onBonificacionKeydown($event)"
+                  matTooltip="Los ítems marcados como bonificación tendrán precio 0"
+                >
+                  Es Bonificación
+                </mat-checkbox>
               </div>
             </div>
 
-            <!-- Input Cantidad Total -->
-            <mat-form-field appearance="outline" class="cantidad-total-field">
-              <mat-label>Cantidad Total a Pedir</mat-label>
-              <input
-                matInput
-                class="cantidad-simplificada-input"
-                type="number"
-                step="0.01"
-                min="0"
-                [formControl]="cantidadSimplificadaControl"
-                (focus)="onCantidadInputFocus(cantidadSimplificadaControl)"
-                (keydown)="onCantidadSimplificadaKeydown($event)"
-              />
-              <mat-hint>{{ cantidadTotalComputedText }}</mat-hint>
-              <mat-error *ngIf="cantidadSimplificadaControl.hasError('required')">Requerido</mat-error>
-              <mat-error *ngIf="cantidadSimplificadaControl.hasError('min')">Debe ser mayor a 0</mat-error>
-            </mat-form-field>
-          </div>
-        </div>
-
-        <!-- Fila 4: Vencimiento (solo si el producto maneja vencimiento) -->
-        <div
-          class="form-row"
-          *ngIf="productoSelectedComputed && productoManejaVencimientoComputed"
-        >
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Vencimiento Esperado</mat-label>
-            <input
-              matInput
-              #vencimientoInput
-              [matDatepicker]="vencimientoPicker"
-              formControlName="vencimientoEsperado"
-              (keydown)="onVencimientoKeydown($event)"
-              (blur)="onVencimientoBlur()"
-              matTooltip="Fecha esperada de vencimiento del producto"
-            />
-            <mat-datepicker-toggle
-              matSuffix
-              [for]="vencimientoPicker"
-            ></mat-datepicker-toggle>
-            <mat-datepicker 
-              #vencimientoPicker
-              (closed)="onVencimientoBlur()"
-            ></mat-datepicker>
-          </mat-form-field>
-        </div>
-
-        <!-- Fila 5: Observación -->
-        <div class="form-row" *ngIf="productoSelectedComputed">
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Observaciones</mat-label>
-            <textarea
-              matInput
-              #observacionInput
-              formControlName="observacion"
-              rows="3"
-              placeholder="Observaciones adicionales sobre el ítem..."
-              (keydown)="onObservacionKeydown($event)"
-              matTooltip="Información adicional sobre el producto o solicitud"
-            ></textarea>
-          </mat-form-field>
-        </div>
-
-        <!-- Subtotal Display -->
-        <div
-          class="subtotal-display"
-          *ngIf="productoSelectedComputed && !isBonificacionComputed"
-        >
-          <mat-card class="subtotal-card">
-            <mat-card-content>
-              <div class="subtotal-content">
-                <span class="subtotal-label">Subtotal:</span>
-                <span class="subtotal-value">{{
-                  subtotalComputed | currency : "Gs." : "symbol" : "1.0-2"
-                }}</span>
+            <!-- Price change indicator -->
+            <div class="precio-cambio-indicator" [class]="'precio-cambio-indicator cambio-nivel-' + precioCambioNivelComputed" *ngIf="precioHaCambiadoComputed && !isBonificacionComputed">
+              <div class="cambio-content">
+                <mat-icon>
+                  {{ precioCambioComputed > 0 ? 'trending_up' : 'trending_down' }}
+                </mat-icon>
+                <span class="cambio-text">
+                  {{ precioCambioPorcentualComputed >= 0 ? '+' : '' }}{{ precioCambioPorcentualComputed | number:'1.1-1' }}%
+                  ({{ precioCambioComputed >= 0 ? '+' : '' }}{{ precioCambioComputed | number:'1.0-0' }} {{ selectedCurrencyPrefix }})
+                </span>
               </div>
-            </mat-card-content>
-          </mat-card>
-        </div>
+              <button mat-stroked-button type="button" class="programar-precio-btn" (click)="onProgramarPrecioClick()">
+                <mat-icon>schedule</mat-icon>
+                Programar cambio de precio
+              </button>
+            </div>
+
+            <!-- Fila 3: Distribuciones por Sucursales (MODO COMPLETO) -->
+            <div class="distribuciones-section" *ngIf="productoSelectedComputed && presentacionSelectedComputed && distribucionModo === 'COMPLETA'">
+              <div class="distribuciones-header">
+                <h4>Distribución por Sucursales</h4>
+                <button
+                  mat-icon-button
+                  color="primary"
+                  (click)="onAddDistribucion()"
+                  matTooltip="Agregar distribución"
+                  type="button"
+                >
+                  <mat-icon>add</mat-icon>
+                </button>
+              </div>
+
+              <!-- Tabla de distribuciones -->
+              <div class="distribuciones-table-container" *ngIf="distribucionesItems.length > 0">
+                <table mat-table [dataSource]="distribucionesDataSource" class="distribuciones-table">
+                  <!-- Sucursal Influencia Column -->
+                  <ng-container matColumnDef="sucursalInfluencia">
+                    <th mat-header-cell *matHeaderCellDef style="text-align: left;">Sucursal Influencia</th>
+                    <td mat-cell *matCellDef="let item; let i = index" style="text-align: left;">
+                      {{ item.sucursalInfluencia?.nombre }}
+                    </td>
+                  </ng-container>
+
+                  <!-- Sucursal Entrega Column -->
+                  <ng-container matColumnDef="sucursalEntrega">
+                    <th mat-header-cell *matHeaderCellDef style="text-align: left;">Suc de Entrega</th>
+                    <td mat-cell *matCellDef="let item; let i = index" style="text-align: left;">
+                      <mat-form-field appearance="outline" class="sucursal-entrega-field">
+                        <mat-select
+                          [formControl]="getDistribucionControl(i, 'sucursalEntregaId')"
+                          (selectionChange)="onCantidadPedirBlur(i)"
+                        >
+                          <mat-option
+                            *ngFor="let sucursal of getSucursalesEntregaDisponibles()"
+                            [value]="sucursal.id"
+                          >
+                            {{ sucursal.nombre }}
+                          </mat-option>
+                        </mat-select>
+                        <mat-error
+                          *ngIf="getDistribucionControl(i, 'sucursalEntregaId')?.hasError('required')"
+                        >
+                          Requerido
+                        </mat-error>
+                      </mat-form-field>
+                    </td>
+                  </ng-container>
+
+                  <!-- Stock Actual Column -->
+                  <ng-container matColumnDef="stockActual">
+                    <th mat-header-cell *matHeaderCellDef>Stock Actual</th>
+                    <td mat-cell *matCellDef="let item; let i = index" class="stock-cell">
+                      <div *ngIf="item.stockActualLoading" class="loading-container">
+                        <mat-spinner diameter="20"></mat-spinner>
+                      </div>
+                      <div *ngIf="!item.stockActualLoading" class="cantidad-display">
+                        <div class="cantidad-presentacion">{{ getCantidadPorPresentacion(item.stockActual) | number : "1.0-2" }}</div>
+                        <div class="cantidad-unidades">({{ item.stockActual | number : "1.0-2" }} unidades)</div>
+                      </div>
+                    </td>
+                  </ng-container>
+
+                  <!-- Cantidad Sugerida Column -->
+                  <ng-container matColumnDef="cantidadSugerida">
+                    <th mat-header-cell *matHeaderCellDef>Cant. Sugerida</th>
+                    <td mat-cell *matCellDef="let item; let i = index">
+                      <span *ngIf="item.cantidadSugeridaLoading">Calculando...</span>
+                      <div *ngIf="!item.cantidadSugeridaLoading" class="cantidad-display">
+                        <div class="cantidad-presentacion">{{ getCantidadPorPresentacion(item.cantidadSugerida) | number : "1.0-2" }}</div>
+                        <div class="cantidad-unidades">({{ item.cantidadSugerida | number : "1.0-2" }} unidades)</div>
+                      </div>
+                    </td>
+                  </ng-container>
+
+                  <!-- Cantidad a Pedir Column -->
+                  <ng-container matColumnDef="cantidadPedir">
+                    <th mat-header-cell *matHeaderCellDef>Cantidad a Pedir</th>
+                    <td mat-cell *matCellDef="let item; let i = index">
+                      <mat-form-field appearance="outline" class="cantidad-input-field">
+                        <input
+                          matInput
+                          type="number"
+                          step="0.01"
+                          min="0"
+                          [formControl]="getDistribucionControl(i, 'cantidadPedir')"
+                          (focus)="onCantidadInputFocus(getDistribucionControl(i, 'cantidadPedir'))"
+                          (keydown)="onCantidadPedirKeydown($event, i)"
+                          (blur)="onCantidadPedirBlur(i)"
+                          [attr.data-index]="i"
+                          class="cantidad-pedir-input"
+                        />
+                        <mat-error
+                          *ngIf="getDistribucionControl(i, 'cantidadPedir')?.hasError('required')"
+                        >
+                          Requerido
+                        </mat-error>
+                        <mat-error
+                          *ngIf="getDistribucionControl(i, 'cantidadPedir')?.hasError('min')"
+                        >
+                          No puede ser negativo
+                        </mat-error>
+                      </mat-form-field>
+                    </td>
+                  </ng-container>
+
+                  <!-- Acciones Column -->
+                  <ng-container matColumnDef="acciones">
+                    <th mat-header-cell *matHeaderCellDef>Acciones</th>
+                    <td mat-cell *matCellDef="let item; let i = index">
+                      <button
+                        mat-icon-button
+                        color="warn"
+                        (click)="onRemoveDistribucion(i)"
+                        matTooltip="Eliminar distribución"
+                        type="button"
+                      >
+                        <mat-icon>delete</mat-icon>
+                      </button>
+                    </td>
+                  </ng-container>
+
+                  <tr mat-header-row *matHeaderRowDef="distribucionesDisplayedColumns"></tr>
+                  <tr mat-row *matRowDef="let row; columns: distribucionesDisplayedColumns"></tr>
+                </table>
+              </div>
+
+              <!-- Mensaje cuando no hay distribuciones -->
+              <div class="no-distribuciones-message" *ngIf="distribucionesItems.length === 0">
+                <p>No hay distribuciones configuradas. Haga clic en el botón "+" para agregar una.</p>
+              </div>
+
+              <!-- Total de cantidad -->
+              <div class="cantidad-total-display" *ngIf="distribucionesItems.length > 0">
+                <mat-card class="total-card">
+                  <mat-card-content>
+                    <div class="total-content">
+                      <span class="total-label">Cantidad Total:</span>
+                      <span class="total-value">{{ cantidadTotalComputedText }}</span>
+                    </div>
+                    <div class="total-error" *ngIf="hasCantidadTotalError">
+                      <mat-icon color="warn">warning</mat-icon>
+                      <span>La cantidad total debe ser mayor a 0</span>
+                    </div>
+                  </mat-card-content>
+                </mat-card>
+              </div>
+            </div>
+
+            <!-- Fila 3: Distribución (MODO SIMPLIFICADO) -->
+            <div class="distribuciones-section simplified" *ngIf="productoSelectedComputed && presentacionSelectedComputed && distribucionModo === 'SIMPLIFICADA'">
+              <div class="simplified-row">
+                <!-- Stock Total -->
+                <div class="stock-total-container" [matTooltip]="stockBreakdownTooltipComputed" matTooltipClass="multiline-tooltip">
+                  <span class="label">Stock Actual (Influencia):</span>
+                  <div class="cantidad-display">
+                    <div class="cantidad-presentacion">{{ getCantidadPorPresentacion(stockTotalSimplificadoComputed) | number : "1.0-2" }}</div>
+                    <div class="cantidad-unidades">({{ stockTotalSimplificadoComputed | number : "1.0-2" }} unidades)</div>
+                  </div>
+                </div>
+
+                <!-- Input Cantidad Total -->
+                <mat-form-field appearance="outline" class="cantidad-total-field">
+                  <mat-label>Cantidad Total a Pedir</mat-label>
+                  <input
+                    matInput
+                    class="cantidad-simplificada-input"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    [formControl]="cantidadSimplificadaControl"
+                    (focus)="onCantidadInputFocus(cantidadSimplificadaControl)"
+                    (keydown)="onCantidadSimplificadaKeydown($event)"
+                  />
+                  <mat-hint>{{ cantidadTotalComputedText }}</mat-hint>
+                  <mat-error *ngIf="cantidadSimplificadaControl.hasError('required')">Requerido</mat-error>
+                  <mat-error *ngIf="cantidadSimplificadaControl.hasError('min')">Debe ser mayor a 0</mat-error>
+                </mat-form-field>
+              </div>
+            </div>
+
+            <!-- Fila 4: Vencimiento (solo si el producto maneja vencimiento) -->
+            <div
+              class="form-row"
+              *ngIf="productoSelectedComputed && productoManejaVencimientoComputed"
+            >
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>Vencimiento Esperado</mat-label>
+                <input
+                  matInput
+                  #vencimientoInput
+                  [matDatepicker]="vencimientoPicker"
+                  formControlName="vencimientoEsperado"
+                  (keydown)="onVencimientoKeydown($event)"
+                  (blur)="onVencimientoBlur()"
+                  matTooltip="Fecha esperada de vencimiento del producto"
+                />
+                <mat-datepicker-toggle
+                  matSuffix
+                  [for]="vencimientoPicker"
+                ></mat-datepicker-toggle>
+                <mat-datepicker
+                  #vencimientoPicker
+                  (closed)="onVencimientoBlur()"
+                ></mat-datepicker>
+              </mat-form-field>
+            </div>
+
+            <!-- Fila 5: Observación -->
+            <div class="form-row" *ngIf="productoSelectedComputed">
+              <mat-form-field appearance="outline" class="full-width">
+                <mat-label>Observaciones</mat-label>
+                <textarea
+                  matInput
+                  #observacionInput
+                  formControlName="observacion"
+                  rows="3"
+                  placeholder="Observaciones adicionales sobre el ítem..."
+                  (keydown)="onObservacionKeydown($event)"
+                  matTooltip="Información adicional sobre el producto o solicitud"
+                ></textarea>
+              </mat-form-field>
+            </div>
+
+            <!-- Subtotal Display -->
+            <div
+              class="subtotal-display"
+              *ngIf="productoSelectedComputed && !isBonificacionComputed"
+            >
+              <mat-card class="subtotal-card">
+                <mat-card-content>
+                  <div class="subtotal-content">
+                    <span class="subtotal-label">Subtotal:</span>
+                    <span class="subtotal-value">{{
+                      subtotalComputed | currency : "Gs." : "symbol" : "1.0-2"
+                    }}</span>
+                  </div>
+                </mat-card-content>
+              </mat-card>
+            </div>
+
+          </div><!-- end form-right-column -->
+        </div><!-- end content-area -->
       </div>
     </form>
   </div>

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.scss
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.scss
@@ -545,4 +545,228 @@
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
-} 
+}
+
+// Two-column layout
+.content-area {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  &.has-product {
+    flex-direction: row;
+    gap: 20px;
+    align-items: flex-start;
+  }
+}
+
+// Product Info Sidebar
+.product-sidebar {
+  flex: 0 0 25%;
+  min-width: 180px;
+  max-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  position: sticky;
+  top: 0;
+
+  .sidebar-image-container {
+    text-align: center;
+
+    .sidebar-product-image {
+      width: 100px;
+      height: 100px;
+      object-fit: contain;
+      border-radius: 8px;
+      cursor: pointer;
+      border: 1px solid rgba(255, 255, 255, 0.15);
+    }
+  }
+
+  .sidebar-nombre {
+    font-size: 13px;
+    font-weight: 600;
+    color: #fff;
+    text-align: center;
+    line-height: 1.3;
+  }
+
+  .sidebar-codigo {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.7);
+    justify-content: center;
+
+    .sidebar-icon {
+      font-size: 14px;
+      width: 14px;
+      height: 14px;
+    }
+  }
+
+  .sidebar-info-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.8);
+    padding: 4px 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.07);
+
+    .sidebar-label {
+      color: rgba(255, 255, 255, 0.5);
+    }
+  }
+
+  .sidebar-precios-section {
+    margin-top: 4px;
+
+    .sidebar-section-title {
+      font-size: 11px;
+      color: rgba(255, 255, 255, 0.5);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 6px;
+    }
+
+    .sidebar-precios-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+
+      th {
+        color: rgba(255, 255, 255, 0.5);
+        font-weight: 400;
+        padding: 3px 6px;
+        text-align: right;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+
+        &:first-child {
+          text-align: left;
+        }
+      }
+
+      td {
+        color: #fff;
+        padding: 4px 6px;
+        text-align: right;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+
+        &:first-child {
+          text-align: left;
+          color: rgba(255, 255, 255, 0.7);
+        }
+      }
+    }
+  }
+}
+
+// Right column
+.form-right-column {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+// Price field wrapper (for "precio anterior" hints)
+.price-field-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+
+  mat-form-field {
+    width: 100%;
+  }
+
+  .precio-anterior-hint {
+    font-size: 90%;
+    color: rgba(255, 255, 255, 0.5);
+    margin-top: 2px;
+    padding-left: 4px;
+    white-space: nowrap;
+  }
+}
+
+// Price change indicator
+.precio-cambio-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+
+  .cambio-content {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    mat-icon {
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
+    }
+
+    .cambio-text {
+      font-size: 13px;
+      font-weight: 500;
+    }
+  }
+
+  // 4-level color coding: lower cost = good (green), higher cost = bad (red)
+  &.cambio-nivel-muy-bajo .cambio-content {
+    mat-icon, .cambio-text { color: #2E7D32; } // dark green — great deal
+  }
+  &.cambio-nivel-bajo .cambio-content {
+    mat-icon, .cambio-text { color: #81C784; } // light green — good
+  }
+  &.cambio-nivel-alto .cambio-content {
+    mat-icon, .cambio-text { color: #FF9800; } // orange — warning
+  }
+  &.cambio-nivel-muy-alto .cambio-content {
+    mat-icon, .cambio-text { color: #f44336; } // red — bad
+  }
+
+  .programar-precio-btn {
+    flex-shrink: 0;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.6);
+    border-color: rgba(255, 255, 255, 0.2);
+    height: 32px;
+    padding: 0 10px;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+      margin-right: 4px;
+    }
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.9);
+      border-color: rgba(255, 255, 255, 0.4);
+    }
+  }
+}
+
+// Responsive: collapse sidebar on small screens
+@media (max-width: 768px) {
+  .product-sidebar {
+    max-width: 100%;
+    flex: none;
+  }
+
+  .content-area.has-product {
+    flex-direction: column;
+  }
+}

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
@@ -189,6 +189,12 @@ export class AddEditItemDialogComponent implements OnInit {
 
   // Almacenar el precio original para comparar cambios
   precioOriginal: number = 0;
+
+  // Price change indicator (computed)
+  precioCambioComputed: number = 0;
+  precioCambioPorcentualComputed: number = 0;
+  precioHaCambiadoComputed: boolean = false;
+  precioCambioNivelComputed: 'muy-bajo' | 'bajo' | 'alto' | 'muy-alto' = 'bajo';
   
   // Bandera para evitar validaciones durante la carga inicial de datos
   private isLoadingInitialData = false;
@@ -586,6 +592,21 @@ export class AddEditItemDialogComponent implements OnInit {
     } else {
       this.cantidadTotalComputedText = "";
     }
+
+    // Price change indicator
+    const precioActual = this.itemForm.get('precioUnitarioSolicitado')?.value || 0;
+    if (this.precioOriginal > 0 && !this.isBonificacionComputed) {
+      this.precioCambioComputed = precioActual - this.precioOriginal;
+      this.precioCambioPorcentualComputed =
+        ((precioActual - this.precioOriginal) / this.precioOriginal) * 100;
+      this.precioHaCambiadoComputed = precioActual !== this.precioOriginal;
+      const pct = this.precioCambioPorcentualComputed;
+      this.precioCambioNivelComputed = pct <= -50 ? 'muy-bajo' : pct < 0 ? 'bajo' : pct <= 50 ? 'alto' : 'muy-alto';
+    } else {
+      this.precioCambioComputed = 0;
+      this.precioCambioPorcentualComputed = 0;
+      this.precioHaCambiadoComputed = false;
+    }
   }
 
   private updatePrecioPorPresentacionFromUnitario(
@@ -675,6 +696,17 @@ export class AddEditItemDialogComponent implements OnInit {
     
     this.selectedProducto = producto;
     this.presentacionesDisponibles = producto.presentaciones || [];
+
+    // Lazy-load full product data (precioPrincipal, imagenPrincipal, costo completo)
+    // ya que el producto del search dialog puede no traer todos los campos
+    this.productoService.onGetProductoParaPedido(producto.id, this.data.pedido != null)
+      .subscribe((productoCompleto) => {
+        if (productoCompleto?.presentaciones) {
+          this.selectedProducto = { ...this.selectedProducto, ...productoCompleto };
+          this.presentacionesDisponibles = productoCompleto.presentaciones;
+          this.updateComputedProperties();
+        }
+      });
 
     // Solo seleccionar automáticamente la primera presentación si NO se proporcionó una presentación
     // y hay exactamente una presentación disponible
@@ -1175,7 +1207,7 @@ export class AddEditItemDialogComponent implements OnInit {
       mensaje = "El precio unitario es 0. ¿Está seguro de que es correcto?";
     }
     // Solo validar cambio de precio si estamos editando y hay un precio original
-    else if (this.data.isEdit && this.precioOriginal > 0) {
+    else if (this.precioOriginal > 0) {
       const cambioPorcentual = ((precio - this.precioOriginal) / this.precioOriginal) * 100;
       const cambioAbsoluto = Math.abs(cambioPorcentual);
 
@@ -1209,6 +1241,10 @@ export class AddEditItemDialogComponent implements OnInit {
         }
       });
     }
+  }
+
+  onProgramarPrecioClick(): void {
+    this.notificacionService.openWarn('Próximamente: programación de cambio de precio');
   }
 
   private markFormGroupTouched(): void {

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -1964,7 +1964,7 @@ export class GestionComprasComponent
     };
 
     const dialogRef = this.dialog.open(AddEditItemDialogComponent, {
-      width: "50%",
+      width: "65%",
       height: "70%",
       data: dialogData,
       disableClose: true,
@@ -2055,7 +2055,7 @@ export class GestionComprasComponent
     };
 
     const dialogRef = this.dialog.open(AddEditItemDialogComponent, {
-      width: "70%",
+      width: "80%",
       height: "70%",
       data: dialogData,
       disableClose: true,
@@ -3758,7 +3758,7 @@ export class GestionComprasComponent
     };
 
     const dialogRef = this.dialog.open(AddEditItemDialogComponent, {
-      width: "50%",
+      width: "65%",
       height: "70%",
       data: dialogData,
       disableClose: true,

--- a/src/app/modules/productos/producto/graphql/graphql-query.ts
+++ b/src/app/modules/productos/producto/graphql/graphql-query.ts
@@ -425,6 +425,9 @@ export const productoQuery = gql`
           descripcion
         }
         imagenPrincipal
+        precioPrincipal {
+          precio
+        }
         precios {
           id
           precio
@@ -568,6 +571,9 @@ export const productoParaPedidoQuery = gql`
           descripcion
         }
         imagenPrincipal
+        precioPrincipal {
+          precio
+        }
         precios {
           id
           precio


### PR DESCRIPTION
## Summary
- Sidebar lateral izquierdo en el diálogo de pedido item con: imagen del producto, nombre, código de barra, IVA, costo medio y tabla de precios de venta por presentación
- Hints "Precio anterior" debajo de los inputs de precio (solo visibles cuando el usuario modifica el costo)
- Indicador visual de cambio de precio con 4 niveles de color (verde oscuro → verde claro → naranja → rojo) y botón stub "Programar cambio de precio"
- Warning de cambio brusco (>50%) ahora funciona tanto en ítems nuevos como en edición
- Lazy-load de datos completos del producto via `productoParaPedidoQuery` para garantizar disponibilidad de `precioPrincipal`
- Dialog width ajustado de 50%/70% a 65%/80% para acomodar el sidebar

## Archivos modificados
- `add-edit-item-dialog.component.html` — layout 2 columnas, sidebar, hints, indicador
- `add-edit-item-dialog.component.ts` — computed properties, lazy-load, fix blur guard
- `add-edit-item-dialog.component.scss` — estilos sidebar, hints, indicador 4 niveles
- `gestion-compras.component.ts` — bump dialog width (3 call sites)
- `graphql-query.ts` — `precioPrincipal { precio }` en `productoQuery` y `productoParaPedidoQuery`

## Test plan
- [ ] Nuevo ítem: seleccionar producto → sidebar con imagen/precios aparece
- [ ] Cambiar precio → indicador % con color correcto + botón "Programar"
- [ ] Cambio >50% + blur → dialog warning (tanto en new como edit)
- [ ] Bonificación checked → hints e indicador ocultos
- [ ] Producto sin imagen → fallback "no-image.png"
- [ ] Click en imagen sidebar → preview fullscreen
- [ ] Botón "Programar cambio de precio" → snackbar "Próximamente"

🤖 Generated with [Claude Code](https://claude.com/claude-code)