### PR TITLE
feat(header): refactor moderno con cotizaciones, reloj y status

### DIFF
--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -1,134 +1,177 @@
-<mat-toolbar color="primary">
-  <mat-toolbar-row style="padding-right: 0" fxLayout="row" fxLayoutAlign="space-between center">
-    <div fxFlex="25" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="20px">
-      <button fxFlex="20" mat-icon-button (click)="toogleSideBar()"
-        [disabled]="!cloudStatus && (!isLocal || !localStatus)" class="header-menu-toggle">
+<mat-toolbar color="primary" class="frc-header">
+  <mat-toolbar-row class="frc-header__row">
+
+    <!-- ZONA 1: burger + sucursal -->
+    <div class="frc-header__zone frc-header__zone--brand">
+      <button mat-icon-button (click)="toogleSideBar()"
+        [disabled]="!cloudStatus && (!isLocal || !localStatus)" class="frc-header__burger">
         <mat-icon>menu</mat-icon>
       </button>
-      <div style="position: relative; text-align: center">
-        <span style="padding-left: 20px; display: inline-block">
-          <ng-container *ngIf="isLocal; else cloudTitle">
-            BODEGA FRANCO {{ mainService?.sucursalActual?.nombre | uppercase }}
-            {{ isDev && isLocalhost ? "DEV" : null }}
-          </ng-container>
-          <ng-template #cloudTitle>
-            <ng-container *ngIf="mainService?.sucursalActual?.id != null && mainService?.sucursalActual?.id != 0; else defaultCloudTitle">
+
+      <div class="frc-header__brand">
+        <span class="frc-header__brand-stack">
+          <span class="frc-header__brand-title">
+            <ng-container *ngIf="isLocal; else cloudTitle">
               BODEGA FRANCO {{ mainService?.sucursalActual?.nombre | uppercase }}
-              {{ isDev ? "DEV" : null }}
+              <span *ngIf="isDev && isLocalhost" class="frc-header__tag">DEV</span>
             </ng-container>
-            <ng-template #defaultCloudTitle>
-              BODEGA FRANCO CLOUD {{ isDev ? "DEV" : null }}
+            <ng-template #cloudTitle>
+              <ng-container
+                *ngIf="mainService?.sucursalActual?.id != null && mainService?.sucursalActual?.id != 0; else defaultCloudTitle">
+                BODEGA FRANCO {{ mainService?.sucursalActual?.nombre | uppercase }}
+                <span *ngIf="isDev" class="frc-header__tag">DEV</span>
+              </ng-container>
+              <ng-template #defaultCloudTitle>
+                BODEGA FRANCO CLOUD <span *ngIf="isDev" class="frc-header__tag">DEV</span>
+              </ng-template>
             </ng-template>
