### PR TITLE
fix(menu): arreglo boton de apertura y cierre del menu lateral

### DIFF
--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -4,7 +4,7 @@
     <!-- ZONA 1: burger + sucursal -->
     <div class="frc-header__zone frc-header__zone--brand">
       <button mat-icon-button (click)="toogleSideBar()"
-        [disabled]="!cloudStatus && (!isLocal || !localStatus)" class="frc-header__burger">
+        [disabled]="!cloudStatus && (!isLocal || !localStatus)" class="frc-header__burger header-menu-toggle">
         <mat-icon>menu</mat-icon>
       </button>
 

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.html
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.html
@@ -87,7 +87,7 @@
             <div *ngIf="mainService?.usuarioActual != null" class="footer-button logout-button"
                 (click)="onLogout(); $event.stopPropagation()">
                 <mat-icon>exit_to_app</mat-icon>
-                <span *ngIf="isExpanded">SALIR</span>
+                <span *ngIf="isExpanded" style="margin-bottom: 6px;">SALIR</span>
             </div>
 
             <div *ngIf="mainService?.usuarioActual == null" class="footer-button login-button"

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.scss
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.scss
@@ -216,10 +216,12 @@
     
     &.logout-button mat-icon {
       color: #ff6b6b;
+      margin-bottom: 6px;
     }
     
     &.login-button mat-icon {
       color: #63cdff;
+      margin-bottom: 6px;
     }
   }
 }

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -558,7 +558,7 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
   handleClickOutside(event: MouseEvent): void {
     const sidenavElement = document.querySelector('.side-nav-container');
     if (this.isExpanded && sidenavElement && !sidenavElement.contains(event.target as Node)) {
-      const isHeaderMenuButton = (event.target as HTMLElement).closest('[class*="header-menu-toggle"]');
+      const isHeaderMenuButton = (event.target as HTMLElement).closest('[class*="header-menu-toggle"], .frc-header__burger');
       if (!isHeaderMenuButton) {
         this.toggleSidenav(false);
       }


### PR DESCRIPTION
### Que resuelve
Corrige un fallo en la navegacion lateral donde el boton del menu en el encabezado no permitia expandir ni contraer el menu lateral. 

Esto ocurria porque el detector de clics externos del menu lateral (click outside) no identificaba al boton del encabezado como un disparador valido debido a la falta de la clase CSS esperada (header-menu-toggle). Como resultado, cada vez que se clickeaba el boton para cambiar el estado del menu, la accion se anulaba inmediatamente al interpretarse de forma erronea como un clic fuera del componente.

Adicionalmente, se ajusto el margen inferior de los iconos y etiquetas de los botones de inicio y cierre de sesion en el pie de pagina del menu lateral para mejorar la alineacion visual cuando el menu esta expandido.

### Como probarlo
1. Iniciar la aplicacion en el entorno de desarrollo.
2. Hacer clic en el boton de menu hamburguesa ubicado en la esquina superior izquierda del encabezado.
3. Verificar que al hacer clic en dicho boton, el menu lateral se expanda si esta contraido, y se contraiga si esta expandido.
4. Validar que hacer clic en cualquier parte fuera del menu lateral cuando este se encuentra expandido continue cerrandolo automaticamente.
5. Hacer clic en los items y sub-items del menu lateral y corroborar que sigan navegando y desplegandose correctamente.
6. Verificar visualmente la correcta alineacion de los botones del pie de pagina (Entrar / Salir) en ambos estados del menu lateral.

### Impacto DB
**No aplica**. Los cambios son puramente de logica de presentacion e interfaz de usuario en el frontend.

### Riesgo
**Bajo**. Las modificaciones estan acotadas a la verificacion de selectores de clases en eventos de clic y estilos CSS locales del componente.
