### PR TITLE
fix(ventas): arreglo error de cancelar venta en lista generica

### DIFF
--- a/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.ts
+++ b/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.ts
@@ -308,6 +308,9 @@ export class GenericListVentaComponent implements OnInit {
   }
 
   onGetBalance() {
+    if (this.selectedCaja?.id == null) {
+      return;
+    }
     this.isLoading = true;
     this.cajaService
       .onCajaBalancePorIdAndSucursalId(


### PR DESCRIPTION
## Qué resuelve
Resuelve un error de tipo `TypeError: Cannot read properties of undefined (reading 'id')` que ocurría al cancelar una venta desde la lista genérica de ventas (`GenericListVentaComponent`). Este error se producía porque el método `onGetBalance()` intentaba obtener el saldo de la caja seleccionada (`this.selectedCaja`), pero cuando se navega al listado general de ventas de forma independiente, `this.selectedCaja` se encuentra indefinido.

## Cómo probarlo
1. Iniciar sesión en la aplicación.
2. Navegar a la sección de Operaciones -> Venta -> Ventas desde el menú lateral.
3. Buscar y seleccionar una venta concluida que se desee cancelar.
4. Hacer clic en el botón de cancelar venta y confirmar la acción en el cuadro de diálogo.
5. Comprobar que la venta cambia su estado correctamente y que no se registre ningún error `TypeError` en la consola del navegador.

## Impacto DB
**No aplica**. El cambio se realiza exclusivamente en el código de la lógica del frontend (Angular) y no introduce modificaciones en la base de datos.

## Riesgo
**Bajo**. El cambio consiste en una verificación para evitar llamadas a servicios con parámetros indefinidos, por lo que no compromete el flujo habitual cuando se cancela una venta dentro de una caja de cobro activa.
