### PR TITLE
feat(lucro): add filtro familia en lucro-por-producto

### DIFF
--- a/src/app/modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component.html
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component.html
@@ -146,7 +146,8 @@
       fxLayoutGap="10px"
       style="width: 100%"
     >
-      <div fxFlex="40%" fxLayout="column" fxLayoutGap="10px">
+      <!-- Columna Producto -->
+      <div fxFlex="33%" fxLayout="column" fxLayoutGap="10px">
         <div fxFlex fxLayoutAlign="start center">
           <div fxFlex="80%">
             <mat-form-field style="width: 100%">
@@ -187,27 +188,64 @@
           </div>
         </div>
       </div>
-      <div fxFlex="40%" fxLayout="column" fxLayoutGap="10px">
-         <div fxFlex fxLayoutAlign="start center">
-          <div fxFlex="63%" style="margin-left: 20px;">
+
+      <!-- Columna Familia -->
+      <div fxFlex="25%" fxLayout="column">
+        <div fxFlex fxLayoutAlign="start center">
+          <div fxFlex="80%">
             <mat-form-field style="width: 100%">
-            <mat-label>Buscar subfamilia</mat-label>
-            <input
-              #subfamiliaInput
-              type="text"
-              matInput
-              [formControl]="buscarSubfamiliaControl"
-              (keyup.enter)="onBuscarSubFamilia()"
-            />
-          </mat-form-field>
+              <mat-label>Buscar familia</mat-label>
+              <input
+                #familiaInput
+                type="text"
+                matInput
+                [formControl]="buscarFamiliaControl"
+                (keyup.enter)="onBuscarFamilia()"
+              />
+            </mat-form-field>
           </div>
-           <div fxFlex="10%" style="text-align: center">
-            <mat-icon class="icon" 
+          <div fxFlex="10%" style="text-align: center">
+            <mat-icon
+              class="icon"
+              (click)="onBuscarFamilia(); $event.stopPropagation()"
+              >search</mat-icon
+            >
+          </div>
+          <div style="text-align: center">
+            <mat-icon
+              style="font-size: 2em"
+              (click)="onClearFamilia()"
+              *ngIf="selectedFamilia != null"
+              class="highlight-hover-danger"
+              >clear</mat-icon
+            >
+          </div>
+        </div>
+      </div>
+
+      <!-- Columna Subfamilia -->
+      <div fxFlex="25%" fxLayout="column">
+        <div fxFlex fxLayoutAlign="start center">
+          <div fxFlex="80%">
+            <mat-form-field style="width: 100%">
+              <mat-label>Buscar subfamilia</mat-label>
+              <input
+                #subfamiliaInput
+                type="text"
+                matInput
+                [formControl]="buscarSubfamiliaControl"
+                (keyup.enter)="onBuscarSubFamilia()"
+              />
+            </mat-form-field>
+          </div>
+          <div fxFlex="10%" style="text-align: center">
+            <mat-icon
+              class="icon"
               (click)="onBuscarSubFamilia(); $event.stopPropagation()"
               >search</mat-icon
             >
           </div>
-           <div style="text-align: center">
+          <div style="text-align: center">
             <mat-icon
               style="font-size: 2em"
               (click)="onClearSubFamilia()"

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component.ts
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component.ts
@@ -34,6 +34,8 @@ import { SubfamiliasSearchGQL } from "../../../../productos/sub-familia/graphql/
 import { SearchSubfamiliaByDescripcionGQL } from "../../../../productos/sub-familia/graphql/searchByDescripcion";
 import { FuncionarioSearchGQL } from "../../../../personas/funcionarios/graphql/funcionarioSearch";
 import { Funcionario } from "../../../../personas/funcionarios/funcionario.model";