+          </span>
+          <span class="frc-header__brand-sub">FRC Sistemas v{{ appVersion }}</span>
+        </span>
+      </div>
+    </div>
+
+    <div class="frc-header__spacer"></div>
+    <div class="frc-header__divider"></div>
+
+    <!-- ZONA 2: cotizaciones -->
+    <div class="frc-header__zone frc-header__zone--cotiz"
+      *ngIf="(cotizaciones$ | async) as cotizaciones">
+      <button mat-icon-button class="frc-header__cotiz-refresh"
+        (click)="onRefreshCotizacion()" matTooltip="Actualizar cotización"
+        [disabled]="isRefreshingCotiz">
+        <mat-icon [class.frc-header__spin]="isRefreshingCotiz">refresh</mat-icon>
+      </button>
+      <div class="frc-header__cotiz-stack">
+        <ng-container *ngIf="cotizaciones.length; else cotizPlaceholder">
+          <div class="frc-header__cotiz-row" *ngFor="let c of cotizaciones"
+            [matTooltip]="'Actualizado: ' + (c.fecha | date:'dd/MM HH:mm')">
+            <span class="frc-header__cotiz-label">{{ c.moneda.denominacion | slice:0:3 | uppercase }}</span>
+            <span class="frc-header__cotiz-values">
+              <span class="frc-header__cotiz-num">{{ c.compraMercado | number:'1.0-0' }}</span>
+              <span class="frc-header__cotiz-sep">/</span>
+              <span class="frc-header__cotiz-num">{{ c.ventaMercado | number:'1.0-0' }}</span>
+            </span>
+          </div>
+        </ng-container>
+        <ng-template #cotizPlaceholder>
+          <span class="frc-header__cotiz-empty">Sin cotización</span>
+        </ng-template>
+      </div>
+    </div>
+
+    <div class="frc-header__divider"></div>
+
+    <!-- ZONA 3: fecha y hora -->
+    <div class="frc-header__zone frc-header__zone--clock" *ngIf="(now$ | async) as now">
+      <span class="frc-header__clock-time">{{ now | date:'HH:mm:ss' }}</span>
+      <span class="frc-header__clock-date">{{ now | date:'EEE dd MMM' | titlecase }}</span>
+    </div>
+
+    <div class="frc-header__divider"></div>
+
+    <!-- ZONA 4: status servers -->
+    <div class="frc-header__zone frc-header__zone--status">
+      <div *ngIf="isLocal" class="frc-header__status-row"
+        [matTooltip]="localStatus === true ? 'Servidor local online' : (localStatus === false ? 'Servidor local offline' : 'Conectando...')">
+        <mat-spinner *ngIf="localStatus == null" diameter="10"></mat-spinner>
+        <span *ngIf="localStatus != null" class="frc-header__status-dot"
+          [class.frc-header__status-dot--on]="localStatus === true"
+          [class.frc-header__status-dot--off]="localStatus === false"
+          [class.blink]="serverWarning && cloudStatus && !localStatus"></span>
+        <span class="frc-header__status-label">LOCAL</span>
+      </div>
+      <div class="frc-header__status-row"
+        [matTooltip]="cloudStatus === true ? 'Central online' : (cloudStatus === false ? 'Central offline' : 'Conectando...')">
+        <mat-spinner *ngIf="cloudStatus == null" diameter="10"></mat-spinner>
+        <span *ngIf="cloudStatus != null" class="frc-header__status-dot"
+          [class.frc-header__status-dot--on]="cloudStatus === true"
+          [class.frc-header__status-dot--off]="cloudStatus === false"
+          [class.blink]="serverWarning && isLocal && localStatus && !cloudStatus"></span>
+        <span class="frc-header__status-label">CENTRAL</span>
+      </div>
+    </div>
+
+    <div class="frc-header__divider"></div>
+    <div class="frc-header__spacer"></div>
+
+    <!-- ZONA 5: acciones + usuario -->
+    <div class="frc-header__zone frc-header__zone--actions">
+      <button mat-icon-button [disabled]="!cloudStatus && (!isLocal || !localStatus)" (click)="onSearch()"
+        matTooltip="Buscar">
+        <mat-icon>search</mat-icon>
+      </button>
+
+      <button mat-icon-button [matMenuTriggerFor]="menuServerIp" matTooltip="Configuración">
+        <mat-icon>settings</mat-icon>
+      </button>
+
+      <button mat-icon-button class="frc-header__notif" (click)="onOpenNotifications()"
+        [disabled]="!cloudStatus && (!isLocal || !localStatus)" matTooltip="Notificaciones">
+        <mat-icon>mail</mat-icon>
+        <ng-container *ngIf="(unreadCount$ | async) as count">
+          <span *ngIf="count > 0" class="notification-badge">
+            {{ count > 99 ? '99+' : count }}
+          </span>
+        </ng-container>
+      </button>
+
+      <button mat-button class="frc-header__user" [matMenuTriggerFor]="menu"
+        [disabled]="!cloudStatus && (!isLocal || !localStatus)">
+        <span class="frc-header__user-inner">
+          <ng-container *ngIf="mainService?.usuarioActual?.persona as persona; else anonUser">
+            <span class="frc-header__user-avatar">
+              <mat-icon>person</mat-icon>
+            </span>
+            <span class="frc-header__user-stack">
+              <span class="frc-header__user-name">{{ persona.nombre | titlecase }}</span>
+              <span class="frc-header__user-role">{{ userMainRole }}</span>
+            </span>
+            <mat-icon class="frc-header__user-caret">arrow_drop_down</mat-icon>
+          </ng-container>
+          <ng-template #anonUser>
+            <mat-icon>person_outline</mat-icon>
           </ng-template>
         </span>
