### PR TITLE
feat(compras): filter rejection notas + Nuevo Producto button

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
@@ -485,6 +485,10 @@
               </div>
 
               <div class="items-actions">
+                <button mat-raised-button (click)="onNuevoProducto()" [disabled]="itemsTabState !== 'editable'">
+                  <mat-icon>inventory_2</mat-icon>
+                  Nuevo Producto
+                </button>
                 <button #addItemButton mat-raised-button color="primary" (click)="onAddItem()" [disabled]="itemsTabState !== 'editable'">
                   <mat-icon>add</mat-icon>
                   Añadir Item

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -84,12 +84,13 @@ import { ProcesoEtapaService } from "./proceso-etapa.service";
 import { DialogosService } from "../../../../shared/components/dialogos/dialogos.service";
 import { MatPaginator, PageEvent } from "@angular/material/paginator";
 import { Tab } from "../../../../layouts/tab/tab.model";
-import { TabData } from "../../../../layouts/tab/tab.service";
+import { TabData, TabService } from "../../../../layouts/tab/tab.service";
 import { ProductoProveedorService } from "../../../productos/producto-proveedor/producto-proveedor.service";
 import { ProductoProveedor } from "../../../productos/producto-proveedor/producto-proveedor.model";
 import { ProductoUltimasComprasByIdGQL } from "../../../productos/producto/graphql/productoUltimasComprasPorId";
 import { DesvincularProductoProveedorGQL } from "../../../productos/producto-proveedor/graphql/desvincularProductoProveedor";
 import { ProductoService } from "../../../productos/producto/producto.service";
+import { ProductoComponent } from "../../../productos/producto/edit-producto/producto.component";
 
 interface PedidoHeader {
   id?: number;
@@ -399,7 +400,8 @@ export class GestionComprasComponent
     private productoProveedorService: ProductoProveedorService,
     private productoUltimasComprasGQL: ProductoUltimasComprasByIdGQL,
     private desvincularProductoProveedorGQL: DesvincularProductoProveedorGQL,
-    private productoService: ProductoService
+    private productoService: ProductoService,
+    private tabService: TabService
   ) {
     // Inicializar objeto "Todos" para sucursales
     this.sucursalTodos = {
@@ -1973,6 +1975,10 @@ export class GestionComprasComponent
   }
 
   // Step 2: Items del Pedido methods
+  onNuevoProducto(): void {
+    this.tabService.addTab(new Tab(ProductoComponent, "Nuevo Producto", null, null));
+  }
+
   onAddItem(): void {
     const dialogData: AddEditItemDialogData = {
       pedido: this.currentPedido as Pedido,

--- a/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.ts
@@ -801,8 +801,9 @@ export class RecepcionMercaderiaComponent implements OnInit, OnDestroy {
       .pipe(untilDestroyed(this))
       .subscribe({
         next: (notas) => {
-          this.notasRecepcion = notas;
-            this.notasDataSource.data = this.notasRecepcion;
+          // Filtrar notas de rechazo sin items activos (no aportan a la recepción física)
+          this.notasRecepcion = notas.filter(n => !n.esNotaRechazo || (n.valorTotal && n.valorTotal > 0));
+          this.notasDataSource.data = this.notasRecepcion;
           this.loadingNotas = false;
           this.updateComputedProperties();
         },


### PR DESCRIPTION
## Summary
- **Filter empty rejection notas** in physical reception — notas with `esNotaRechazo=true` and no value are hidden from the list
- **Add "Nuevo Producto" button** next to "Añadir Item" in pedido items tab — opens ProductoComponent in a new tab for product creation

## Test plan
- [x] Open recepción física with a rejection nota → rejection nota not in list
- [x] Click "Nuevo Producto" → product creation opens in new tab
- [x] Compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)