### PR TITLE
feat(gastos): redireccionamiento a la lista de ventas

### DIFF
--- a/src/app/modules/financiero/gastos/list-gastos/list-gastos.component.html
+++ b/src/app/modules/financiero/gastos/list-gastos/list-gastos.component.html
@@ -124,16 +124,18 @@
           Caja
         </th>
         <td mat-cell *matCellDef="let gasto" style="text-align: center">
-          <span>{{ gasto?.caja?.id }}</span>
+         <div style="display: flex; align-items: center; justify-content: center;">
+           <span>{{ gasto?.caja?.id }}</span>
           <button
             mat-icon-button
             matTooltip="Ir a caja"
-            (click)="onIrACaja(gasto.cajaSalida)"
+            (click)="onIrACaja(gasto)"
           >
             <mat-icon style="color: rgb(0, 128, 255); font-size: 0.9em"
               >launch</mat-icon
             >
           </button>
+         </div>
         </td>
       </ng-container>
 

--- a/src/app/modules/financiero/gastos/list-gastos/list-gastos.component.ts
+++ b/src/app/modules/financiero/gastos/list-gastos/list-gastos.component.ts
@@ -110,8 +110,17 @@ export class ListGastosComponent implements OnInit {
     this.dataSource.data = []
   }
 
-  onIrACaja(cajaSalida: PdvCaja) {
-    this.tabService.addTab(new Tab(ListVentaComponent, 'Ventas de la caja ' + this.selectedGasto.caja.id, new TabData(null, this.selectedGasto.caja), ListGastosComponent))
+  onIrACaja(gasto: Gasto) {
+    if (gasto?.caja != null) {
+      this.tabService.addTab(
+        new Tab(
+          ListVentaComponent,
+          "Ventas de la caja " + gasto.caja.id,
+          new TabData(null, gasto.caja),
+          ListGastosComponent
+        )
+      );
+    }
   }
 
   onAdd(gasto, i){


### PR DESCRIPTION
### Que resuelve
Se corrigio el metodo **onIrACaja** en el componente **ListGastosComponent** que no realizaba la redireccion a la lista de ventas. El error se debia a que en el HTML se pasaba una propiedad inexistente (cajaSalida) y en el TypeScript el metodo no utilizaba el parametro recibido, intentando acceder a una variable no inicializada. Tambien se mejoro la disposicion visual del ID de la caja y el boton de acceso en la tabla.

### Como probarlo
1. Iniciar la aplicacion y navegar al modulo de Gastos (Financiero -> Gastos).
2. En la lista de gastos, ubicar la columna Caja.
3. Hacer clic en el icono de lanzamiento (launch) al lado del ID de la caja.
4. Verificar que se abra una nueva pestaña con el titulo "Ventas de la caja [ID]" y que se carguen correctamente las ventas asociadas a esa caja.

### Impacto DB
**No aplica**. Los cambios son puramente a nivel de frontend (UI y logica de navegacion).

### Riesgo
**Bajo**. Solo afecta a la navegacion desde la lista de gastos hacia la lista de ventas.