-        <span style="
-            position: absolute;
-            bottom: -20px;
-            left: 0;
-            width: 100%;
-            font-size: small;
-          ">
-          FRC Sistemas Informáticos v{{ appVersion }}
-        </span>
-      </div>
+      </button>
     </div>
 
-    <div fxFlex="50" fxLayout="row" fxLayoutGap="20px" fxLayoutAlign="end center" style="width: 100%">
-      <div fxFlex="10">
-        <button fxFlex mat-icon-button [matMenuTriggerFor]="menuServerIp">
-          <mat-icon>settings</mat-icon>
-        </button>
-        <mat-menu #menuServerIp="matMenu">
-          <div style="padding: 5px">
-            <button mat-flat-button color="success" (click)="createQrCode()"
-              [disabled]="!cloudStatus && (!isLocal || !localStatus)">
-              QR de la sucursal
-            </button>
-          </div>
-          <div *ngIf="mainService.usuarioActual?.roles.includes(ROLES.SOPORTE)" style="padding: 5px">
-            <button mat-flat-button color="success" (click)="onGetConfiguracion()"
-              [disabled]="!cloudStatus && (!isLocal || !localStatus)">
-              Configuración del Sistema
-            </button>
-          </div>
-          <button mat-menu-item [matMenuTriggerFor]="sucursales">
-            Cambiar sucursal
-          </button>
-        </mat-menu>
-      </div>
-
-      <div fxFlex="10">
-        <button mat-icon-button [disabled]="!cloudStatus && (!isLocal || !localStatus)" (click)="onSearch()">
-          <mat-icon>search</mat-icon>
-        </button>
-      </div>
-      <div fxFlex="50">
-        <button mat-button [matMenuTriggerFor]="menu" [disabled]="!cloudStatus && (!isLocal || !localStatus)">
-          <mat-icon *ngIf="mainService?.usuarioActual?.persona == null" fxFlex>person_outline</mat-icon>
-          <div style="text-overflow: ellipsis; font-size: medium" *ngIf="mainService?.usuarioActual?.persona != null">
-            Usuario: {{ mainService.usuarioActual.persona.nombre | titlecase }}
-          </div>
-        </button>
-        <mat-menu #menu="matMenu">
-          <button mat-menu-item (click)="onLogout()" *ngIf="mainService?.usuarioActual?.persona != null"
-            [disabled]="!cloudStatus && (!isLocal || !localStatus)">
-            Salir
-          </button>
-          <button mat-menu-item (click)="onLogin()" *ngIf="mainService?.usuarioActual?.persona == null"
-            [disabled]="!cloudStatus && (!isLocal || !localStatus)">
-            Entrar
-          </button>
-        </mat-menu>
-      </div>
-      <div fxFlex="10" style="position: relative;">
-        <button mat-icon-button class="header-menu-toggle" (click)="onOpenNotifications()"
-          [disabled]="!cloudStatus && (!isLocal || !localStatus)">
-          <mat-icon>mail</mat-icon>
-          <ng-container *ngIf="(unreadCount$ | async) as count">
-            <span *ngIf="count > 0" class="notification-badge">
-              {{ count > 99 ? '99+' : count }}
-            </span>
-          </ng-container>
-        </button>
-      </div>
-    </div>
-    <div [fxFlex]="isLocal ? '15' : '10'" fxLayout="column" fxLayoutAlign="center center"
-      [class.server-warning]="serverWarning" style="background-color: rgb(32, 32, 32)">
-      <div fxFlex fxLayout="row" fxLayoutAlign="space-between center" style="width: 100%; padding: 0 5px">
-        <div *ngIf="isLocal" fxFlex="50" fxLayout="column" fxLayoutAlign="center center">
-          <div style="font-size: 0.5em">LOCAL</div>
-          <div *ngIf="localStatus == true" style="font-size: 0.6em; color: #43a047">
-            Online
-          </div>
-          <div *ngIf="localStatus == false" [class.blink]="serverWarning && cloudStatus"
-            style="font-size: 0.6em; color: #f44336">
-            Offline
-          </div>
-          <div *ngIf="localStatus == null" style="font-size: 0.6em; color: #f44336">
-            <mat-spinner diameter="15"></mat-spinner>
-          </div>
-        </div>
-        <div [fxFlex]="isLocal ? '50' : '100'" fxLayout="column" fxLayoutAlign="center center">
-          <div style="font-size: 0.5em">CENTRAL</div>
-          <div *ngIf="cloudStatus == true" style="font-size: 0.6em; color: #43a047">
-            Online
-          </div>
-          <div *ngIf="cloudStatus == false" [class.blink]="serverWarning && isLocal && localStatus"
-            style="font-size: 0.6em; color: #f44336">
-            Offline
-          </div>
-          <div *ngIf="cloudStatus == null" style="font-size: 0.6em; color: #f44336">
-            <mat-spinner diameter="15"></mat-spinner>
-          </div>
-        </div>
-      </div>
-    </div>
   </mat-toolbar-row>
 </mat-toolbar>
 
