### PR TITLE
feat(funcionarios): permitir ver foto de perfil ampliada al hacer clic

### DIFF
--- a/src/app/modules/personas/funcionarios/adicionar-funcionario-dialog/adicionar-funcionario-dialog.component.html
+++ b/src/app/modules/personas/funcionarios/adicionar-funcionario-dialog/adicionar-funcionario-dialog.component.html
@@ -206,11 +206,10 @@
         <div fxFlex="30" fxLayout="column" fxLayoutAlign="center center">
           <img
             fxFlex="90"
-            [src]="
-              selectedFuncionario?.imagenPrincipal != null
-                ? selectedFuncionario.imagenPrincipal
-                : 'assets/avatar-3x4.png'
-            "
+            [src]="fotoPerfilUrl"
+            [class.foto-clickeable]="tieneFotoPerfil"
+            [matTooltip]="tieneFotoPerfil ? 'Ver foto ampliada' : ''"
+            (click)="onVerFotoPerfil($event)"
             style="height: 100%; object-fit: contain"
           />
           <div
@@ -299,4 +298,28 @@
       (clickEvent)="onSave()"
     ></app-boton>
   </div>
+</div>
+
+<div
+  *ngIf="fotoAmpliada"
+  class="foto-overlay"
+  (click)="cerrarFotoAmpliada()"
+  role="dialog"
+  aria-label="Foto de perfil ampliada"
+>
+  <button
+    type="button"
+    class="foto-overlay-cerrar"
+    mat-icon-button
+    aria-label="Cerrar"
+    (click)="cerrarFotoAmpliada(); $event.stopPropagation()"
+  >
+    <mat-icon>close</mat-icon>
+  </button>
+  <img
+    class="foto-overlay-imagen"
+    [src]="fotoPerfilUrl"
+    [alt]="'Foto de perfil de ' + (selectedPersona?.nombre || 'funcionario')"
+    (click)="$event.stopPropagation()"
+  />
 </div>

--- a/src/app/modules/personas/funcionarios/adicionar-funcionario-dialog/adicionar-funcionario-dialog.component.scss
+++ b/src/app/modules/personas/funcionarios/adicionar-funcionario-dialog/adicionar-funcionario-dialog.component.scss
@@ -5,3 +5,33 @@
 :host::ng-deep.mat-mdc-form-field-text-prefix  {
     width: 100% !important;
 }
+
+.foto-clickeable {
+    cursor: zoom-in;
+}
+
+.foto-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.85);
+    padding: 24px;
+}
+
+.foto-overlay-imagen {
+    max-width: min(90vw, 600px);
+    max-height: 85vh;
+    object-fit: contain;
+    border-radius: 4px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.foto-overlay-cerrar {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    color: #fff;
+}

--- a/src/app/modules/personas/funcionarios/adicionar-funcionario-dialog/adicionar-funcionario-dialog.component.ts
+++ b/src/app/modules/personas/funcionarios/adicionar-funcionario-dialog/adicionar-funcionario-dialog.component.ts
@@ -69,6 +69,15 @@ export class AdicionarFuncionarioDialogComponent implements OnInit {
   marcacionesDataSource = new MatTableDataSource<Marcacion>([])
 
   currencyMask = new CurrencyMask();
+  fotoAmpliada = false;
+
+  get fotoPerfilUrl(): string {
+    return this.selectedFuncionario?.imagenPrincipal ?? 'assets/avatar-3x4.png';
+  }
+
+  get tieneFotoPerfil(): boolean {
+    return !!this.selectedFuncionario?.imagenPrincipal;
+  }
 
   constructor(
     private sucursalService: SucursalService,
@@ -293,6 +302,17 @@ export class AdicionarFuncionarioDialogComponent implements OnInit {
 
   onCancel() {
     this.matDialogRef.close()
+  }
+
+  onVerFotoPerfil(event: Event): void {
+    event.stopPropagation();
+    if (this.tieneFotoPerfil) {
+      this.fotoAmpliada = true;
+    }
+  }
+
+  cerrarFotoAmpliada(): void {
+    this.fotoAmpliada = false;
   }
 
   onEditarPersona() {


### PR DESCRIPTION
## Summary
- Al hacer clic en la foto de perfil del funcionario en el modal de información, se abre una vista ampliada con overlay.
- Solo aplica cuando el funcionario tiene foto real (no el avatar por defecto).
- Se puede cerrar con clic fuera o con el botón cerrar.

## Test plan
- [ ] Abrir lista de funcionarios y editar uno con foto de perfil
- [ ] Hacer clic en la foto y verificar que se muestra ampliada
- [ ] Cerrar el overlay con el botón X y con clic fuera
- [ ] Verificar que un funcionario sin foto no abre el overlay al hacer clic