+import { Familia } from "../../../../productos/familia/familia.model";
+import { FamiliasSearchGQL } from "../../../../productos/familia/graphql/familiasSearch";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -68,6 +70,8 @@ export class LucroPorProductoComponent implements OnInit {
   buscarCajeroControl = new FormControl();
   selectedUsuario: Usuario;
   selectedSubFamilia: Subfamilia;
+  selectedFamilia: Familia;
+  buscarFamiliaControl = new FormControl();
   cajeroIdList: number[];
 
   displayedColumns: string[] = [
@@ -104,6 +108,8 @@ export class LucroPorProductoComponent implements OnInit {
     private funcionarioSearch: FuncionarioSearchGQL,
     private usuarioService: UsuarioService,
     private searchSubfamilia: SearchSubfamiliaByDescripcionGQL,
+    private searchSubfamiliaFiltered: SubfamiliasSearchGQL,
+    private searchFamilia: FamiliasSearchGQL,
     private matDialog: MatDialog
   ) {}
 
@@ -206,7 +212,8 @@ export class LucroPorProductoComponent implements OnInit {
           productoIdList,
           this.selectedSubFamilia?.id,
           this.page,
-          this.size
+          this.size,
+          this.selectedFamilia?.id
         )
         .subscribe((res) => {
           console.log('Data received:', res);
@@ -250,9 +257,11 @@ export class LucroPorProductoComponent implements OnInit {
     this.sucursalControl.setValue(null);
     this.buscarProductoControl.setValue(null);
     this.buscarSubfamiliaControl.setValue(null);
+    this.buscarFamiliaControl.setValue(null);
     this.buscarCajeroControl.setValue(null);
     this.selectedUsuario = null;
     this.selectedSubFamilia = null;
+    this.selectedFamilia = null;
     this.productoList = [];
     this.dataSource.data = [];
     this.totalElements = 0;
@@ -298,7 +307,9 @@ export class LucroPorProductoComponent implements OnInit {
       this.toSucursalesId(this.sucursalControl.value),
       this.cajeroIdList,
       productoIdList,
-      this.selectedSubFamilia?.id
+      this.selectedSubFamilia?.id,
+      true,
+      this.selectedFamilia?.id
     );
   }
 
@@ -438,43 +449,78 @@ export class LucroPorProductoComponent implements OnInit {
       });
   }
 
+  onBuscarFamilia() {
+    let tableData: TableData[] = [
+      { id: "id", nombre: "Id" },
+      { id: "nombre", nombre: "Nombre" }
+    ];
+    let data: SearchListtDialogData = {
+      query: this.searchFamilia,
+      tableData: tableData,
+      titulo: "Buscar Familia",
+      search: true,
+      queryData: { texto: this.buscarFamiliaControl.value },
+      inicialSearch: true,
+      paginator: true,
+    };
+    this.matDialog
+      .open(SearchListDialogComponent, {
+        data: data,
+        width: "60%",
+        height: "80%",
+      })
+      .afterClosed()
+      .subscribe((res: Familia | any) => {
+        if (res != null) {
+          this.selectedFamilia = { id: parseInt(res.id, 10), nombre: res.nombre } as Familia;
+          this.buscarFamiliaControl.setValue(res.nombre);
+        }
+      });
+  }
+
+  onClearFamilia() {
+    this.selectedFamilia = null;
+    this.buscarFamiliaControl.setValue(null);
+  }
+
   onBuscarSubFamilia() {
     let tableData: TableData[] = [
-          {
-            id: "id",
-            nombre: "Id",
-          },
-          {
-            id: "nombre",
-            nombre: "Nombre",
-          },
-          {
-            id: "familia.nombre",
-            nombre: "Familia",
-          },
-        ];
-        let data: SearchListtDialogData = {
-          query: this.searchSubfamilia,
-          tableData: tableData,
-          titulo: "Buscar Subfamilia",
-          search: true,
-          queryData: { texto: this.buscarSubfamiliaControl.value },
-          inicialSearch: true,
-          paginator: true,
-        };
-        this.matDialog
-          .open(SearchListDialogComponent, {
-            data: data,
-            width: "60%",
-            height: "80%",
-          })
-          .afterClosed()
-          .subscribe((res: Subfamilia | any) => {
-            if (res != null) {
-              this.selectedSubFamilia = res;
-              this.buscarSubfamiliaControl.setValue(res.nombre);
-            }
-          });
+      { id: "id", nombre: "Id" },
+      { id: "nombre", nombre: "Nombre" },
+      { id: "familia.nombre", nombre: "Familia" },
+    ];
+
+    // Si hay familia seleccionada, filtra por ella; si no, busca en todas
+    const querySubfamilia = this.selectedFamilia
+      ? this.searchSubfamiliaFiltered
+      : this.searchSubfamilia;
+
+    const queryData = this.selectedFamilia
+      ? { texto: this.buscarSubfamiliaControl.value, familiaId: this.selectedFamilia.id }
+      : { texto: this.buscarSubfamiliaControl.value };
+
+    let data: SearchListtDialogData = {
+      query: querySubfamilia,
+      tableData: tableData,
+      titulo: "Buscar Subfamilia",
+      search: true,
+      queryData: queryData,
+      inicialSearch: true,
+      paginator: true,
+    };
+    this.matDialog
+      .open(SearchListDialogComponent, {
+        data: data,
+        width: "60%",
+        height: "80%",
+      })
+      .afterClosed()
+      .subscribe((res: Subfamilia | any) => {
+        if (res != null) {
+          this.selectedSubFamilia = { id: parseInt(res.id, 10), nombre: res.nombre } as Subfamilia;
+          this.buscarSubfamiliaControl.setValue(res.nombre);
+        }
+      });
   }
 
   onClearSubFamilia() {

--- a/src/app/modules/productos/producto/graphql/graphql-query.ts
+++ b/src/app/modules/productos/producto/graphql/graphql-query.ts
@@ -681,6 +681,7 @@ export const lucroPorProductoQuery = gql`
     $usuarioIdList: [ID]
     $productoIdList: [ID]
     $subfamiliaId: ID
+    $familiaId: ID
   ) {
     data: lucroPorProducto(
       fechaInicio: $fechaInicio
@@ -690,6 +691,7 @@ export const lucroPorProductoQuery = gql`
       usuarioIdList: $usuarioIdList
       productoIdList: $productoIdList
       subfamiliaId: $subfamiliaId
+      familiaId: $familiaId
     )
   }
 `;
@@ -750,6 +752,7 @@ export const exportarReporteConFiltrosQuery = gql`
       $subfamiliaId: ID
       $page: Int
       $size: Int
