### PR TITLE
fix(notificaciones): panel overlay independiente sin desplazar tabs n…

### DIFF
--- a/src/app/layouts/default/default.component.html
+++ b/src/app/layouts/default/default.component.html
@@ -5,50 +5,6 @@
     <mat-drawer mode="side" [opened]="true" class="side-drawer">
       <app-side-mini-variant [isExpanded]="sideBarOpen" (toggleSideNav)="setSideNav($event)"></app-side-mini-variant>
     </mat-drawer>
-    <mat-drawer mode="over" position="end" [(opened)]="notificationsOpen" class="notifications-drawer">
-      <div class="notifications-content">
-        <div class="notifications-header">
-          <div class="notifications-title">
-            Notificaciones
-          </div>
-          <div class="notifications-actions">
-            <mat-form-field class="date-filter-field" appearance="outline">
-              <mat-label>Rango de fecha</mat-label>
-              <mat-date-range-input [formGroup]="fechaFormGroup" [rangePicker]="picker">
-                <input matStartDate formControlName="inicio" placeholder="Fecha Inicio" [max]="today" />
-                <input matEndDate formControlName="fin" placeholder="Fecha Fin" [max]="today" />
-              </mat-date-range-input>
-              <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-              <mat-date-range-picker #picker></mat-date-range-picker>
-            </mat-form-field>
-            <button mat-raised-button color="accent" class="filter-button" (click)="aplicarFiltroFechas()">
-              <mat-icon>search</mat-icon>
-              Filtrar
-            </button>
-            <button mat-raised-button class="clear-button" (click)="limpiarFiltroFechas()">
-              <mat-icon>clear</mat-icon>
-              Limpiar
-            </button>
-            <button mat-raised-button class="mark-all-button" (click)="marcarTodasComoLeidas()">
-              <mat-icon>done_all</mat-icon>
-              <span>Marcar todas</span>
-            </button>
-            <button mat-raised-button color="primary" class="btn-crear-notificacion" (click)="crearNotificacion()">
-              <mat-icon>add</mat-icon>
-              <span>Crear Notificacion</span>
-            </button>
-          </div>
-        </div>
-        <div class="notifications-scroll">
-          <app-notification-board></app-notification-board>
-        </div>
-        <ng-template #noNotifications>
-          <div class="no-notifications">
-            No hay nuevas notificaciones
-          </div>
-        </ng-template> 
-      </div>
-    </mat-drawer>
     <mat-drawer-content style="overflow: hidden;">
       <mat-tab-group class="main-tab-group" [selectedIndex]="selectedTab" (selectedTabChange)="tabChanged($event)"
         style="width: 100%" mat-stretch-tabs="false">
@@ -81,4 +37,49 @@
       </mat-tab-group>
     </mat-drawer-content>
   </mat-drawer-container>
+
+  <aside *ngIf="notificationsOpen" class="notifications-overlay" aria-label="Notificaciones">
+    <div class="notifications-content">
+      <div class="notifications-header">
+        <div class="notifications-title">
+          Notificaciones
+        </div>
+        <div class="notifications-actions">
+          <mat-form-field class="date-filter-field" appearance="outline">
+            <mat-label>Rango de fecha</mat-label>
+            <mat-date-range-input [formGroup]="fechaFormGroup" [rangePicker]="picker">
+              <input matStartDate formControlName="inicio" placeholder="Fecha Inicio" [max]="today" />
+              <input matEndDate formControlName="fin" placeholder="Fecha Fin" [max]="today" />
+            </mat-date-range-input>
+            <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+            <mat-date-range-picker #picker></mat-date-range-picker>
+          </mat-form-field>
+          <button mat-raised-button color="accent" class="filter-button" (click)="aplicarFiltroFechas()">
+            <mat-icon>search</mat-icon>
+            Filtrar
+          </button>
+          <button mat-raised-button class="clear-button" (click)="limpiarFiltroFechas()">
+            <mat-icon>clear</mat-icon>
+            Limpiar
+          </button>
+          <button mat-raised-button class="mark-all-button" (click)="marcarTodasComoLeidas()">
+            <mat-icon>done_all</mat-icon>
+            <span>Marcar todas</span>
+          </button>
+          <button mat-raised-button color="primary" class="btn-crear-notificacion" (click)="crearNotificacion()">
+            <mat-icon>add</mat-icon>
+            <span>Crear Notificacion</span>
+          </button>
+        </div>
+      </div>
+      <div class="notifications-scroll">
+        <app-notification-board></app-notification-board>
+      </div>
+      <ng-template #noNotifications>
+        <div class="no-notifications">
+          No hay nuevas notificaciones
+        </div>
+      </ng-template>
+    </div>
+  </aside>
 </div>

--- a/src/app/layouts/default/default.component.scss
+++ b/src/app/layouts/default/default.component.scss
@@ -42,11 +42,21 @@
   color: white;
 }
 
-.notifications-drawer {
+.notifications-overlay {
+  position: fixed;
+  top: 64px;
+  right: 0;
+  bottom: 0;
   z-index: 1000;
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.35);
+  pointer-events: auto;
+
+  @media (max-width: 599px) {
+    top: 56px;
+  }
 }
 
-.notifications-drawer .notifications-content {
+.notifications-overlay .notifications-content {
   width: 80vw;
   max-width: 1200px;
   height: 100%;
@@ -56,7 +66,7 @@
   color: white;
 }
 
-.notifications-drawer .notifications-scroll {
+.notifications-overlay .notifications-scroll {
   flex: 1;
   padding: 16px;
   overflow-y: auto;
@@ -286,7 +296,7 @@
   margin-top: 32px;
 }
 
-.notifications-drawer .notifications-paginator {
+.notifications-overlay .notifications-paginator {
   padding: 4px 8px 8px 8px;
   border-top: 1px solid rgba(255, 255, 255, 0.1);
   position: sticky;
@@ -299,9 +309,8 @@
 }
 
 @media (max-width: 600px) {
-  .notifications-drawer .notifications-content {
+  .notifications-overlay .notifications-content {
     width: 92vw;
-    transform: translateX(0);
   }
 }
 

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -560,10 +560,14 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
 
   @HostListener('document:click', ['$event'])
   handleClickOutside(event: MouseEvent): void {
+    const target = event.target as HTMLElement;
     const sidenavElement = document.querySelector('.side-nav-container');
-    if (this.isExpanded && sidenavElement && !sidenavElement.contains(event.target as Node)) {
-      const isHeaderMenuButton = (event.target as HTMLElement).closest('[class*="header-menu-toggle"], .frc-header__burger');
-      if (!isHeaderMenuButton) {
+
+    const isHeaderInteraction = target.closest('.frc-header');
+    const isNotificationsPanel = target.closest('.notifications-overlay');
+
+    if (this.isExpanded && sidenavElement && !sidenavElement.contains(target)) {
+      if (!isHeaderInteraction && !isNotificationsPanel) {
         this.toggleSidenav(false);
       }
     }


### PR DESCRIPTION
Summary
Corrige un bug de layout al abrir el panel de notificaciones: las pestañas y su contenido ya no se desplazan ni se comprimen, y el menú lateral expandido permanece abierto.

El panel de notificaciones pasa a mostrarse como una capa fija independiente (overlay) en lugar de usar un mat-drawer dentro del contenedor principal. Además, los clics en el header o en el panel de notificaciones ya no activan el cierre automático del menú lateral.