### PR TITLE
fix(compras): format creadoEn with dateToString in rechazar distribucion

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/rechazar-item-dialog/rechazar-item-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/rechazar-item-dialog/rechazar-item-dialog.component.ts
@@ -468,7 +468,7 @@ export class RechazarItemDialogComponent implements OnInit {
         sucursalInfluenciaId: distribucion.sucursalInfluencia?.id || null,
         sucursalEntregaId: distribucion.sucursalEntrega?.id,
         cantidad: distribucion.cantidad,
-        creadoEn: distribucion.creadoEn,
+        creadoEn: distribucion.creadoEn ? dateToString(new Date(distribucion.creadoEn)) : null,
         usuarioId: distribucion.usuario?.id || null
       };
 


### PR DESCRIPTION
## Summary
- Backend GQL returns `creadoEn` as raw ISO string on plain objects (not Date instances)
- Wrap with `new Date()` + `dateToString()` to produce `"yyyy-MM-dd HH:mm"` format that backend expects
- Companion fix to central PR #53 (modelMapper → stringToDate)

## Test plan
- [ ] Rechazar un item con distribuciones → no ModelMapper error

🤖 Generated with [Claude Code](https://claude.com/claude-code)