### PR TITLE
feat(productos): buscador inteligente con debounce en listado y barra global

### DIFF
--- a/src/app/modules/productos/producto/list-producto/list-producto.component.html
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.html
@@ -10,8 +10,15 @@
               <div>
                 <mat-form-field style="width: 100%">
                   <mat-label>Buscar producto</mat-label>
-                  <input #filtroProductoInput matInput type="text" [formControl]="filtroProductoControl"
-                    (keyup.enter)="onFiltrar()" (focusin)="filtroProductoInput.select()" />
+                  <input
+                    #filtroProductoInput
+                    matInput
+                    type="text"
+                    [formControl]="filtroProductoControl"
+                    (keyup.enter)="onFiltrar()"
+                    (focusin)="filtroProductoInput.select()"
+                    autocomplete="off"
+                  />
                 </mat-form-field>
               </div>
             </span>

--- a/src/app/modules/productos/producto/list-producto/list-producto.component.ts
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.ts
@@ -65,6 +65,7 @@ import { NotificacionSnackbarService } from "../../../../notificacion-snackbar.s
 import { GestionProveedoresProductoDialogComponent } from "../gestion-proveedores-producto-dialog/gestion-proveedores-producto-dialog.component";
 import { Familia } from "../../familia/familia.model";
 import { FamiliasSearchGQL } from "../../familia/graphql/familiasSearch";
+import { BuscadorTextoService } from "../../../../shared/services/buscador-texto.service";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -162,7 +163,8 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
     private movimientoStockService: MovimientoStockService,
     private thermalPrinterService: ThermalPrinterService,
     private snackBar: MatSnackBar,
-    private notificacionService: NotificacionSnackbarService
+    private notificacionService: NotificacionSnackbarService,
+    private buscadorTextoService: BuscadorTextoService
   ) {
     setTimeout(() => (this.service = injector.get(ProductoService)));
   }
@@ -176,6 +178,14 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
     this.stockFiltroControl.valueChanges.subscribe(() => {
       this.updateSucursalSelectEnabled();
     });
+
+    this.buscadorTextoService
+      .observarTexto(
+        this.filtroProductoControl,
+        () => this.filtroCodigoControl.value === true
+      )
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.onFiltrar());
   }
 
   ngAfterViewInit(): void {

--- a/src/app/shared/services/buscador-texto.service.ts
+++ b/src/app/shared/services/buscador-texto.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
+
+/**
+ * Utilidad genérica para búsqueda textual con debounce.
+ * No transforma el texto: el backend (Lucene) resuelve similitud y ranking.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class BuscadorTextoService {
+  readonly debounceMs = 400;
+
+  /**
+   * Emite cuando el usuario deja de escribir (solo modo texto, no código).
+   */
+  observarTexto(
+    control: FormControl<string | null>,
+    esBusquedaPorCodigo: () => boolean
+  ): Observable<void> {
+    return control.valueChanges.pipe(
+      debounceTime(this.debounceMs),
+      distinctUntilChanged(),
+      filter(() => !esBusquedaPorCodigo()),
+      map(() => void 0)
+    );
+  }
+}

--- a/src/app/shared/widgets/search-bar-dialog/search-bar-dialog.component.html
+++ b/src/app/shared/widgets/search-bar-dialog/search-bar-dialog.component.html
@@ -11,7 +11,6 @@
           type="text"
           matInput
           [formControl]="buscarControl"
-          (keyup)="onBuscar()"
           placeholder="Buscar listas, productos, reportes etc."
         />
         <span matTextPrefix style="padding-right: 20px">

--- a/src/app/shared/widgets/search-bar-dialog/search-bar-dialog.component.ts
+++ b/src/app/shared/widgets/search-bar-dialog/search-bar-dialog.component.ts
@@ -5,7 +5,11 @@ import { MainService } from '../../../main.service';
 import { NotificacionSnackbarService } from '../../../notificacion-snackbar.service';
 import { MatDialogRef } from '@angular/material/dialog';
 import { ROLES } from '../../../modules/personas/roles/roles.enum';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { BuscadorTextoService } from '../../services/buscador-texto.service';
+import { filter, switchMap, tap } from 'rxjs/operators';
 
