### PR TITLE
fix(productos): error al generar reporte de productos

### DIFF
--- a/src/app/modules/productos/producto/graphql/graphql-query.ts
+++ b/src/app/modules/productos/producto/graphql/graphql-query.ts
@@ -717,9 +717,7 @@ export const exportarReporteConFiltrosQuery = gql`
       $stockFiltro: String, 
       $sucursalId: ID, 
       $usuarioId: ID, 
-      $usuario: String,
-      $page: Int,
-      $size: Int
+      $usuario: String
     ) {
       data: exportarReporteConFiltros(
         texto: $texto, 
@@ -733,9 +731,7 @@ export const exportarReporteConFiltrosQuery = gql`
         stockFiltro: $stockFiltro, 
         sucursalId: $sucursalId, 
         usuarioId: $usuarioId, 
-        usuario: $usuario,
-        page: $page,
-        size: $size
+        usuario: $usuario
       )
     }
   `;

--- a/src/app/modules/productos/producto/list-producto/list-producto.component.ts
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.ts
@@ -502,9 +502,7 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
       stockFiltro: this.stockFiltroControl.value !== 'todos' ? this.stockFiltroControl.value : null,
       sucursalId: (this.sucursalFiltroControl.value && this.isSucursalSelectEnabled) ? this.sucursalFiltroControl.value : null,
       usuarioId: this.mainService.usuarioActual.id,
-      usuario: this.mainService.usuarioActual.nickname || this.mainService.usuarioActual.persona?.nombre || 'Usuario',
-      page: this.pageIndex,
-      size: this.pageSize
+      usuario: this.mainService.usuarioActual.nickname || this.mainService.usuarioActual.persona?.nombre || 'Usuario'
     };
   }
 


### PR DESCRIPTION
### Qué resuelve 
Corrige un error de validación de GraphQL que impedía la generación del reporte de productos desde el componente de lista. El problema se originaba porque el frontend enviaba los parámetros de paginación page y size a la consulta exportarReporteConFiltros, los cuales no están definidos en el esquema del backend para esta operación específica. Al ser una exportación completa del set de datos filtrados, la paginación no es requerida por el servidor.

### Cómo probarlo

1. Acceder al módulo de Productos y abrir la Lista de productos.
2. Aplicar cualquier combinación de filtros (opcional).
3. Hacer clic en el botón de generar reporte (icono de PDF).
4. Validar que el diálogo de carga se cierre correctamente y el reporte aparezca en la pestaña de Reportes.
5. Verificar que no aparezcan errores de validación de GraphQL ("Query failed to validate") en la consola del servidor o del navegador.

### Impacto DB 
- No aplica. Los cambios son exclusivamente a nivel de la interfaz de consulta GraphQL y lógica del componente frontend.

### Riesgo 
- Bajo. La modificación afecta únicamente a la consulta exportarReporteConFiltrosQuery, la cual es de uso exclusivo para la generación de este reporte y no interfiere con el buscador de la tabla ni otras funciones de edición de productos.