### PR TITLE
fix(timbrado): error consulta graphql

### DIFF
--- a/src/app/modules/financiero/timbrado/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/timbrado/graphql/graphql-query.ts
@@ -175,7 +175,7 @@ export const timbradoDetalleQuery = gql`
 
 export const findByNumeroQuery = gql`
   query ($numero: String, $page: Int, $size: Int) {
-    data: findByNumero(numero: $numero, page: $page, size: $size) {
+    data: findTimbradoByNumero(numero: $numero, page: $page, size: $size) {
       getTotalPages
       getTotalElements
       getNumberOfElements


### PR DESCRIPTION
### Qué resuelve
Este cambio soluciona un conflicto de nombres en el esquema GraphQL donde las entidades Timbrado y NotaRecepcion compartían una consulta denominada findByNumero. Este conflicto causaba errores de validación en el frontend al intentar buscar timbrados, ya que el motor de GraphQL seleccionaba la definición de NotaRecepcion (que espera un tipo Integer) en lugar de la de Timbrado (que espera un tipo String).

Se ha renombrado la consulta en el módulo de Timbrado a findTimbradoByNumero tanto en el backend como en el frontend para garantizar la unicidad de la operación.

### Cómo probarlo

1. Acceder al módulo de Timbrados en el frontend.
2. Realizar una búsqueda utilizando el campo de número de timbrado.
3. Verificar en la consola del navegador que no se generen errores de tipo VariableTypeMismatch o FieldUndefined.
4. Confirmar que los resultados de la búsqueda se visualizan correctamente en la tabla.

### Impacto DB
**No aplica.** Los cambios son exclusivamente a nivel de capa de API (GraphQL) y lógica de componentes frontend. No se han realizado modificaciones en las tablas ni en los datos de la base de datos.

### Riesgo
**Bajo.** El cambio está localizado en el módulo de Timbrado y utiliza un alias en el frontend para mantener la compatibilidad con la estructura de datos esperada por los componentes existentes. Se ha verificado que findByNumero solo era utilizado por este módulo en el frontend.