+@UntilDestroy()
 @Component({
   selector: 'app-search-bar-dialog',
   templateUrl: './search-bar-dialog.component.html',
@@ -21,16 +25,50 @@ export class SearchBarDialogComponent implements OnInit {
     private searchBarService: SearchBarService,
     private matDialogRef: MatDialogRef<SearchBarDialogComponent>,
     private injector: Injector,
-    private notificacionService: NotificacionSnackbarService
-  ) {
-    setTimeout(() => this.mainService = injector.get(MainService));
-  }
+    private notificacionService: NotificacionSnackbarService,
+    private buscadorTextoService: BuscadorTextoService
+  ) {}
 
   ngOnInit(): void {
+    this.mainService = this.injector.get(MainService);
+
+    this.buscadorTextoService
+      .observarTexto(this.buscarControl, () => false)
+      .pipe(
+        tap(() => this.actualizarMenu()),
+        filter(() => !!this.buscarControl.value?.trim()),
+        switchMap(() =>
+          this.searchBarService.onSearch(this.buscarControl.value ?? '')
+        ),
+        untilDestroyed(this)
+      )
+      .subscribe((result) => {
+        this.searchDataList = {
+          componentes: this.searchBarService.filtrarComponentes(
+            this.buscarControl.value ?? ''
+          ),
+          productos: result.productos ?? [],
+        };
+      });
+
+    this.buscarControl.valueChanges
+      .pipe(untilDestroyed(this))
+      .subscribe((texto) => {
+        if (!texto?.trim()) {
+          this.searchDataList = { componentes: [], productos: [] };
+        } else {
+          this.actualizarMenu();
+        }
+      });
   }
 
-  async onBuscar() {
-    this.searchDataList = await this.searchBarService.onSearch(this.buscarControl.value)
+  private actualizarMenu(): void {
+    const texto = this.buscarControl.value ?? '';
+    const componentes = this.searchBarService.filtrarComponentes(texto);
+    this.searchDataList = {
+      componentes,
+      productos: this.searchDataList?.productos ?? [],
+    };
   }
 
   hasPermissionToAccess(item: SearchData): boolean {

--- a/src/app/shared/widgets/search-bar-dialog/search-bar.service.ts
+++ b/src/app/shared/widgets/search-bar-dialog/search-bar.service.ts
@@ -6,6 +6,8 @@ import { Tab } from './../../../layouts/tab/tab.model';
 import { TabData, TabService } from './../../../layouts/tab/tab.service';
 import { ListProductoComponent } from './../../../modules/productos/producto/list-producto/list-producto.component';
 import { Injectable, Type } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { comparatorLike } from '../../../commons/core/utils/string-utils';
 import { Producto } from '../../../modules/productos/producto/producto.model';
 import { EditTransferenciaComponent } from '../../../modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component';
@@ -16,12 +18,10 @@ import { ListCajaComponent } from '../../../modules/financiero/pdv/caja/list-caj
 import { ListSectorComponent } from '../../../modules/empresarial/sector/list-sector/list-sector.component';
 import { SolicitarRecursosDialogComponent } from '../../../modules/configuracion/solicitar-recursos-dialog/solicitar-recursos-dialog.component';
 import { ROLES } from '../../../modules/personas/roles/roles.enum';
-import { PrecioDelivery } from '../../../modules/operaciones/delivery/precio-delivery.model';
 import { PrecioDeliveryComponent } from '../../../modules/operaciones/delivery/precio-delivery/precio-delivery.component';
 import { ListClientesComponent } from '../../../modules/personas/clientes/list-clientes/list-clientes.component';
 import { ListRetiroComponent } from '../../../modules/financiero/retiro/list-retiro/list-retiro.component';
 import { ListGastosComponent } from '../../../modules/financiero/gastos/pages/list-gastos/list-gastos.component';
-import { LucroPorProducto } from '../../../modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.model';
 import { LucroPorProductoComponent } from '../../../modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component';
 
 export enum TIPO_SEARCH {
@@ -70,38 +70,35 @@ export class SearchBarService {
 
   searchDataList: SearchData[] = []
 
-  timer;
-
-  constructor(private tabService: TabService,
-    private productoService: ProductoService,
+  constructor(
+    private tabService: TabService,
+    private productoService: ProductoService
   ) { }
 
-  onSearch(texto): Promise<SearchDataResult> {
-    if (this.timer != null) {
-      clearTimeout(this.timer);
-    }
-    return new Promise((resolve, rejects) => {
-      let result = new SearchDataResult;
-      let componentes = componenteList.filter(e => comparatorLike(texto, e.title))
-      result.componentes = componentes;
-      let productoList: Producto[];
-      this.timer = setTimeout(() => {
-        this.productoService.onSearch(texto)
-          .pipe()
-          .subscribe(res => {
-            if (res != null) {
-              productoList = res;
-              result.productos = []
-              productoList.forEach(p => {
-                let item: SearchData = { title: p.descripcion, component: ProductoComponent, data: p }
-                result.productos.push(item)
-              })
-            }
-            return resolve(result);
-          })
-      }, 1000);
-    })
+  onSearch(texto: string): Observable<SearchDataResult> {
+    const result = new SearchDataResult();
+    result.productos = [];
 
+    if (!texto?.trim()) {
+      return of(result);
+    }
+
+    return this.productoService.onSearch(texto).pipe(
+      map((productoList) => {
+        if (productoList != null) {
+          result.productos = productoList.map((p) => ({
+            title: p.descripcion,
+            component: ProductoComponent,
+            data: p,
+          }));
+        }
+        return result;
+      })
+    );
+  }
+
+  filtrarComponentes(texto: string): SearchData[] {
+    return componenteList.filter((e) => comparatorLike(texto ?? '', e.title));
   }
 
   openTab(data: SearchData) {


### PR DESCRIPTION
## Summary
- Agrega `BuscadorTextoService` con debounce (400ms) para búsqueda textual; el backend Lucene resuelve similitud y ranking.
- Integra búsqueda con debounce en el listado de productos (solo modo texto, no por código).
- Refactoriza la barra de búsqueda global: RxJS en lugar de `keyup`/`setTimeout`, filtrado de componentes y productos vía API.

## Test plan
- [ ] Abrir lista de productos y buscar por descripción: debe filtrar tras dejar de escribir (~400ms), sin disparar en cada tecla.
- [ ] Activar búsqueda por código en listado: el debounce de texto no debe interferir; Enter sigue filtrando.
- [ ] Abrir barra de búsqueda global (Ctrl+K o atajo configurado): componentes filtran al escribir; productos aparecen tras debounce.
- [ ] Vaciar el campo: resultados de componentes y productos se limpian.
- [ ] Ejecutar `npm run check` antes de merge.


Made with [Cursor](https://cursor.com)