+<mat-menu #menuServerIp="matMenu">
+  <div style="padding: 5px">
+    <button mat-flat-button color="success" (click)="createQrCode()"
+      [disabled]="!cloudStatus && (!isLocal || !localStatus)">
+      QR de la sucursal
+    </button>
+  </div>
+  <div *ngIf="mainService.usuarioActual?.roles.includes(ROLES.SOPORTE)" style="padding: 5px">
+    <button mat-flat-button color="success" (click)="onGetConfiguracion()"
+      [disabled]="!cloudStatus && (!isLocal || !localStatus)">
+      Configuración del Sistema
+    </button>
+  </div>
+  <button mat-menu-item [matMenuTriggerFor]="sucursales" *ngIf="sucursalList?.length">
+    <mat-icon>swap_horiz</mat-icon>
+    <span>Cambiar sucursal</span>
+  </button>
+</mat-menu>
+
+<mat-menu #menu="matMenu">
+  <button mat-menu-item (click)="onLogout()" *ngIf="mainService?.usuarioActual?.persona != null"
+    [disabled]="!cloudStatus && (!isLocal || !localStatus)">
+    <mat-icon>logout</mat-icon>
+    <span>Salir</span>
+  </button>
+  <button mat-menu-item (click)="onLogin()" *ngIf="mainService?.usuarioActual?.persona == null"
+    [disabled]="!cloudStatus && (!isLocal || !localStatus)">
+    <mat-icon>login</mat-icon>
+    <span>Entrar</span>
+  </button>
+</mat-menu>
+
 <mat-menu #sucursales="matMenu">
-  <a mat-menu-item *ngIf="isDev" (click)="onDevMode(true)">Dev server</a>
-  <a mat-menu-item *ngIf="isDev" (click)="onDevMode(false)">Dev sucursal</a>
   <a *ngFor="let sucursal of sucursalList" [class.selected]="sucursal?.id == this.mainService?.sucursalActual?.id"
     mat-menu-item (click)="
       sucursal?.id != this.mainService?.sucursalActual?.id || isDev

--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -1,3 +1,7 @@
+:host {
+  display: block;
+}
+
 ul {
   list-style-type: none;
 }
