### PR TITLE
feat(transferencia): restringir ingreso de productos con stock negativo

### DIFF
--- a/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
@@ -1342,7 +1342,38 @@ export class EditTransferenciaComponent implements OnInit {
     return referencias.join(' | ');
   }
 
-  private onEjecutarGuardadoItem() {
+  onEjecutarGuardadoItem() {
+    if (this.selectedProducto == null) return;
+
+    const sucursalOrigenId = this.selectedTransferencia?.sucursalOrigen?.id;
+    const productoId = this.selectedProducto?.id;
+
+    if (productoId != null && sucursalOrigenId != null) {
+      this.cargandoService.openDialog(false, "Verificando stock...");
+      this.productoService.onGetStockPorProductoAndSucursal(productoId, sucursalOrigenId, true)
+        .subscribe({
+          next: (stock) => {
+            this.cargandoService.closeDialog();
+            if (stock != null && stock < 0) {
+              this.notificacionService.openWarn(
+                `El producto tiene stock negativo (${stock}) y no puede ser transferido.`
+              );
+              this.onClear();
+              return;
+            }
+            this.procederConGuardadoItem();
+          },
+          error: (err) => {
+            this.cargandoService.closeDialog();
+            this.notificacionService.openAlgoSalioMal("Error al verificar el stock del producto");
+          }
+        });
+    } else {
+      this.procederConGuardadoItem();
+    }
+  }
+
+  procederConGuardadoItem() {
     if (this.selectedTransferencia?.id != null) {
       this.cantidadPresentacionControl.enable();
       this.presentacionControl.enable();


### PR DESCRIPTION
## Que resuelve
Previene que se ingresen productos con stock negativo en las transferencias de mercadería. Al intentar agregar o editar un item en la transferencia, el sistema verifica asincrónicamente el stock actual del producto en la sucursal de origen. Si la existencia de stock es menor a cero, se bloquea la inserción, se limpia el formulario de carga y se muestra una advertencia en la interfaz de usuario que indica que el producto no puede ser transferido debido a su stock negativo.

## Como probarlo
1. Iniciar una nueva transferencia o abrir una transferencia existente en estado de edicion.
2. Identificar un producto que cuente con stock negativo (menor a cero) en la sucursal de origen seleccionada.
3. Intentar ingresar dicho producto utilizando el codigo de barra, o seleccionandolo desde el dialogo de busqueda de productos.
4. Definir una cantidad e intentar guardar el item (presionando enter o haciendo clic en el boton de guardar).
5. Confirmar que se bloquea la operacion, que el formulario de carga de productos se limpia y que aparece la notificacion de advertencia correspondiente.
6. Intentar el mismo proceso con un producto que tenga stock positivo o cero, y verificar que se agregue correctamente a la tabla de la transferencia.

## Impacto DB
No aplica. Los cambios corresponden a una validacion del lado del cliente en el frontend que utiliza una consulta de lectura existente en la API. No se modifican esquemas, tablas ni datos en la base de datos de forma directa mediante este cambio.

## Riesgo
Bajo. La logica de validacion es local al componente de edicion de transferencias y no altera metodos globales de busqueda de productos, servicios generales, ni otros modulos del sistema.
