### PR TITLE
feat(graficos): modulo analisis de producto con ventas y compras

### DIFF
--- a/src/app/modules/grafico/analisis-producto/analisis-producto.component.html
+++ b/src/app/modules/grafico/analisis-producto/analisis-producto.component.html
@@ -1,0 +1,141 @@
+<div class="analisis-producto-container">
+    <div class="filters-section">
+        <mat-button-toggle-group [formControl]="modoControl" class="modo-toggle">
+            <mat-button-toggle *ngFor="let m of modos" [value]="m.valor">{{ m.label }}</mat-button-toggle>
+        </mat-button-toggle-group>
+
+        <mat-form-field appearance="outline" class="filter-field filter-small">
+            <mat-label>Año</mat-label>
+            <mat-select [formControl]="anhoControl">
+                <mat-option *ngFor="let anho of anhos" [value]="anho">{{ anho }}</mat-option>
+            </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="filter-field filter-rango">
+            <mat-label>Período</mat-label>
+            <mat-date-range-input [formGroup]="fechaRangoGroup" [rangePicker]="pickerRango">
+                <input matStartDate formControlName="inicio" placeholder="Desde" [min]="minFechaAnho" [max]="maxFechaAnho">
+                <input matEndDate formControlName="fin" placeholder="Hasta" [min]="minFechaAnho" [max]="maxFechaAnho">
+            </mat-date-range-input>
+            <mat-datepicker-toggle matSuffix [for]="pickerRango"></mat-datepicker-toggle>
+            <mat-date-range-picker #pickerRango></mat-date-range-picker>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="filter-field filter-producto">
+            <mat-label>Productos</mat-label>
+            <input matInput readonly [value]="etiquetaProductosFiltro"
+                placeholder="Todos los productos"
+                (click)="abrirBusquedaProducto()">
+            <button mat-icon-button matSuffix type="button" (click)="abrirBusquedaProducto(); $event.stopPropagation()"
+                matTooltip="Seleccionar productos">
+                <mat-icon>search</mat-icon>
+            </button>
+            <button mat-icon-button matSuffix *ngIf="productosFiltro.length" type="button"
+                (click)="limpiarProductosFiltro(); $event.stopPropagation()" matTooltip="Quitar filtro">
+                <mat-icon>close</mat-icon>
+            </button>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="filter-field">
+            <mat-label>Sucursal</mat-label>
+            <mat-select [formControl]="sucursalControl">
+                <mat-option [value]="null">Todas</mat-option>
+                <mat-option *ngFor="let s of sucursales$ | async" [value]="s.id">{{ s.nombre }}</mat-option>
+            </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="filter-field">
+            <mat-label>Familia</mat-label>
+            <mat-select [formControl]="familiaControl">
+                <mat-option [value]="null">Todas</mat-option>
+                <mat-option *ngFor="let f of familias$ | async" [value]="f.id">{{ f.nombre | titlecase }}</mat-option>
+            </mat-select>
+        </mat-form-field>
+
+        <mat-button-toggle-group [formControl]="vistaTemporalControl" class="vista-toggle">
+            <mat-button-toggle *ngFor="let v of vistasTemporales" [value]="v.valor">{{ v.label }}</mat-button-toggle>
+        </mat-button-toggle-group>
+
+        <mat-form-field appearance="outline" class="filter-field filter-small">
+            <mat-label>Top</mat-label>
+            <mat-select [formControl]="limitControl">
+                <mat-option *ngFor="let l of limits" [value]="l">{{ l }}</mat-option>
+            </mat-select>
+        </mat-form-field>
+
+        <button mat-icon-button (click)="limpiarFiltros()" matTooltip="Limpiar filtros">
+            <mat-icon>filter_alt_off</mat-icon>
+        </button>
+    </div>
+
+    <div class="productos-filtro-chips" *ngIf="productosFiltro.length">
+        <mat-chip-set>
+            <mat-chip *ngFor="let p of productosFiltro" (removed)="quitarProductoFiltro(p)">
+                {{ p.descripcion }}
+                <button matChipRemove>
+                    <mat-icon>cancel</mat-icon>
+                </button>
+            </mat-chip>
+        </mat-chip-set>
+    </div>
+
+    <div class="loading-overlay" *ngIf="cargando">
+        <mat-spinner diameter="40"></mat-spinner>
+    </div>
+
+    <ng-container *ngIf="datos$ | async as datos">
+        <div class="stats-row" *ngIf="datos.productoSeleccionado">
+            <div class="stat-card">
+                <span class="stat-label">Producto seleccionado</span>
+                <span class="stat-value truncate">{{ datos.productoSeleccionado.descripcion }}</span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-label">Cantidad total</span>
+                <span class="stat-value">{{ datos.productoSeleccionado.cantidadFormateada }}</span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-label">Promedio</span>
+                <span class="stat-value">{{ datos.promedioPeriodo }}</span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-label">{{ datos.labelPeriodoPico }}</span>
+                <span class="stat-value">{{ datos.periodoPico }}</span>
+            </div>
+        </div>
+
+        <div class="charts-layout">
+            <div class="chart-panel">
+                <div echarts [options]="datos.rankingOptions" class="chart" (chartClick)="onChartClick($event)"></div>
+            </div>
+
+            <div class="chart-panel">
+                <div echarts [options]="datos.temporalOptions" class="chart"></div>
+            </div>
+        </div>
+
+        <div class="products-details" *ngIf="datos.hayDatos">
+            <h3 class="details-title">Detalle por producto — clic para ver evolución</h3>
+            <div class="details-list">
+                <div *ngFor="let p of datos.productos; trackBy: trackByProductoId"
+                    class="detail-item"
+                    [class.selected]="datos.productoSeleccionado?.productoId === p.productoId"
+                    (click)="seleccionarProducto(p.productoId)"
+                    matTooltip="Ver evolución">
+                    <span class="rank-badge">#{{ p.rank }}</span>
+                    <div class="item-color-dot" [style.background-color]="p.color"></div>
+                    <div class="item-info">
+                        <span class="item-name">{{ p.descripcion }}</span>
+                        <span class="item-qty">{{ p.cantidadFormateada }}</span>
+                        <span class="nivel-badge" [class]="'nivel-' + p.nivel">{{ p.nivelLabel }}</span>
+                    </div>
+                    <div class="item-amount">{{ p.montoFormateado }}</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="no-data-message" *ngIf="!datos.hayDatos && !cargando">
+            <mat-icon>inventory</mat-icon>
+            <span>No hay ventas de productos para el período seleccionado</span>
+        </div>
+    </ng-container>
+</div>