@@ -6,22 +10,336 @@ ul {
   background-color: rgb(0, 143, 64) !important;
 }
 
-.server-warning {
-  transition: background-color 0.3s ease;
+$header-height: 72px;
+
+.frc-header {
+  padding: 0;
+  min-height: $header-height;
+  height: $header-height;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+
+  &__row {
+    width: 100%;
+    height: $header-height;
+    min-height: $header-height;
+    padding: 0 8px 0 0;
+    display: flex;
+    align-items: stretch;
+    gap: 0;
+  }
+
+  &__zone {
+    display: flex;
+    align-items: center;
+    padding: 0 16px;
+    min-width: 0;
+    height: 100%;
+
+    &--brand {
+      flex: 0 0 auto;
+      padding: 0 4px 0 4px;
+      gap: 4px;
+    }
+
+    &--cotiz {
+      flex: 0 0 auto;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      gap: 6px;
+      min-width: 200px;
+    }
+
+    &--clock {
+      flex: 0 0 auto;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-width: 130px;
+      line-height: 1.1;
+    }
+
+    &--status {
+      flex: 0 0 auto;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-start;
+      gap: 6px;
+      min-width: 110px;
+    }
+
+    &--actions {
+      flex: 0 0 auto;
+      gap: 6px;
+      padding-right: 6px;
+    }
+  }
+
+  &__spacer {
+    flex: 1 1 auto;
+  }
+
+  &__divider {
+    width: 1px;
+    align-self: center;
+    height: 44px;
+    background: rgba(255, 255, 255, 0.18);
+    margin: 0 2px;
+  }
+
+  /* ---------- BRAND ---------- */
+  &__burger {
+    flex-shrink: 0;
+  }
+
+  &__brand {
+    display: flex;
+    align-items: center;
+    padding: 0 8px;
+    line-height: 1.1;
+    text-align: left;
+    min-width: 0;
+    height: auto;
+    cursor: default;
+    user-select: none;
+  }
+
+  &__brand-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.2;
+    min-width: 0;
+  }
+
+  &__brand-title {
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 320px;
+  }
+
+  &__brand-sub {
+    font-size: 11px;
+    opacity: 0.78;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    margin-top: 2px;
+  }
+
+  &__brand-caret {
+    font-size: 22px;
+    width: 22px;
+    height: 22px;
+    opacity: 0.85;
+  }
+
+  &__tag {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.22);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    margin-left: 6px;
+    vertical-align: middle;
+  }
+
+  /* ---------- COTIZACIONES ---------- */
+  &__cotiz-refresh {
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    flex-shrink: 0;
+    align-self: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    mat-icon {
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
+      line-height: 20px;
+      margin: 0;
+      opacity: 0.85;
+    }
+  }
+
+  &__cotiz-stack {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  &__cotiz-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    line-height: 1.1;
+  }
+
+  &__cotiz-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+    opacity: 0.8;
+    width: 32px;
+  }
+
+  &__cotiz-values {
+    font-size: 14px;
+    font-weight: 600;
+    font-feature-settings: 'tnum';
+    display: flex;
+    align-items: baseline;
+    gap: 5px;
+  }
+
+  &__cotiz-sep {
+    opacity: 0.55;
+    font-weight: 400;
+  }
+
+  &__cotiz-empty {
+    font-size: 12px;
+    opacity: 0.6;
+    font-style: italic;
+  }
+
+  /* ---------- CLOCK ---------- */
+  &__clock-time {
+    font-size: 18px;
+    font-weight: 600;
+    font-feature-settings: 'tnum';
+    letter-spacing: 0.4px;
+    line-height: 1.1;
+  }
+
+  &__clock-date {
+    font-size: 11px;
+    opacity: 0.78;
+    letter-spacing: 0.4px;
+    margin-top: 3px;
+  }
+
+  /* ---------- STATUS ---------- */
+  &__status-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    letter-spacing: 0.4px;
+    line-height: 1.1;
+  }
+
+  &__status-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: #888;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.05);
+    flex-shrink: 0;
+
+    &--on {
+      background: #43a047;
+      box-shadow: 0 0 6px rgba(67, 160, 71, 0.6);
+    }
+
+    &--off {
+      background: #ef5350;
+      box-shadow: 0 0 6px rgba(239, 83, 80, 0.6);
+    }
+  }
+
+  &__status-label {
+    font-weight: 600;
+    opacity: 0.88;
+  }
+
+  /* ---------- ACTIONS / USER ---------- */
+  &__notif {
+    position: relative;
+  }
+
+  &__user {
+    padding: 4px 10px;
+    line-height: 1.15;
+    text-align: left;
+    height: auto;
+  }
+
+  &__user-inner {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+  }
+
+  &__user-avatar {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.22);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+
+    mat-icon {
+      font-size: 22px;
+      width: 22px;
+      height: 22px;
+      line-height: 22px;
+    }
+  }
+
+  &__user-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.2;
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+
+  &__user-name {
+    font-size: 14px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 280px;
+  }
+
+  &__user-role {
+    font-size: 10px;
+    letter-spacing: 0.6px;
+    opacity: 0.78;
+    text-transform: uppercase;
+    margin-top: 2px;
+  }
+
+  &__user-caret {
+    font-size: 22px;
+    width: 22px;
+    height: 22px;
+    opacity: 0.85;
+    flex-shrink: 0;
+  }
 }
 
