### PR TITLE
fix(productos): estandarización esquema graphql

### DIFF
--- a/src/app/modules/productos/producto/graphql/graphql-query.ts
+++ b/src/app/modules/productos/producto/graphql/graphql-query.ts
@@ -179,12 +179,12 @@ export const searchProductoWithFilters = gql`
     $activo: Boolean
     $stock: Boolean
     $balanza: Boolean
-    $familia: Int
-    $subfamilia: Int
+    $familia: ID
+    $subfamilia: ID
     $vencimiento: Boolean
     $costoCero: Boolean
     $stockFiltro: String
-    $sucursalId: Int
+    $sucursalId: ID
     $page: Int
     $size: Int
   ) {
@@ -676,7 +676,7 @@ export const lucroPorProductoQuery = gql`
   query lucroPorProducto(
     $fechaInicio: String
     $fechaFin: String
-    $sucursalIdList: [Int]
+    $sucursalIdList: [ID]
     $usuarioId: ID!
     $usuarioIdList: [ID]
     $productoIdList: [ID]
@@ -697,7 +697,7 @@ export const lucroPorProductoQuery = gql`
 `;
 
 export const imprimirCodigoBarraQuery = gql`
-  query imprimirCodigoBarra($codigoId: Int) {
+  query imprimirCodigoBarra($codigoId: ID) {
     data: imprimirCodigoBarra(codigoId: $codigoId)
   }
 `;
@@ -717,7 +717,7 @@ export const exportarReporteConFiltrosQuery = gql`
       $balanza: Boolean, 
       $vencimiento: Boolean, 
       $costoCero: Boolean, 
-      $familiaId: Int, 
+      $familiaId: ID, 
       $subfamiliaId: ID, 
       $stockFiltro: String, 
       $sucursalId: ID, 


### PR DESCRIPTION
### Qué resuelve 
Corrección de errores de validación de GraphQL (Query failed to validate) detectados en el servidor alpha. El problema se originaba por una discrepancia entre los tipos de variables enviados por el frontend (ID) y los tipos definidos en el esquema del backend (Int) para ciertos campos de identificadores. Se estandarizaron los parámetros de sucursal, familia y subfamilia al tipo ID en las consultas de productos y reportes de lucro para garantizar la compatibilidad entre entornos.

### Como probarlo

1. Ingresar al módulo de Lucro por Producto y aplicar filtros de Sucursal, Familia o Subfamilia.
2. Verificar que la tabla cargue los datos correctamente y que no se generen errores de validación en los logs del servidor ni en la consola del navegador.
3. Probar la generación de reportes en PDF y la búsqueda con filtros en el listado general de productos para asegurar que la estandarización no afectó otras funcionalidades.

### Impacto DB 
Ninguno.

### Riesgo 
Bajo.

