### PR TITLE
feat(menu): colapsar secciones hermanas en menu lateral

### DIFF
--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -568,12 +568,43 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
       }
     }
   }
+  collapseSiblings(targetSection: any): void {
+    const isFirstLevel = this.navigationItems.some(item => item === targetSection);
+    if (isFirstLevel) {
+      this.navigationItems.forEach(item => {
+        if (item !== targetSection && 'isExpanded' in item) {
+          item.isExpanded = false;
+        }
+      });
+      return;
+    }
+
+    for (const parent of this.navigationItems) {
+      if ('items' in parent && parent.items) {
+        const isChild = parent.items.some(child => child === targetSection);
+        if (isChild) {
+          parent.items.forEach(child => {
+            if (child !== targetSection && 'isExpanded' in child) {
+              child.isExpanded = false;
+            }
+          });
+          break;
+        }
+      }
+    }
+  }
+
   toggleMenuSection(section: any, event: Event): void {
     event.stopPropagation();
     if (this.isExpanded) {
-      section.isExpanded = !section.isExpanded;
+      const willExpand = !section.isExpanded;
+      if (willExpand) {
+        this.collapseSiblings(section);
+      }
+      section.isExpanded = willExpand;
     } else {
       this.toggleSidenav(true);
+      this.collapseSiblings(section);
       section.isExpanded = true;
     }
   }


### PR DESCRIPTION
## Qué resuelve
Resuelve el comportamiento del menú lateral donde al expandir una nueva sección, las demás secciones abiertas permanecían desplegadas simultáneamente. Con esta modificación, al abrir cualquier sección, las secciones hermanas en el mismo nivel jerárquico se contraen de manera automática, manteniendo una interfaz más limpia y ordenada.

## Cómo probarlo
1. Iniciar sesión en la aplicación.
2. Abrir el menú lateral y expandir una sección de primer nivel, por ejemplo, Operaciones.
3. Desplegar una sección diferente de primer nivel, por ejemplo, Financiero o R.R.H.H.
4. Confirmar que la sección que estaba abierta previamente se contrae de forma automática.
5. Probar el mismo comportamiento en las subsecciones de segundo nivel que poseen hijos (como Gestión de Stock, Venta y Observaciones dentro de la sección Operaciones).

## Impacto DB
No aplica. El cambio afecta únicamente a la lógica de visualización del frontend.

## Riesgo
Bajo. Es un ajuste puramente de UI/UX en el comportamiento del menú lateral que no interfiere con el flujo de datos del sistema.