+/* ---------- ANIMATIONS ---------- */
 @keyframes blink {
-  0% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.3;
-  }
-
-  100% {
-    opacity: 1;
-  }
+  0% { opacity: 1; }
+  50% { opacity: 0.3; }
+  100% { opacity: 1; }
 }
 
 .blink {
@@ -29,25 +347,16 @@ ul {
   font-weight: bold;
 }
 
-@keyframes border-blink {
-  0% {
-    border-color: transparent;
-  }
-
-  50% {
-    border-color: #f44336;
-  }
-
-  100% {
-    border-color: transparent;
-  }
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
-.server-warning {
-  border-left: 2px solid transparent;
-  animation: border-blink 2s linear infinite;
+.frc-header__spin {
+  animation: spin 0.8s linear infinite;
 }
 
+/* ---------- NOTIFICATION BADGE ---------- */
 .notification-badge {
   position: absolute;
   top: 2px;
@@ -65,4 +374,21 @@ ul {
   padding: 0 3px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   z-index: 1;
+}
+
+/* ---------- RESPONSIVE ---------- */
+@media (max-width: 1280px) {
+  .frc-header__user { min-width: 60px; }
+  .frc-header__user-stack { display: none; }
+  .frc-header__user-caret { display: none; }
+}
+
+@media (max-width: 1100px) {
+  .frc-header__zone--clock { min-width: 100px; }
+  .frc-header__clock-date { display: none; }
+}
+
+@media (max-width: 980px) {
+  .frc-header__zone--cotiz { display: none; }
+  .frc-header__divider:nth-of-type(1) { display: none; }
 }

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -8,7 +8,8 @@ import {
 import { FormControl } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
-import { Observable, Subscription } from "rxjs";
+import { Observable, Subscription, timer } from "rxjs";
+import { map } from "rxjs/operators";
 import { ElectronService } from "../../../commons/core/electron/electron.service";
 import { TabService } from "../../../layouts/tab/tab.service";
 import { MainService } from "../../../main.service";
@@ -30,6 +31,7 @@ import { UsuarioService } from "../../../modules/personas/usuarios/usuario.servi
 import { InicioSesion } from "../../../modules/configuracion/models/inicio-sesion.model";
 import { connectionStatusSub, cloudConnectionStatusSub } from "../../services/graphql-connection.service";
 import { NotificacionesTableroService } from "../../../modules/notificaciones/services/notificaciones-tablero.service";
+import { CotizacionHeaderService } from "../../services/cotizacion-header.service";
 @UntilDestroy({ checkProperties: true })
 @Component({
   selector: "app-header",
@@ -56,6 +58,10 @@ export class HeaderComponent implements OnInit, OnDestroy {
   @Output() openNotificationsEvent: EventEmitter<void> = new EventEmitter<void>();
   appVersion = null;
   unreadCount$ = this.notificacionesTableroService.unreadCount$;
+  cotizaciones$ = this.cotizacionHeaderService.cotizaciones$;
+  now$ = timer(0, 1000).pipe(map(() => new Date()));
+  userMainRole = '';
+  isRefreshingCotiz = false;
 
   constructor(
     public mainService: MainService,
@@ -70,8 +76,9 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private dialogoService: DialogosService,
     private usuarioService: UsuarioService,
     private loginDialogService: LoginDialogService,
-    private notificacionesTableroService: NotificacionesTableroService
-  ) { 
+    private notificacionesTableroService: NotificacionesTableroService,
+    private cotizacionHeaderService: CotizacionHeaderService
+  ) {
     setTimeout(() => {
       console.log(this.mainService.usuarioActual);
     }, 2000);
@@ -117,8 +124,17 @@ export class HeaderComponent implements OnInit, OnDestroy {
           if (tokenFcm) {
             this.notificacionesTableroService.setTokenFcm(tokenFcm);
           }
+          this.refreshUserChip();
+        } else {
+          this.userMainRole = '';
         }
       });
+    this.refreshUserChip();
+  }
+
+  private refreshUserChip(): void {
+    const roles = this.mainService?.usuarioActual?.roles || [];
+    this.userMainRole = roles.length ? String(roles[0]).toUpperCase() : '';
   }
   private updateServerWarning(): void {
     if (this.cloudStatus != null) {
@@ -170,6 +186,13 @@ export class HeaderComponent implements OnInit, OnDestroy {
     if (this.configChangedSub) {
       this.configChangedSub.unsubscribe();
     }
+  }
+
+  onRefreshCotizacion() {
+    if (this.isRefreshingCotiz) return;
+    this.isRefreshingCotiz = true;
+    this.cotizacionHeaderService.refresh();
+    setTimeout(() => (this.isRefreshingCotiz = false), 1500);
   }
 
   onSearch() {

--- a/src/app/shared/services/cotizacion-header.service.ts
+++ b/src/app/shared/services/cotizacion-header.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { BehaviorSubject, Subscription, timer } from 'rxjs';
+import { filter, take } from 'rxjs/operators';
+import { Cambio } from '../../modules/financiero/cambio/cambio.model';
+import { CambioService } from '../../modules/financiero/cambio/cambio.service';
+import { Moneda } from '../../modules/financiero/moneda/moneda.model';
+import { MonedaService } from '../../modules/financiero/moneda/moneda.service';
+import { MainService } from '../../main.service';
+
+export interface CotizacionView {
+  moneda: Moneda;
+  local: number;
+  ventaMercado: number;
+  compraMercado: number;
+  fecha: Date;
+}
+
+const REFRESH_MS = 10 * 60 * 1000;
+
+const DEFAULT_DENOMS = ['DOLAR', 'DOLARES', 'DOLAR AMERICANO', 'REAL', 'REALES'];
+
+@Injectable({ providedIn: 'root' })
+export class CotizacionHeaderService implements OnDestroy {
+  cotizaciones$ = new BehaviorSubject<CotizacionView[]>([]);
+
+  private monedas: Moneda[] = [];
+  private authSub: Subscription;
+  private timerSub: Subscription;
+
+  constructor(
+    private monedaService: MonedaService,
+    private cambioService: CambioService,
+    private mainService: MainService,
+  ) {
+    this.authSub = this.mainService.authenticationSub
+      .pipe(filter((auth) => !!auth))
+      .subscribe(() => this.bootstrap());
+  }
+
+  refresh(): void {
+    if (!this.monedas.length) {
+      this.loadMonedas();
+      return;
+    }
+    this.fetchAll();
+  }
+
+  ngOnDestroy(): void {
+    this.authSub?.unsubscribe();
+    this.timerSub?.unsubscribe();
+  }
+
+  private bootstrap(): void {
+    this.timerSub?.unsubscribe();
+    this.loadMonedas();
+    this.timerSub = timer(REFRESH_MS, REFRESH_MS).subscribe(() => this.fetchAll());
+  }
+
+  private loadMonedas(): void {
+    this.monedaService
+      .onGetAll()
+      .pipe(take(1))
+      .subscribe((res) => {
+        if (!res) return;
+        this.monedas = res
+          .filter((m) => DEFAULT_DENOMS.includes((m.denominacion || '').toUpperCase()))
+          .sort((a, b) => this.denomRank(a) - this.denomRank(b));
+        this.fetchAll();
+      });
+  }
+
+  private fetchAll(): void {
+    if (!this.monedas.length) return;
+    const next: CotizacionView[] = [];
+    let pending = this.monedas.length;
+    this.monedas.forEach((moneda) => {
+      this.cambioService
+        .getUltimoCambioPorMonedaId(moneda.id)
+        .pipe(take(1))
+        .subscribe({
+          next: (cambio: Cambio) => {
+            if (cambio) {
+              next.push({
+                moneda,
+                local: cambio.valorEnGs,
+                ventaMercado: cambio.valorEnGsVentaMercado,
+                compraMercado: cambio.valorEnGsCompraMercado,
+                fecha: cambio.creadoEn,
+              });
+            }
+            if (--pending === 0) this.emit(next);
+          },
+          error: () => {
+            if (--pending === 0) this.emit(next);
+          },
+        });
+    });
+  }
+
+  private emit(next: CotizacionView[]): void {
+    next.sort((a, b) => this.denomRank(a.moneda) - this.denomRank(b.moneda));
+    this.cotizaciones$.next(next);
+  }
+
+  private denomRank(m: Moneda): number {
+    const d = (m?.denominacion || '').toUpperCase();
+    if (d.startsWith('DOLAR')) return 0;
+    if (d.startsWith('REAL')) return 1;
+    return 99;
+  }
+}


### PR DESCRIPTION
## Resumen

Refactor completo del header del desktop con look moderno y mejor distribución.

## Cambios

- **Layout en 5 zonas**: brand (izq), cotizaciones / reloj / status (centrados), acciones + usuario (der).
- **Cotizaciones USD/BRL** via nuevo `CotizacionHeaderService` con polling 10 min.
- **Botón refresh manual** al lado del stack de cotizaciones (icono + spin durante carga).
- **Reloj** con tick 1s + fecha localizada es-PY.
- **Status local/central** como dots compactos verticales (verde/rojo + blink en warning).
- **Avatar circular** con icono persona, nombre y rol del usuario; nombre completo si entra, ellipsis si no.
- **Sucursal switcher** movido al menú de settings (⚙).
- **Tipografía coherente** al sistema (sin monoespaciada), header height 72px.

## Archivos

- `shared/components/header/*` — HTML / SCSS / TS reescritos.
- `shared/services/cotizacion-header.service.ts` — nuevo, polling reactivo de USD/REAL.

## Cómo probar

1. `npm start`
2. Login → ver cotizaciones cargar a los pocos segundos.
3. Click en icono refresh → spin breve + valores re-fetch.
4. Verificar reloj actualiza cada segundo, fecha en español.
5. Menú ⚙ → "Cambiar sucursal" abre submenú.
6. Status servers reaccionan a desconexión (toggle backend).

## Riesgo

Bajo. Solo afecta `HeaderComponent` y un service nuevo en shared/services. No toca backend, ni schemas GraphQL nuevos (consume `ultimoCambioPorMonedaId` ya existente). Sin impacto DB. Rollback = revert commit.