--- a/src/app/modules/grafico/analisis-producto/analisis-producto.component.scss
+++ b/src/app/modules/grafico/analisis-producto/analisis-producto.component.scss
@@ -1,0 +1,313 @@
+$primary: #689F38;
+$accent: #009688;
+$warn: #F44336;
+$warning: #FF9800;
+$background: #424242;
+$background-dark: #303030;
+$text: #E0E0E0;
+$text-secondary: #9E9E9E;
+$border: #555;
+
+.analisis-producto-container {
+    padding: 16px;
+    background: $background-dark;
+    color: $text;
+    position: relative;
+    min-height: 100%;
+}
+
+.filters-section {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    background: $background;
+    padding: 12px;
+    border-radius: 12px;
+    border: 1px solid $border;
+    margin-bottom: 16px;
+}
+
+.modo-toggle,
+.vista-toggle {
+    margin-right: 4px;
+}
+
+.filter-producto {
+    min-width: 220px;
+    max-width: 300px;
+
+    input[readonly] {
+        cursor: pointer;
+    }
+}
+
+.productos-filtro-chips {
+    margin: -8px 0 12px;
+    padding: 0 4px;
+
+    mat-chip-set {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+    }
+
+    mat-chip {
+        max-width: 280px;
+
+        ::ng-deep .mdc-evolution-chip__text-label {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    }
+}
+
+.filter-rango {
+    min-width: 260px;
+    max-width: 320px;
+}
+
+.filter-field {
+    flex: 1;
+    min-width: 120px;
+    max-width: 180px;
+}
+
+.filter-small {
+    max-width: 110px;
+}
+
+.loading-overlay {
+    position: absolute;
+    top: 120px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+}
+
+.stats-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    margin-bottom: 16px;
+}
+
+.stat-card {
+    background: $background;
+    border: 1px solid $border;
+    border-radius: 8px;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.stat-label {
+    font-size: 0.65rem;
+    color: $text-secondary;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.stat-value {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: $text;
+
+    &.truncate {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}
+
+.charts-layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 16px;
+
+    &.loading {
+        opacity: 0.5;
+        pointer-events: none;
+    }
+}
+
+.chart-panel {
+    background: $background;
+    border: 1px solid $border;
+    border-radius: 12px;
+    padding: 8px;
+}
+
+.chart {
+    width: 100%;
+    height: 340px;
+}
+
+.products-details {
+    background: $background;
+    border: 1px solid $border;
+    border-radius: 12px;
+    padding: 16px;
+}
+
+.details-title {
+    font-size: 0.9rem;
+    color: $text-secondary;
+    margin: 0 0 4px;
+    font-weight: 500;
+}
+
+.details-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 14px;
+    margin-top: 16px;
+    max-height: 75vh;
+    overflow-y: auto;
+    padding-right: 5px;
+    padding-bottom: 20px;
+
+    &::-webkit-scrollbar {
+        width: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: rgba($background-dark, 0.5);
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: rgba($primary, 0.5);
+        border-radius: 3px;
+
+        &:hover {
+            background: $primary;
+        }
+    }
+}
+
+.rank-badge {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: rgba($text, 0.5);
+    min-width: 28px;
+}
+
+.detail-item {
+    display: flex;
+    align-items: center;
+    padding: 16px;
+    background: $background-dark;
+    border-radius: 10px;
+    border: 1px solid rgba($border, 0.3);
+    gap: 14px;
+    cursor: pointer;
+    transition: all 0.25s ease;
+
+    &:hover {
+        border-color: rgba($primary, 0.6);
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    }
+
+    &.selected {
+        border-color: $primary;
+        background: rgba(104, 159, 56, 0.12);
+        box-shadow: 0 0 0 1px rgba($primary, 0.4);
+    }
+}
+
+.item-color-dot {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    border: 2px solid rgba(255, 255, 255, 0.15);
+}
+
+.item-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    gap: 2px;
+}
+
+.item-name {
+    font-size: 1rem;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.item-qty {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: $text-secondary;
+}
+
+.item-amount {
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: #8BC34A;
+    white-space: nowrap;
+}
+
+.nivel-badge {
+    display: inline-block;
+    width: fit-content;
+    font-size: 0.65rem;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-weight: 600;
+    margin-top: 2px;
+
+    &.nivel-alto {
+        background: rgba(104, 159, 56, 0.25);
+        color: #8BC34A;
+    }
+
+    &.nivel-medio {
+        background: rgba(255, 152, 0, 0.2);
+        color: $warning;
+    }
+
+    &.nivel-bajo {
+        background: rgba(244, 67, 54, 0.2);
+        color: $warn;
+    }
+}
+
+.no-data-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 48px;
+    color: $text-secondary;
+
+    mat-icon {
+        font-size: 48px;
+        width: 48px;
+        height: 48px;
+    }
+}
+
+@media (max-width: 1200px) {
+    .charts-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .stats-row {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 700px) {
+    .details-list {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/app/modules/grafico/analisis-producto/analisis-producto.component.ts
+++ b/src/app/modules/grafico/analisis-producto/analisis-producto.component.ts
@@ -1,0 +1,731 @@
+import { Component, OnInit, ChangeDetectionStrategy, inject, ChangeDetectorRef } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { EChartsOption } from 'echarts';
+import {
+  BehaviorSubject, Observable, combineLatest, startWith, debounceTime,
+  switchMap, distinctUntilChanged, tap, map, of, catchError, forkJoin
+} from 'rxjs';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { ProductoVendidoEstadistica } from '../models/producto-vendido-estadistica.model';
+import { ProductoVentaPorPeriodo } from '../models/producto-venta-periodo.model';
+import { ProductoCompraPorPeriodo } from '../models/producto-compra-periodo.model';
+import { Sucursal } from '../../empresarial/sucursal/sucursal.model';
+import { Familia } from '../../productos/familia/familia.model';
+import { MatDialog } from '@angular/material/dialog';
+import { GraficoService } from '../grafico.service';
+import { Producto } from '../../productos/producto/producto.model';
+import {
+  PdvSearchProductoData,
+  PdvSearchProductoDialogComponent,
+  PdvSearchProductoResponseData
+} from '../../productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component';
+import { dateToString } from '../../../commons/core/utils/dateUtils';
+
+type ModoRanking = 'mas' | 'menos';
+type NivelVenta = 'alto' | 'medio' | 'bajo';
+type VistaTemporal = 'dia' | 'mes';
+
+interface ProductoDetalle {
+  productoId: string;
+  descripcion: string;
+  cantidad: number;
+  totalMonto: number;
+  cantidadFormateada: string;
+  montoFormateado: string;
+  porcentaje: number;
+  nivel: NivelVenta;
+  nivelLabel: string;
+  color: string;
+  rank: number;
+}
+
+interface VistaAnalisis {
+  rankingOptions: EChartsOption;
+  temporalOptions: EChartsOption;
+  productos: ProductoDetalle[];
+  productoSeleccionado: ProductoDetalle | null;
+  promedioPeriodo: string;
+  periodoPico: string;
+  labelPeriodoPico: string;
+  hayDatos: boolean;
+  tituloRanking: string;
+}
+
+interface RangoFechas {
+  inicio: string;
+  fin: string;
+  inicioDate: Date;
+  finDate: Date;
+}
+
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'analisis-producto',
+  templateUrl: './analisis-producto.component.html',
+  styleUrls: ['./analisis-producto.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'analisis-producto-host' }
+})
+export class AnalisisProductoComponent implements OnInit {
+
+  private graficoService = inject(GraficoService);
+  private dialog = inject(MatDialog);
+  private cdr = inject(ChangeDetectorRef);
+
+  private datosSubject = new BehaviorSubject<VistaAnalisis | null>(null);
+  datos$: Observable<VistaAnalisis | null> = this.datosSubject.asObservable();
+
+  private sucursalesSubject = new BehaviorSubject<Sucursal[]>([]);
+  sucursales$: Observable<Sucursal[]> = this.sucursalesSubject.asObservable();
+
+  private familiasSubject = new BehaviorSubject<Familia[]>([]);
+  familias$: Observable<Familia[]> = this.familiasSubject.asObservable();
+
+  cargando = false;
+
+  private productoSeleccionadoId: string | null = null;
+  private ultimoRango: RangoFechas | null = null;
+
+  sucursalControl = new FormControl<number | null>(null);
+  familiaControl = new FormControl<number | null>(null);
+  limitControl = new FormControl<number>(15);
+  modoControl = new FormControl<ModoRanking>('mas');
+  vistaTemporalControl = new FormControl<VistaTemporal>('dia');
+  anhoControl = new FormControl<number>(new Date().getFullYear());
+  productosFiltro: Producto[] = [];
+
+  anhos: number[] = [];
+  minFechaAnho = new Date(new Date().getFullYear(), 0, 1);
+  maxFechaAnho = new Date();
+
+  private ajustandoRango = false;
+
+  fechaRangoGroup = new FormGroup({
+    inicio: new FormControl<Date | null>(null),
+    fin: new FormControl<Date | null>(null)
+  });
+
+  limits = [10, 15, 20, 30, 50, 75, 100];
+  modos: { valor: ModoRanking; label: string }[] = [
+    { valor: 'mas', label: 'Más vendidos' },
+    { valor: 'menos', label: 'Menos vendidos' }
+  ];
+  vistasTemporales: { valor: VistaTemporal; label: string }[] = [
+    { valor: 'dia', label: 'Por día' },
+    { valor: 'mes', label: 'Por mes' }
+  ];
+
+  meses = [
+    { valor: 1, nombre: 'Enero' }, { valor: 2, nombre: 'Febrero' }, { valor: 3, nombre: 'Marzo' },
+    { valor: 4, nombre: 'Abril' }, { valor: 5, nombre: 'Mayo' }, { valor: 6, nombre: 'Junio' },
+    { valor: 7, nombre: 'Julio' }, { valor: 8, nombre: 'Agosto' }, { valor: 9, nombre: 'Septiembre' },
+    { valor: 10, nombre: 'Octubre' }, { valor: 11, nombre: 'Noviembre' }, { valor: 12, nombre: 'Diciembre' }
+  ];
+
+  private colores = {
+    text: '#E0E0E0',
+    textSecondary: '#9E9E9E',
+    primary: '#689F38',
+    accent: '#009688',
+    warn: '#F44336',
+    warning: '#FF9800'
+  };
+
+  private paleta = ['#689F38', '#009688', '#FF9800', '#2196F3', '#4DB6AC', '#E91E63', '#9C27B0', '#00BCD4'];
+
+  ngOnInit(): void {
+    this.inicializarAnhos();
+    this.inicializarRangoPorDefecto();
+    this.configurarSincronizacionAnho();
+    this.cargarMetadata();
+    this.configurarDataStream();
+  }
+
+  private inicializarAnhos(): void {
+    const anhoActual = new Date().getFullYear();
+    this.anhos = Array.from({ length: 5 }, (_, i) => anhoActual - i);
+  }
+
+  private inicializarRangoPorDefecto(): void {
+    const hoy = new Date();
+    const anho = hoy.getFullYear();
+    this.anhoControl.setValue(anho, { emitEvent: false });
+    this.actualizarLimitesAnho(anho);
+    const inicioMes = new Date(anho, hoy.getMonth(), 1);
+    this.ajustandoRango = true;
+    this.fechaRangoGroup.setValue({ inicio: inicioMes, fin: hoy }, { emitEvent: false });
+    this.ajustandoRango = false;
+  }
+
+  private configurarSincronizacionAnho(): void {
+    this.anhoControl.valueChanges.pipe(untilDestroyed(this)).subscribe(anho => {
+      if (this.ajustandoRango || anho == null) return;
+      this.ajustarRangoPorAnho(anho);
+    });
+
+    this.fechaRangoGroup.valueChanges.pipe(untilDestroyed(this)).subscribe(() => {
+      if (this.ajustandoRango) return;
+      this.syncAnhoDesdeRango();
+    });
+  }
+
+  private actualizarLimitesAnho(anho: number): void {
+    const hoy = new Date();
+    hoy.setHours(23, 59, 59, 999);
+    this.minFechaAnho = new Date(anho, 0, 1);
+    this.maxFechaAnho = anho === hoy.getFullYear() ? hoy : new Date(anho, 11, 31);
+  }
+
+  private ajustarRangoPorAnho(anho: number): void {
+    const hoy = new Date();
+    const inicio = new Date(anho, 0, 1);
+    const fin = anho === hoy.getFullYear() ? hoy : new Date(anho, 11, 31);
+    this.actualizarLimitesAnho(anho);
+    this.ajustandoRango = true;
+    this.fechaRangoGroup.setValue({ inicio, fin });
+    this.ajustandoRango = false;
+  }
+
+  private syncAnhoDesdeRango(): void {
+    const inicio = this.fechaRangoGroup.value.inicio;
+    if (!inicio) return;
+    const anho = inicio.getFullYear();
+    if (this.anhoControl.value === anho) {
+      this.actualizarLimitesAnho(anho);
+      return;
+    }
+    this.ajustandoRango = true;
+    this.anhoControl.setValue(anho, { emitEvent: false });
+    this.actualizarLimitesAnho(anho);
+    this.ajustandoRango = false;
+  }
+
+  abrirBusquedaProducto(): void {
+    const data: PdvSearchProductoData = {
+      mostrarOpciones: false,
+      mostrarStock: true,
+      conservarUltimaBusqueda: true,
+      modoSeleccionMultiple: true,
+      productosSeleccionados: [...this.productosFiltro]
+    };
+
+    this.dialog.open(PdvSearchProductoDialogComponent, {
+      data,
+      width: '75%',
+      height: '85%',
+      maxWidth: '95vw'
+    }).afterClosed().pipe(untilDestroyed(this)).subscribe((res: PdvSearchProductoResponseData) => {
+      if (res?.productos?.length) {
+        this.aplicarProductosFiltro(res.productos);
+      }
+    });
+  }
+
+  aplicarProductosFiltro(productos: Producto[]): void {
+    this.productosFiltro = productos || [];
+    this.productoSeleccionadoId = this.productosFiltro.length > 0
+      ? String(this.productosFiltro[0].id)
+      : null;
+    this.cargarTodo();
+  }
+
+  quitarProductoFiltro(producto: Producto): void {
+    this.productosFiltro = this.productosFiltro.filter(p => p.id !== producto.id);
+    if (this.productoSeleccionadoId === String(producto.id)) {
+      this.productoSeleccionadoId = this.productosFiltro.length > 0
+        ? String(this.productosFiltro[0].id)
+        : null;
+    }
+    this.cargarTodo();
+  }
+
+  limpiarProductosFiltro(): void {
+    this.productosFiltro = [];
+    this.productoSeleccionadoId = null;
+    this.cargarTodo();
+  }
+
+  get etiquetaProductosFiltro(): string {
+    if (this.productosFiltro.length === 0) return 'Todos los productos';
+    if (this.productosFiltro.length === 1) return this.productosFiltro[0].descripcion;
+    return `${this.productosFiltro.length} productos seleccionados`;
+  }
+
+  private cargarMetadata(): void {
+    this.graficoService.obtenerSucursales().pipe(
+      untilDestroyed(this),
+      map(sucs => (sucs || []).filter(s => s.activo && s.id > 0 && s.id !== 999)),
+      catchError(() => of([]))
+    ).subscribe(sucs => this.sucursalesSubject.next(sucs));
+
+    this.graficoService.obtenerFamilias().pipe(
+      untilDestroyed(this),
+      catchError(() => of([]))
+    ).subscribe(fams => this.familiasSubject.next(fams));
+  }
+
+  private configurarDataStream(): void {
+    combineLatest([
+      this.sucursalControl.valueChanges.pipe(startWith(this.sucursalControl.value)),
+      this.familiaControl.valueChanges.pipe(startWith(this.familiaControl.value)),
+      this.limitControl.valueChanges.pipe(startWith(this.limitControl.value)),
+      this.modoControl.valueChanges.pipe(startWith(this.modoControl.value)),
+      this.fechaRangoGroup.valueChanges.pipe(startWith(this.fechaRangoGroup.value)),
+      this.vistaTemporalControl.valueChanges.pipe(startWith(this.vistaTemporalControl.value))
+    ]).pipe(
+      debounceTime(400),
+      untilDestroyed(this)
+    ).subscribe(() => this.cargarTodo());
+  }
+
+  seleccionarProducto(productoId: string): void {
+    this.productoSeleccionadoId = productoId;
+    this.recargarTemporal();
+  }
+
+  onChartClick(event: any): void {
+    const nombre = event?.name;
+    if (!nombre) return;
+    const datos = this.datosSubject.value;
+    const producto = datos?.productos.find(p =>
+      p.descripcion === nombre || this.truncar(p.descripcion, 28) === nombre
+    );
+    if (producto) {
+      this.seleccionarProducto(producto.productoId);
+    }
+  }
+
+  private obtenerRangoFechas(): RangoFechas | null {
+    const inicio = this.fechaRangoGroup.value.inicio;
+    const fin = this.fechaRangoGroup.value.fin;
+    if (!inicio || !fin) return null;
+
+    const inicioDate = new Date(inicio);
+    const finDate = new Date(fin);
+    inicioDate.setHours(0, 0, 0, 0);
+    finDate.setHours(0, 0, 0, 0);
+
+    if (finDate < inicioDate) return null;
+
+    const finExclusive = new Date(finDate);
+    finExclusive.setDate(finExclusive.getDate() + 1);
+
+    return {
+      inicio: `${dateToString(inicioDate, 'yyyy-MM-dd')} 00:00:00`,
+      fin: `${dateToString(finExclusive, 'yyyy-MM-dd')} 00:00:00`,
+      inicioDate,
+      finDate
+    };
+  }
+
+  private cargarTodo(): void {
+    const rango = this.obtenerRangoFechas();
+    if (!rango) return;
+
+    this.ultimoRango = rango;
+    this.cargando = true;
+    this.cdr.markForCheck();
+
+    const sucId = this.sucursalControl.value || undefined;
+    const famId = this.familiaControl.value || undefined;
+    const limit = this.limitControl.value || 15;
+    const modo = this.modoControl.value || 'mas';
+    const productoIdsFiltro = this.productosFiltro.map(p => p.id);
+    const ascendente = modo === 'menos';
+
+    this.graficoService.obtenerProductosMasVendidos(
+      rango.inicio, rango.fin, sucId, famId, limit, ascendente, undefined,
+      productoIdsFiltro.length > 0 ? productoIdsFiltro : undefined
+    ).pipe(
+      catchError(() => of([])),
+      untilDestroyed(this)
+    ).subscribe(productos => {
+      const lista = productos || [];
+      const idValido = this.productoSeleccionadoId
+        && lista.some(p => String(p.productoId) === this.productoSeleccionadoId);
+      const idTemporal = idValido
+        ? this.productoSeleccionadoId
+        : (lista.length > 0 ? String(lista[0].productoId) : null);
+
+      this.productoSeleccionadoId = idTemporal;
+
+      if (!idTemporal) {
+        this.finalizarCarga(lista, [], [], modo, null, rango);
+        return;
+      }
+
+      this.cargarVentasPeriodo(idTemporal, rango, lista, modo);
+    });
+  }
+
+  private recargarTemporal(): void {
+    const datos = this.datosSubject.value;
+    const rango = this.ultimoRango || this.obtenerRangoFechas();
+    if (!rango || !this.productoSeleccionadoId || !datos) return;
+
+    this.cargando = true;
+    this.cdr.markForCheck();
+
+    const productosRaw = datos.productos.map(p => ({
+      productoId: p.productoId,
+      descripcion: p.descripcion,
+      cantidad: p.cantidad,
+      totalMonto: p.totalMonto,
+      porcentaje: p.porcentaje
+    } as ProductoVendidoEstadistica));
+
+    this.cargarVentasPeriodo(
+      this.productoSeleccionadoId,
+      rango,
+      productosRaw,
+      this.modoControl.value || 'mas'
+    );
+  }
+
+  private cargarVentasPeriodo(
+    productoId: string,
+    rango: RangoFechas,
+    productos: ProductoVendidoEstadistica[],
+    modo: ModoRanking
+  ): void {
+    const sucId = this.sucursalControl.value || undefined;
+    const vista = this.vistaTemporalControl.value || 'dia';
+    const ventasReq = vista === 'mes'
+      ? this.graficoService.obtenerVentasProductoPorMes(rango.inicio, rango.fin, Number(productoId), sucId)
+      : this.graficoService.obtenerVentasProductoPorDia(rango.inicio, rango.fin, Number(productoId), sucId);
+    const comprasReq = vista === 'mes'
+      ? this.graficoService.obtenerComprasProductoPorMes(rango.inicio, rango.fin, Number(productoId), sucId)
+      : this.graficoService.obtenerComprasProductoPorDia(rango.inicio, rango.fin, Number(productoId), sucId);
+
+    forkJoin({
+      ventas: ventasReq.pipe(catchError(() => of([] as ProductoVentaPorPeriodo[]))),
+      compras: comprasReq.pipe(catchError(() => of([] as ProductoCompraPorPeriodo[])))
+    }).pipe(untilDestroyed(this)).subscribe(({ ventas, compras }) => {
+      this.finalizarCarga(productos, ventas || [], compras || [], modo, productoId, rango);
+    });
+  }
+
+  private finalizarCarga(
+    productos: ProductoVendidoEstadistica[],
+    ventasPeriodo: ProductoVentaPorPeriodo[],
+    comprasPeriodo: ProductoCompraPorPeriodo[],
+    modo: ModoRanking,
+    productoId: string | null,
+    rango: RangoFechas
+  ): void {
+    this.cargando = false;
+    const vista = this.vistaTemporalControl.value || 'dia';
+    this.actualizarVista(productos, ventasPeriodo, comprasPeriodo, modo, productoId, vista, rango);
+  }
+
+  private actualizarVista(
+    estadisticas: ProductoVendidoEstadistica[],
+    ventasPeriodo: ProductoVentaPorPeriodo[],
+    comprasPeriodo: ProductoCompraPorPeriodo[],
+    modo: ModoRanking,
+    productoId: string | null,
+    vistaTemporal: VistaTemporal,
+    rango: RangoFechas
+  ): void {
+    const vista = this.construirVista(estadisticas, ventasPeriodo, comprasPeriodo, modo, productoId, vistaTemporal, rango);
+    this.datosSubject.next(vista);
+    this.cdr.markForCheck();
+  }
+
+  private construirVista(
+    estadisticas: ProductoVendidoEstadistica[],
+    ventasPeriodo: ProductoVentaPorPeriodo[],
+    comprasPeriodo: ProductoCompraPorPeriodo[],
+    modo: ModoRanking,
+    productoId: string | null,
+    vistaTemporal: VistaTemporal,
+    rango: RangoFechas
+  ): VistaAnalisis {
+    const validas = (estadisticas || []).filter(e => e.cantidad > 0);
+    const maxCantidad = validas.length > 0 ? Math.max(...validas.map(e => e.cantidad)) : 0;
+
+    const productos: ProductoDetalle[] = validas.map((e, i) => {
+      const nivel = this.calcularNivel(e.cantidad, maxCantidad);
+      return {
+        productoId: String(e.productoId),
+        descripcion: e.descripcion,
+        cantidad: e.cantidad,
+        totalMonto: e.totalMonto,
+        cantidadFormateada: `${e.cantidad.toLocaleString('es-PY')} unidades`,
+        montoFormateado: `₲ ${e.totalMonto.toLocaleString('es-PY')}`,
+        porcentaje: e.porcentaje,
+        nivel,
+        nivelLabel: nivel === 'alto' ? 'Alta rotación' : nivel === 'medio' ? 'Rotación media' : 'Baja rotación',
+        color: this.paleta[i % this.paleta.length],
+        rank: i + 1
+      };
+    });
+
+    const productoSeleccionado = productos.find(p => p.productoId === productoId) || productos[0] || null;
+    const tituloRanking = modo === 'mas' ? 'Productos con mayor venta' : 'Productos con menor venta';
+
+    return {
+      rankingOptions: this.buildRankingChart(productos, tituloRanking, modo),
+      ...this.buildTemporalChart(ventasPeriodo, comprasPeriodo, productoSeleccionado?.descripcion || 'Producto', vistaTemporal, rango),
+      productos,
+      productoSeleccionado,
+      hayDatos: productos.length > 0,
+      tituloRanking
+    };
+  }
+
+  private calcularNivel(cantidad: number, max: number): NivelVenta {
+    if (max <= 0) return 'bajo';
+    const ratio = cantidad / max;
+    if (ratio >= 0.66) return 'alto';
+    if (ratio >= 0.33) return 'medio';
+    return 'bajo';
+  }
+
+  private buildRankingChart(productos: ProductoDetalle[], titulo: string, modo: ModoRanking): EChartsOption {
+    const nombres = [...productos].reverse().map(p => this.truncar(p.descripcion, 28));
+    const cantidades = [...productos].reverse().map(p => p.cantidad);
+    const colores = [...productos].reverse().map(p => {
+      if (modo === 'menos') return this.colores.warn;
+      return p.nivel === 'alto' ? this.colores.primary : p.nivel === 'medio' ? this.colores.warning : this.colores.textSecondary;
+    });
+
+    return {
+      title: {
+        text: titulo,
+        subtext: 'Cantidad vendida en el período',
+        left: 'center',
+        textStyle: { color: this.colores.text, fontSize: 16, fontWeight: 'bold' },
+        subtextStyle: { color: this.colores.textSecondary, fontSize: 11 }
+      },
+      tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+      grid: { left: '28%', right: '8%', bottom: '8%', top: '18%' },
+      xAxis: { type: 'value', axisLabel: { color: this.colores.textSecondary }, splitLine: { lineStyle: { color: '#444' } } },
+      yAxis: {
+        type: 'category',
+        data: nombres,
+        axisLabel: { color: this.colores.textSecondary, fontSize: 10 }
+      },
+      series: [{
+        name: 'Cantidad',
+        type: 'bar',
+        data: cantidades.map((v, i) => ({ value: v, itemStyle: { color: colores[i], borderRadius: [0, 4, 4, 0] } }))
+      }]
+    };
+  }
+
+  private buildTemporalChart(
+    ventasPeriodo: ProductoVentaPorPeriodo[],
+    comprasPeriodo: ProductoCompraPorPeriodo[],
+    nombreProducto: string,
+    vistaTemporal: VistaTemporal,
+    rango: RangoFechas
+  ): Pick<VistaAnalisis, 'temporalOptions' | 'promedioPeriodo' | 'periodoPico' | 'labelPeriodoPico'> {
+    const serie = vistaTemporal === 'mes'
+      ? this.prepararSerieMensual(ventasPeriodo, comprasPeriodo, rango)
+      : this.prepararSerieDiaria(ventasPeriodo, comprasPeriodo, rango);
+
+    const { etiquetas, cantidades, montos, tooltips, comprasCantidades, comprasCount } = serie;
+    const diasConVenta = cantidades.filter(c => c > 0).length;
+    const totalCant = cantidades.reduce((s, v) => s + v, 0);
+    const promedio = diasConVenta > 0 ? totalCant / diasConVenta : 0;
+    const maxIdx = cantidades.length > 0 ? cantidades.indexOf(Math.max(...cantidades)) : -1;
+    const periodoPico = maxIdx >= 0 && cantidades[maxIdx] > 0 ? etiquetas[maxIdx] : '-';
+    const unidadPromedio = vistaTemporal === 'mes' ? 'uds/mes' : 'uds/día con venta';
+    const tituloEvolucion = vistaTemporal === 'mes' ? 'Evolución mensual' : 'Evolución diaria';
+    const rotar = etiquetas.length > 14;
+
+    const temporalOptions: EChartsOption = {
+      title: {
+        text: `${tituloEvolucion}: ${this.truncar(nombreProducto, 35)}`,
+        subtext: `Del ${etiquetas[0] || '-'} al ${etiquetas[etiquetas.length - 1] || '-'}`,
+        left: 'center',
+        textStyle: { color: this.colores.text, fontSize: 14, fontWeight: 'bold' },
+        subtextStyle: { color: this.colores.textSecondary, fontSize: 11 }
+      },
+      tooltip: {
+        trigger: 'axis',
+        formatter: (params: any) => {
+          const idx = params[0]?.dataIndex ?? 0;
+          const ventas = cantidades[idx] || 0;
+          const compras = comprasCantidades[idx] || 0;
+          const nCompras = comprasCount[idx] || 0;
+          let html = `<strong>${tooltips[idx]}</strong><br/>
+            Ventas: ${ventas.toLocaleString('es-PY')} uds<br/>
+            Monto ventas: ₲ ${(montos[idx] || 0).toLocaleString('es-PY')}`;
+          if (compras > 0 || nCompras > 0) {
+            html += `<br/>Compras: ${compras.toLocaleString('es-PY')} uds`;
+            html += `<br/>Recepciones: ${nCompras}`;
+          }
+          return html;
+        }
+      },
+      legend: { data: ['Ventas', 'Compras', 'Promedio ventas'], bottom: 0, textStyle: { color: this.colores.textSecondary, fontSize: 10 } },
+      grid: { left: '3%', right: '4%', bottom: rotar ? '22%' : '14%', top: '20%', containLabel: true },
+      xAxis: {
+        type: 'category',
+        data: etiquetas,
+        axisLabel: {
+          color: this.colores.textSecondary,
+          rotate: rotar ? 45 : 0,
+          fontSize: 9,
+          interval: this.calcularIntervaloEtiquetas(etiquetas.length)
+        },
+        axisLine: { lineStyle: { color: '#555' } }
+      },
+      yAxis: {
+        type: 'value',
+        axisLabel: { color: this.colores.textSecondary },
+        splitLine: { lineStyle: { color: '#444' } }
+      },
+      series: [
+        {
+          name: 'Ventas',
+          type: 'bar',
+          data: cantidades.map((v, i) => {
+            const tieneCompra = (comprasCantidades[i] || 0) > 0 || (comprasCount[i] || 0) > 0;
+            return {
+              value: v,
+              itemStyle: {
+                color: tieneCompra
+                  ? { type: 'linear', x: 0, y: 0, x2: 0, y2: 1, colorStops: [{ offset: 0, color: '#7E57C2' }, { offset: 1, color: '#512DA8' }] }
+                  : { type: 'linear', x: 0, y: 0, x2: 0, y2: 1, colorStops: [{ offset: 0, color: this.colores.accent }, { offset: 1, color: '#00796B' }] },
+                borderRadius: [4, 4, 0, 0]
+              }
+            };
+          })
+        },
+        {
+          name: 'Compras',
+          type: 'bar',
+          data: comprasCantidades,
+          itemStyle: { color: '#FF9800', borderRadius: [4, 4, 0, 0] }
+        },
+        {
+          name: 'Promedio ventas',
+          type: 'line',
+          data: cantidades.map(() => promedio),
+          smooth: true,
+          symbol: 'none',
+          lineStyle: { color: this.colores.warning, type: 'dashed', width: 2 }
+        }
+      ]
+    };
+
+    return {
+      temporalOptions,
+      promedioPeriodo: `${promedio.toFixed(1)} ${unidadPromedio}`,
+      periodoPico,
+      labelPeriodoPico: vistaTemporal === 'mes' ? 'Mes con más ventas' : 'Día con más ventas'
+    };
+  }
+
+  private prepararSerieDiaria(ventas: ProductoVentaPorPeriodo[], compras: ProductoCompraPorPeriodo[], rango: RangoFechas) {
+    const mapaVentas = new Map<string, { cantidad: number; monto: number }>();
+    for (const v of ventas) {
+      const key = this.normalizarFechaPeriodo(v.periodo);
+      mapaVentas.set(key, { cantidad: v.cantidad, monto: v.totalMonto });
+    }
+    const mapaCompras = new Map<string, { cantidad: number; cantidadCompras: number }>();
+    for (const c of compras) {
+      const key = this.normalizarFechaPeriodo(c.periodo);
+      mapaCompras.set(key, { cantidad: c.cantidad, cantidadCompras: c.cantidadCompras });
+    }
+
+    const etiquetas: string[] = [];
+    const tooltips: string[] = [];
+    const cantidades: number[] = [];
+    const montos: number[] = [];
+    const comprasCantidades: number[] = [];
+    const comprasCount: number[] = [];
+    const cursor = new Date(rango.inicioDate);
+
+    while (cursor <= rango.finDate) {
+      const key = dateToString(cursor, 'yyyy-MM-dd');
+      const dia = String(cursor.getDate()).padStart(2, '0');
+      const mes = String(cursor.getMonth() + 1).padStart(2, '0');
+      etiquetas.push(`${dia}/${mes}`);
+      tooltips.push(`${dia}/${mes}/${cursor.getFullYear()}`);
+      const d = mapaVentas.get(key);
+      const c = mapaCompras.get(key);
+      cantidades.push(d?.cantidad || 0);
+      montos.push(d?.monto || 0);
+      comprasCantidades.push(c?.cantidad || 0);
+      comprasCount.push(c?.cantidadCompras || 0);
+      cursor.setDate(cursor.getDate() + 1);
+    }
+
+    return { etiquetas, cantidades, montos, tooltips, comprasCantidades, comprasCount };
+  }
+
+  private prepararSerieMensual(ventas: ProductoVentaPorPeriodo[], compras: ProductoCompraPorPeriodo[], rango: RangoFechas) {
+    const mapaVentas = new Map<string, { cantidad: number; monto: number }>();
+    for (const v of ventas) {
+      mapaVentas.set(v.periodo, { cantidad: v.cantidad, monto: v.totalMonto });
+    }
+    const mapaCompras = new Map<string, { cantidad: number; cantidadCompras: number }>();
+    for (const c of compras) {
+      mapaCompras.set(c.periodo, { cantidad: c.cantidad, cantidadCompras: c.cantidadCompras });
+    }
+
+    const etiquetas: string[] = [];
+    const tooltips: string[] = [];
+    const cantidades: number[] = [];
+    const montos: number[] = [];
+    const comprasCantidades: number[] = [];
+    const comprasCount: number[] = [];
+    const cursor = new Date(rango.inicioDate.getFullYear(), rango.inicioDate.getMonth(), 1);
+    const finMes = new Date(rango.finDate.getFullYear(), rango.finDate.getMonth(), 1);
+
+    while (cursor <= finMes) {
+      const key = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, '0')}`;
+      const nombreMes = this.meses[cursor.getMonth()]?.nombre?.substring(0, 3) || key;
+      etiquetas.push(`${nombreMes} ${cursor.getFullYear()}`);
+      tooltips.push(`${this.meses[cursor.getMonth()]?.nombre} ${cursor.getFullYear()}`);
+      const d = mapaVentas.get(key);
+      const c = mapaCompras.get(key);
+      cantidades.push(d?.cantidad || 0);
+      montos.push(d?.monto || 0);
+      comprasCantidades.push(c?.cantidad || 0);
+      comprasCount.push(c?.cantidadCompras || 0);
+      cursor.setMonth(cursor.getMonth() + 1);
+    }
+
+    return { etiquetas, cantidades, montos, tooltips, comprasCantidades, comprasCount };
+  }
+
+  private normalizarFechaPeriodo(periodo: string): string {
+    if (!periodo) return '';
+    const texto = periodo.substring(0, 10);
+    if (/^\d{4}-\d{2}-\d{2}$/.test(texto)) return texto;
+    const d = new Date(periodo);
+    if (!isNaN(d.getTime())) return dateToString(d, 'yyyy-MM-dd');
+    return texto;
+  }
+
+  private calcularIntervaloEtiquetas(total: number): number | 'auto' {
+    if (total <= 15) return 0;
+    if (total <= 31) return 1;
+    if (total <= 60) return 2;
+    return Math.floor(total / 20);
+  }
+
+  private truncar(texto: string, max: number): string {
+    return texto.length > max ? texto.substring(0, max - 2) + '…' : texto;
+  }
+
+  trackByProductoId(_: number, item: ProductoDetalle): string {
+    return item.productoId;
+  }
+
+  limpiarFiltros(): void {
+    this.sucursalControl.setValue(null);
+    this.familiaControl.setValue(null);
+    this.limitControl.setValue(15);
+    this.modoControl.setValue('mas');
+    this.vistaTemporalControl.setValue('dia');
+    this.limpiarProductosFiltro();
+    this.inicializarRangoPorDefecto();
+    this.cargarTodo();
+  }
+}

--- a/src/app/modules/grafico/grafico.service.ts
+++ b/src/app/modules/grafico/grafico.service.ts
@@ -16,6 +16,12 @@ import { GastosPorCategoriaGQL } from './graphql/gastos-por-categoria.gql';
 import { VentasPorMesGQL } from './graphql/ventas-por-mes.gql';
 import { GastosPorMesGQL } from './graphql/gastos-por-mes.gql';
 import { VentasPorSucursalGQL } from './graphql/ventas-por-sucursal.gql';
+import { VentasProductoPorDiaGQL } from './graphql/ventas-producto-por-dia.gql';
+import { VentasProductoPorMesGQL } from './graphql/ventas-producto-por-mes.gql';
+import { ComprasProductoPorDiaGQL } from './graphql/compras-producto-por-dia.gql';
+import { ComprasProductoPorMesGQL } from './graphql/compras-producto-por-mes.gql';
+import { ProductoVentaPorPeriodo } from './models/producto-venta-periodo.model';
+import { ProductoCompraPorPeriodo } from './models/producto-compra-periodo.model';
 
 @Injectable({
   providedIn: 'root'
@@ -34,6 +40,10 @@ export class GraficoService {
   private ventasPorMesGQL = inject(VentasPorMesGQL);
   private gastosPorMesGQL = inject(GastosPorMesGQL);
   private ventasPorSucursalGQL = inject(VentasPorSucursalGQL);
+  private ventasProductoPorDiaGQL = inject(VentasProductoPorDiaGQL);
+  private ventasProductoPorMesGQL = inject(VentasProductoPorMesGQL);
+  private comprasProductoPorDiaGQL = inject(ComprasProductoPorDiaGQL);
+  private comprasProductoPorMesGQL = inject(ComprasProductoPorMesGQL);
 
   obtenerSucursales(): Observable<Sucursal[]> {
     return this.sucursalService.onGetAllSucursales(true);
@@ -63,13 +73,16 @@ export class GraficoService {
     );
   }
 
-  obtenerProductosMasVendidos(inicio: string, fin: string, sucId?: number, familiaId?: number, limit: number = 10): Observable<any[]> {
+  obtenerProductosMasVendidos(inicio: string, fin: string, sucId?: number, familiaId?: number, limit: number = 10, ascendente: boolean = false, productoId?: number, productoIds?: number[]): Observable<any[]> {
+    const ids = productoIds?.length ? productoIds.map(id => String(id)) : null;
     return this.genericService.onCustomQuery(
       this.productosMasVendidosGQL,
       {
-        inicio, fin, limit,
+        inicio, fin, limit, ascendente,
         sucursalId: sucId ? String(sucId) : null,
-        familiaId: familiaId ? String(familiaId) : null
+        familiaId: familiaId ? String(familiaId) : null,
+        productoId: productoId ? String(productoId) : null,
+        productoIds: ids
       },
       true,
       null,
@@ -126,6 +139,62 @@ export class GraficoService {
     return this.genericService.onCustomQuery(
       this.gastosPorMesGQL,
       { anio, sucId: sucId ? String(sucId) : null },
+      true,
+      null,
+      true
+    );
+  }
+
+  obtenerVentasProductoPorDia(inicio: string, fin: string, productoId: number, sucId?: number): Observable<ProductoVentaPorPeriodo[]> {
+    return this.genericService.onCustomQuery(
+      this.ventasProductoPorDiaGQL,
+      {
+        inicio, fin,
+        productoId: String(productoId),
+        sucursalId: sucId ? String(sucId) : null
+      },
+      true,
+      null,
+      true
+    );
+  }
+
+  obtenerVentasProductoPorMes(inicio: string, fin: string, productoId: number, sucId?: number): Observable<ProductoVentaPorPeriodo[]> {
+    return this.genericService.onCustomQuery(
+      this.ventasProductoPorMesGQL,
+      {
+        inicio, fin,
+        productoId: String(productoId),
+        sucursalId: sucId ? String(sucId) : null
+      },
+      true,
+      null,
+      true
+    );
+  }
+
+  obtenerComprasProductoPorDia(inicio: string, fin: string, productoId: number, sucId?: number): Observable<ProductoCompraPorPeriodo[]> {
+    return this.genericService.onCustomQuery(
+      this.comprasProductoPorDiaGQL,
+      {
+        inicio, fin,
+        productoId: String(productoId),
+        sucursalId: sucId ? String(sucId) : null
+      },
+      true,
+      null,
+      true
+    );
+  }
+
+  obtenerComprasProductoPorMes(inicio: string, fin: string, productoId: number, sucId?: number): Observable<ProductoCompraPorPeriodo[]> {
+    return this.genericService.onCustomQuery(
+      this.comprasProductoPorMesGQL,
+      {
+        inicio, fin,
+        productoId: String(productoId),
+        sucursalId: sucId ? String(sucId) : null
+      },
       true,
       null,
       true

--- a/src/app/modules/grafico/graficos.module.ts
+++ b/src/app/modules/grafico/graficos.module.ts
@@ -6,10 +6,12 @@ import { MaterialModule } from '../../commons/core/material.module';
 import { SharedModule } from '../../shared/shared.module';
 import { NgxEchartsModule } from 'ngx-echarts';
 import { GraficosRoutingModule } from './graficos-routing.module';
+import { ProductoModule } from '../productos/productos.module';
 
 import { VentaFuncionarioComponent } from './venta-funcionario/venta-funcionario.component';
 import { FormaPagoComponent } from './forma-pago/forma-pago.component';
 import { ProductoVendidoComponent } from './producto-vendido/producto-vendido.component';
+import { AnalisisProductoComponent } from './analisis-producto/analisis-producto.component';
 import { VentasDiasComponent } from './ventas-dias/ventas-dias.component';
 import { GastoCategoriaComponent } from './gasto-categoria/gasto-categoria.component';
 import { IngresoGastoComponent } from './ingreso-gasto/ingreso-gasto.component';
@@ -45,6 +47,7 @@ export function loadEcharts() {
         VentaFuncionarioComponent,
         FormaPagoComponent,
         ProductoVendidoComponent,
+        AnalisisProductoComponent,
         VentasDiasComponent,
         GastoCategoriaComponent,
         IngresoGastoComponent,
@@ -56,6 +59,7 @@ export function loadEcharts() {
         ReactiveFormsModule,
         MaterialModule,
         SharedModule,
+        ProductoModule,
         GraficosRoutingModule,
         NgxEchartsModule.forRoot({
             echarts: loadEcharts

--- a/src/app/modules/grafico/graficos/graficos.component.html
+++ b/src/app/modules/grafico/graficos/graficos.component.html
@@ -36,5 +36,9 @@
     <div class="chart-card clickable" (click)="onChartClick('productos')">
       <div echarts [options]="productosMasVendidosOptions" class="chart"></div>
     </div>
+
+    <div class="chart-card clickable" (click)="onChartClick('analisis-producto')">
+      <div echarts [options]="analisisProductoOptions" class="chart"></div>
+    </div>
   </div>
 </div>

--- a/src/app/modules/grafico/graficos/graficos.component.ts
+++ b/src/app/modules/grafico/graficos/graficos.component.ts
@@ -3,6 +3,7 @@ import { EChartsOption } from 'echarts';
 import { TabService } from '../../../layouts/tab/tab.service';
 import { Tab } from '../../../layouts/tab/tab.model';
 import { ProductoVendidoComponent } from '../producto-vendido/producto-vendido.component';
+import { AnalisisProductoComponent } from '../analisis-producto/analisis-producto.component';
 
 import { FormaPagoComponent } from '../forma-pago/forma-pago.component';
 import { VentaFuncionarioComponent } from '../venta-funcionario/venta-funcionario.component';
@@ -53,6 +54,7 @@ export class GraficosComponent implements OnInit, AfterViewInit {
     ventasHoraOptions: EChartsOption = {};
     ventasFuncionarioOptions: EChartsOption = {};
     productosMasVendidosOptions: EChartsOption = {};
+    analisisProductoOptions: EChartsOption = {};
 
     constructor() { }
 
@@ -79,6 +81,9 @@ export class GraficosComponent implements OnInit, AfterViewInit {
         switch (type) {
             case 'productos':
                 this.tabService.addTab(new Tab(ProductoVendidoComponent, 'Productos Vendidos', null, null));
+                break;
+            case 'analisis-producto':
+                this.tabService.addTab(new Tab(AnalisisProductoComponent, 'Análisis de Productos', null, null));
                 break;
 
             case 'pago':
@@ -370,25 +375,70 @@ export class GraficosComponent implements OnInit, AfterViewInit {
         });
 
 
-        this.productosMasVendidosOptions = {
-            title: {
-                text: 'Top Productos Más Vendidos',
-                left: 'center',
-                textStyle: { color: this.colores.text, fontSize: 14, fontWeight: 'bold' }
-            },
-            legend: { bottom: 5, textStyle: { color: this.colores.textSecondary, fontSize: 10 } },
-            grid: { left: '20%', right: '4%', bottom: '18%', top: '15%' },
-            xAxis: { type: 'value' },
-            yAxis: {
-                type: 'category',
-                data: ['Cerveza Brahma 1L', 'Coca Cola 2L', 'Hielo 5kg', 'Cerveza Pilsen Lata', 'Agua Mineral 500ml', 'Gaseosa Pepsi 2L', 'Vino Tinto 750ml', 'Cerveza Corona', 'Energizante Red Bull', 'Whisky J. Walker']
-            },
-            series: [
-                { name: 'Canindeyu 1', type: 'bar', stack: 'total', data: [1250, 980, 850, 720, 650, 580, 420, 380, 320, 280] },
-                { name: 'Curuguaty 2', type: 'bar', stack: 'total', data: [980, 1100, 720, 650, 580, 490, 380, 290, 250, 180] },
-                { name: 'Renacer', type: 'bar', stack: 'total', data: [720, 650, 920, 480, 420, 380, 290, 250, 180, 150] }
-            ]
-        };
+        const mesActual = new Date();
+        const fechaInicioProd = `${mesActual.getFullYear()}-${String(mesActual.getMonth() + 1).padStart(2, '0')}-01 00:00:00`;
+        const fechaFinMes = new Date(mesActual.getFullYear(), mesActual.getMonth() + 1, 1);
+        const fechaFinProd = `${fechaFinMes.getFullYear()}-${String(fechaFinMes.getMonth() + 1).padStart(2, '0')}-01 00:00:00`;
+
+        this.graficoService.obtenerProductosMasVendidos(fechaInicioProd, fechaFinProd, undefined, undefined, 5, false)
+            .subscribe(productos => {
+                const lista = (productos || []).slice(0, 5).reverse();
+                const nombres = lista.map((p: any) => p.descripcion?.length > 18 ? p.descripcion.substring(0, 16) + '…' : p.descripcion);
+                const cantidades = lista.map((p: any) => p.cantidad);
+
+                this.productosMasVendidosOptions = {
+                    title: {
+                        text: 'Top Productos Más Vendidos',
+                        left: 'center',
+                        textStyle: { color: this.colores.text, fontSize: 14, fontWeight: 'bold' }
+                    },
+                    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+                    grid: { left: '28%', right: '8%', bottom: '8%', top: '18%' },
+                    xAxis: { type: 'value', axisLabel: { color: this.colores.textSecondary, fontSize: 9 } },
+                    yAxis: {
+                        type: 'category',
+                        data: nombres.length ? nombres : ['Sin datos'],
+                        axisLabel: { color: this.colores.textSecondary, fontSize: 9 }
+                    },
+                    series: [{
+                        name: 'Cantidad',
+                        type: 'bar',
+                        data: cantidades.length ? cantidades : [0],
+                        itemStyle: { color: this.colores.primary, borderRadius: [0, 4, 4, 0] }
+                    }]
+                };
+            });
+
+        this.graficoService.obtenerProductosMasVendidos(fechaInicioProd, fechaFinProd, undefined, undefined, 5, true)
+            .subscribe(productos => {
+                const lista = (productos || []).slice(0, 5).reverse();
+                const nombres = lista.map((p: any) => p.descripcion?.length > 16 ? p.descripcion.substring(0, 14) + '…' : p.descripcion);
+                const cantidades = lista.map((p: any) => p.cantidad);
+
+                this.analisisProductoOptions = {
+                    title: {
+                        text: 'Análisis de Productos',
+                        subtext: 'Menor rotación del mes',
+                        left: 'center',
+                        textStyle: { color: this.colores.text, fontSize: 14, fontWeight: 'bold' },
+                        subtextStyle: { color: this.colores.textSecondary, fontSize: 10 }
+                    },
+                    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+                    grid: { left: '28%', right: '8%', bottom: '12%', top: '22%' },
+                    xAxis: { type: 'value', axisLabel: { color: this.colores.textSecondary, fontSize: 9 } },
+                    yAxis: {
+                        type: 'category',
+                        data: nombres.length ? nombres : ['Sin datos'],
+                        axisLabel: { color: this.colores.textSecondary, fontSize: 9 }
+                    },
+                    series: [{
+                        name: 'Cantidad',
+                        type: 'bar',
+                        data: cantidades.length ? cantidades : [0],
+                        itemStyle: { color: this.colores.warn, borderRadius: [0, 4, 4, 0] }
+                    }]
+                };
+            });
     }
 
 }

--- a/src/app/modules/grafico/graphql/compras-producto-por-dia.gql.ts
+++ b/src/app/modules/grafico/graphql/compras-producto-por-dia.gql.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import gql from 'graphql-tag';
+import { ProductoCompraPorPeriodo } from '../models/producto-compra-periodo.model';
+
+export interface Response {
+  data: ProductoCompraPorPeriodo[];
+}
+
+const comprasProductoPorDiaQuery = gql`
+  query comprasProductoPorDia($inicio: String, $fin: String, $productoId: ID!, $sucursalId: ID) {
+    data: comprasProductoPorDia(inicio: $inicio, fin: $fin, productoId: $productoId, sucursalId: $sucursalId) {
+      periodo
+      cantidad
+      cantidadCompras
+    }
+  }
+`;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ComprasProductoPorDiaGQL extends Query<Response> {
+  document = comprasProductoPorDiaQuery;
+}

--- a/src/app/modules/grafico/graphql/compras-producto-por-mes.gql.ts
+++ b/src/app/modules/grafico/graphql/compras-producto-por-mes.gql.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import gql from 'graphql-tag';
+import { ProductoCompraPorPeriodo } from '../models/producto-compra-periodo.model';
+
+export interface Response {
+  data: ProductoCompraPorPeriodo[];
+}
+
+const comprasProductoPorMesQuery = gql`
+  query comprasProductoPorMes($inicio: String, $fin: String, $productoId: ID!, $sucursalId: ID) {
+    data: comprasProductoPorMes(inicio: $inicio, fin: $fin, productoId: $productoId, sucursalId: $sucursalId) {
+      periodo
+      cantidad
+      cantidadCompras
+    }
+  }
+`;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ComprasProductoPorMesGQL extends Query<Response> {
+  document = comprasProductoPorMesQuery;
+}

--- a/src/app/modules/grafico/graphql/productos-mas-vendidos.gql.ts
+++ b/src/app/modules/grafico/graphql/productos-mas-vendidos.gql.ts
@@ -8,8 +8,8 @@ export interface Response {
 }
 
 const productosMasVendidosQuery = gql`
-  query productosMasVendidos($inicio: String, $fin: String, $limit: Int, $sucursalId: ID, $familiaId: ID) {
-    data: productosMasVendidos(inicio: $inicio, fin: $fin, limit: $limit, sucursalId: $sucursalId, familiaId: $familiaId) {
+  query productosMasVendidos($inicio: String, $fin: String, $limit: Int, $sucursalId: ID, $familiaId: ID, $ascendente: Boolean, $productoId: ID, $productoIds: [ID]) {
+    data: productosMasVendidos(inicio: $inicio, fin: $fin, limit: $limit, sucursalId: $sucursalId, familiaId: $familiaId, ascendente: $ascendente, productoId: $productoId, productoIds: $productoIds) {
       productoId
       descripcion
       cantidad

--- a/src/app/modules/grafico/graphql/ventas-producto-por-dia.gql.ts
+++ b/src/app/modules/grafico/graphql/ventas-producto-por-dia.gql.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import gql from 'graphql-tag';
+import { ProductoVentaPorPeriodo } from '../models/producto-venta-periodo.model';
+
+export interface Response {
+  data: ProductoVentaPorPeriodo[];
+}
+
+const ventasProductoPorDiaQuery = gql`
+  query ventasProductoPorDia($inicio: String, $fin: String, $productoId: ID!, $sucursalId: ID) {
+    data: ventasProductoPorDia(inicio: $inicio, fin: $fin, productoId: $productoId, sucursalId: $sucursalId) {
+      periodo
+      cantidad
+      totalMonto
+    }
+  }
+`;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class VentasProductoPorDiaGQL extends Query<Response> {
+  document = ventasProductoPorDiaQuery;
+}

--- a/src/app/modules/grafico/graphql/ventas-producto-por-mes.gql.ts
+++ b/src/app/modules/grafico/graphql/ventas-producto-por-mes.gql.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import gql from 'graphql-tag';
+import { ProductoVentaPorPeriodo } from '../models/producto-venta-periodo.model';
+
+export interface Response {
+  data: ProductoVentaPorPeriodo[];
+}
+
+const ventasProductoPorMesQuery = gql`
+  query ventasProductoPorMes($inicio: String, $fin: String, $productoId: ID!, $sucursalId: ID) {
+    data: ventasProductoPorMes(inicio: $inicio, fin: $fin, productoId: $productoId, sucursalId: $sucursalId) {
+      periodo
+      cantidad
+      totalMonto
+    }
+  }
+`;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class VentasProductoPorMesGQL extends Query<Response> {
+  document = ventasProductoPorMesQuery;
+}

--- a/src/app/modules/grafico/models/producto-compra-periodo.model.ts
+++ b/src/app/modules/grafico/models/producto-compra-periodo.model.ts
@@ -1,0 +1,5 @@
+export interface ProductoCompraPorPeriodo {
+  periodo: string;
+  cantidad: number;
+  cantidadCompras: number;
+}

--- a/src/app/modules/grafico/models/producto-venta-periodo.model.ts
+++ b/src/app/modules/grafico/models/producto-venta-periodo.model.ts
@@ -1,0 +1,5 @@
+export interface ProductoVentaPorPeriodo {
+    periodo: string;
+    cantidad: number;
+    totalMonto: number;
+}

--- a/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.css
+++ b/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.css
@@ -24,6 +24,23 @@
   margin: 0;
 }
 
+.tr.mat-mdc-row.row-seleccionada,
+tr.mat-row.row-seleccionada {
+  background-color: rgba(104, 159, 56, 0.2) !important;
+}
+
+.footer-buttons {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.apply-btn {
+  margin-right: auto;
+}
+
 .header-section .dialog-title {
   margin: 0;
   font-size: 1.8rem;

--- a/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.html
+++ b/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.html
@@ -82,6 +82,18 @@
               multiTemplateDataRows
               class="mat-elevation-z8"
             >
+              <ng-container matColumnDef="seleccion" *ngIf="modoSeleccionMultiple">
+                <th mat-header-cell *matHeaderCellDef style="width: 48px; text-align: center"></th>
+                <td mat-cell *matCellDef="let producto" style="text-align: center">
+                  <mat-checkbox
+                    [checked]="isSeleccionado(producto)"
+                    (click)="$event.stopPropagation()"
+                    (change)="toggleSeleccion(producto)"
+                    color="primary">
+                  </mat-checkbox>
+                </td>
+              </ng-container>
+
               <ng-container matColumnDef="id">
                 <th mat-header-cell *matHeaderCellDef>Id</th>
                 <td mat-cell *matCellDef="let producto">{{ producto.id }}</td>
@@ -361,11 +373,8 @@
                 #tableRows
                 mat-row
                 *matRowDef="let row; columns: displayedColumns; let i = dataIndex"
-                (click)="
-                  expandedProducto = null;
-                  highlight(i);
-                  tableKeyDownEvent('Enter', i)
-                "
+                [class.row-seleccionada]="modoSeleccionMultiple && isSeleccionado(row)"
+                (click)="onFilaClick(row, i)"
                 tabindex="999"
                 (keydown)="tableKeyDownEvent($event.key, selectedRowIndex); $event.stopPropagation(); $event.preventDefault();"
               ></tr>
@@ -396,11 +405,20 @@
   <!-- Footer Section -->
   <div class="footer-section">
     <div class="footer-buttons">
-      <button 
-        mat-button 
-        (click)="dialogRef.close()" 
-        class="exit-btn"
-      >
+      <button
+        *ngIf="modoSeleccionMultiple"
+        mat-raised-button
+        color="primary"
+        (click)="aplicarSeleccionMultiple()"
+        [disabled]="cantidadSeleccionados() === 0"
+        class="apply-btn">
+        <mat-icon>check</mat-icon>
+        Aplicar filtro ({{ cantidadSeleccionados() }})
+      </button>
+      <button
+        mat-button
+        (click)="dialogRef.close()"
+        class="exit-btn">
         <mat-icon>close</mat-icon>
         Salir
       </button>

--- a/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.ts
+++ b/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.ts
@@ -53,13 +53,16 @@ export interface PdvSearchProductoData {
   costo?: boolean;
   transferencia?: Transferencia;
   servidor?: boolean;
+  modoSeleccionMultiple?: boolean;
+  productosSeleccionados?: Producto[];
 }
 
 export interface PdvSearchProductoResponseData {
-  producto: Producto;
-  presentacion: Presentacion;
+  producto?: Producto;
+  presentacion?: Presentacion;
   precio?: PrecioPorSucursal;
   cantidad?: number;
+  productos?: Producto[];
 }
 
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
@@ -121,6 +124,8 @@ export class PdvSearchProductoDialogComponent implements OnInit, AfterViewInit {
   isTransferencia: boolean = false;
   existenciaOrigen: number = 0;
   existenciaDestino: number = 0;
+  modoSeleccionMultiple = false;
+  productosSeleccionadosMap = new Map<number, Producto>();
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: PdvSearchProductoData,
@@ -154,6 +159,15 @@ export class PdvSearchProductoDialogComponent implements OnInit, AfterViewInit {
   ngOnInit(): void {
     console.log('Iniciando dialogo de busqueda de producto');
     this.dataSource = new MatTableDataSource<Producto>([]);
+    this.modoSeleccionMultiple = !!this.data?.modoSeleccionMultiple;
+
+    if (this.modoSeleccionMultiple) {
+      this.displayedColumns = ['seleccion', ...this.displayedColumns.filter(c => c !== 'acciones')];
+      (this.data.productosSeleccionados || []).forEach(p => {
+        if (p?.id) this.productosSeleccionadosMap.set(p.id, p);
+      });
+    }
+
     this.createForm();
 
     this.productoDetailList = [];
@@ -262,9 +276,42 @@ export class PdvSearchProductoDialogComponent implements OnInit, AfterViewInit {
   highlight(index: number) {
     if (index >= 0 && index <= this.dataSource.data.length - 1) {
       this.selectedRowIndex = index;
-      // this.expandedProducto = this.dataSource.data[index];
-      // this.getProductoDetail(this.expandedProducto, index);
     }
+  }
+
+  toggleSeleccion(producto: Producto, event?: Event): void {
+    event?.stopPropagation();
+    if (!producto?.id) return;
+    if (this.productosSeleccionadosMap.has(producto.id)) {
+      this.productosSeleccionadosMap.delete(producto.id);
+    } else {
+      this.productosSeleccionadosMap.set(producto.id, producto);
+    }
+    this.cdr.markForCheck();
+  }
+
+  isSeleccionado(producto: Producto): boolean {
+    return producto?.id != null && this.productosSeleccionadosMap.has(producto.id);
+  }
+
+  cantidadSeleccionados(): number {
+    return this.productosSeleccionadosMap.size;
+  }
+
+  aplicarSeleccionMultiple(): void {
+    const productos = Array.from(this.productosSeleccionadosMap.values());
+    this.dialogRef.close({ productos } as PdvSearchProductoResponseData);
+  }
+
+  onFilaClick(producto: Producto, index: number): void {
+    if (this.modoSeleccionMultiple) {
+      this.toggleSeleccion(producto);
+      this.highlight(index);
+      return;
+    }
+    this.expandedProducto = null;
+    this.highlight(index);
+    this.tableKeyDownEvent('Enter', index);
   }
 
   highlightPresentacion(index: number) {


### PR DESCRIPTION
## Summary
- Agrega el componente `analisis-producto` con ranking, evolución temporal (día/mes), ventas y compras en el gráfico.
- Integra queries GraphQL de ventas y compras por periodo, y extiende `productosMasVendidos`.
- Mejora `PdvSearchProductoDialog` con selección múltiple para filtrar varios productos.
- Filtros: más/menos vendidos, año, rango de fechas, sucursal, familia y top configurable.

## Contributors
- [@Diego777rey](https://github.com/Diego777rey)
- [@cursoragent](https://github.com/cursoragent)

Made with [@Diego777rey](https://github.com/Diego777rey) and [@cursoragent](https://github.com/cursoragent).

## Test plan
- [ ] Ejecutar `npm run check` sin errores AOT.
- [ ] Abrir Gráficos > Análisis de Productos y validar carga de ranking y evolución.
- [ ] Probar filtros de año, periodo, sucursal, familia y selección múltiple de productos.
- [ ] Verificar barras de ventas (verde/violeta) y compras (naranja) con backend actualizado.
- [ ] Confirmar vista por día y por mes.

## Dependencias
- Requiere merge del PR backend: https://github.com/GabFrank/franco-system-backend-servidor/pull/78