### PR TITLE
fix(ventas): mat select nulo al limpiar filtros

### DIFF
--- a/src/app/modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component.ts
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component.ts
@@ -58,6 +58,7 @@ export class LucroPorProductoComponent implements OnInit {
   selectedSucursal: Sucursal;
   sucursalList: Sucursal[];
   sucursalIdList: number[];
+  previousSelectedSucursales: any[] = [];
   buscarProductoControl = new FormControl();
   buscarSubfamiliaControl = new FormControl();
   isPesable = false;
@@ -120,6 +121,28 @@ export class LucroPorProductoComponent implements OnInit {
       inicioHora: this.horaInicioControl,
       finHora: this.horaFinalControl,
     });
+
+    this.sucursalControl.valueChanges
+      .pipe(untilDestroyed(this))
+      .subscribe((selectedValues: any[]) => {
+        if (!selectedValues) return;
+        const hasTodas = selectedValues.includes(null);
+        if (hasTodas && selectedValues.length > 1) {
+          const prevValues = this.previousSelectedSucursales || [];
+          const hadTodasPrev = prevValues.includes(null);
+
+          if (!hadTodasPrev) {
+            this.previousSelectedSucursales = [null];
+            this.sucursalControl.setValue([null], { emitEvent: false });
+          } else {
+            const newSelection = selectedValues.filter(val => val !== null);
+            this.previousSelectedSucursales = newSelection;
+            this.sucursalControl.setValue(newSelection, { emitEvent: false });
+          }
+        } else {
+          this.previousSelectedSucursales = selectedValues;
+        }
+      });
 
     this.sucursalList = [];
     this.sucursalIdList = [];
@@ -216,10 +239,30 @@ export class LucroPorProductoComponent implements OnInit {
   cargarMasDatos() {}
 
   resetFiltro() {
-    this.fechaInicioControl.setValue(null);
-    this.fechaFinalControl.setValue(null);
-    this.sucursalList = [];
-    this.sucursalIdList = [];
+    let hoy = new Date();
+    let aux = new Date();
+    aux.setDate(hoy.getDate() - 2);
+
+    this.fechaInicioControl.setValue(aux);
+    this.fechaFinalControl.setValue(hoy);
+    this.horaInicioControl.setValue("00:00");
+    this.horaFinalControl.setValue("23:59");
+    this.sucursalControl.setValue(null);
+    this.buscarProductoControl.setValue(null);
+    this.buscarSubfamiliaControl.setValue(null);
+    this.buscarCajeroControl.setValue(null);
+    this.selectedUsuario = null;
+    this.selectedSubFamilia = null;
+    this.productoList = [];
+    this.dataSource.data = [];
+    this.totalElements = 0;
+
+    this.totalVenta = 0;
+    this.totalCosto = 0;
+    this.totalLucro = 0;
+    this.totalDescuento = 0;
+    this.totalAumento = 0;
+    this.margenPromedio = 0;
   }
 
   onGenerarPdf() {


### PR DESCRIPTION
### Qué resuelve

1. Se corrige el problema donde el botón para limpiar filtros (resetFiltro) vaciaba completamente la lista de sucursales disponibles en el mat-select en lugar de simplemente resetear la selección actual. Esto hacía que al hacer clic en limpiar filtros solo se mostrara la opción "Todas" y ninguna otra sucursal.
2. Se implementó una lógica de selección inteligente para el filtro de sucursales:
- Si el usuario selecciona el ítem "Todas" y ya había otras sucursales marcadas, se desmarcan las demás opciones para dejar solamente "Todas".
- Si el usuario tiene marcado "Todas" y selecciona una sucursal específica, se desmarca automáticamente la opción "Todas" para dejar únicamente la sucursal seleccionada.

### Cómo probarlo

1. Acceder al módulo de Financiero > Lucro por producto.
2. Abrir el filtro de sucursales y verificar que la lista cargue las sucursales correctamente.
3. Marcar una o varias sucursales específicas de la lista.
4. Luego, seleccionar la opción "Todas" de la lista y verificar que las sucursales específicas se desmarquen automáticamente.
5. Con la opción "Todas" seleccionada, marcar una sucursal específica y verificar que la opción "Todas" se desmarque automáticamente.
6. Hacer clic en el botón para limpiar los filtros y verificar que todos los filtros vuelvan a su estado inicial, pero el listado del mat-select de sucursales mantenga todos los ítems disponibles.

### Impacto DB
- No requiere ningún cambio ni impacto en la base de datos.

### Riesgo
- Bajo. Los cambios solo afectan a la lógica de la interfaz de usuario en el frontend del componente de reportes de lucro por producto.