+      $familiaId: ID
     ) {
        data: lucroPorProductoList(
         fechaInicio: $fechaInicio
@@ -760,6 +763,7 @@ export const exportarReporteConFiltrosQuery = gql`
         subfamiliaId: $subfamiliaId
         page: $page
         size: $size
+        familiaId: $familiaId
       ) {
         content {
           productoId

--- a/src/app/modules/productos/producto/producto.service.ts
+++ b/src/app/modules/productos/producto/producto.service.ts
@@ -206,7 +206,8 @@ export class ProductoService {
     usuarioIdList?,
     productoIdList?,
     subfamiliaId?: number,
-    servidor = true
+    servidor = true,
+    familiaId?: number
   ) {
     this.genericService
       .onCustomQuery(
@@ -218,7 +219,8 @@ export class ProductoService {
           usuarioId: this.mainService.usuarioActual.id,
           usuarioIdList,
           productoIdList,
-          subfamiliaId
+          subfamiliaId,
+          familiaId
         },
         servidor
       )
@@ -245,6 +247,7 @@ export class ProductoService {
     subfamiliaId?: number,
     page?: number,
     size?: number,
+    familiaId?: number,
     servidor = true
   ): Observable<any> {
     return this.genericService.onCustomQuery(this.lucroPorProductoList, {
@@ -255,7 +258,8 @@ export class ProductoService {
       productoIdList,
       subfamiliaId,
       page,
-      size
+      size,
+      familiaId
     }, servidor);
   }
 }


### PR DESCRIPTION
### Qué resuelve 
Implementación del filtro por familia en el reporte de lucro por productos, permitiendo un análisis más preciso de la rentabilidad por categorías principales. Además, se optimizó el layout de los filtros en la interfaz de usuario para mejorar la usabilidad y el aprovechamiento del espacio horizontal.

### Como probarlo

1. Ingresar al módulo de reporte de lucro por producto.
2. Seleccionar una familia en el nuevo campo de filtro.
3. Verificar que los resultados en la tabla se filtren correctamente por la familia elegida.
4. Generar el reporte en PDF y confirmar que el filtro de familia aparezca en la cabecera y los datos coincidan con lo seleccionado.
5. Observar que los campos de búsqueda (Producto, Familia y Subfamilia) ahora se encuentran alineados en una sola fila con una distribución equilibrada.

### Impacto DB 
Ninguno.

### Riesgo 
Bajo.