### PR TITLE
feat(productos): mejora accesibilidad ui y seguridad

### DIFF
--- a/src/app/modules/productos/producto/list-producto/list-producto.component.html
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.html
@@ -208,11 +208,10 @@
           </mat-form-field>
         </div>
         <div fxFlex="50">
-          <mat-form-field style="width: 100%; padding-right: 10px;" 
-          [hidden]="!isSucursalSelectEnabled">
+          <mat-form-field style="width: 100%; padding-right: 10px;">
             <mat-label>Sucursal</mat-label>
             <mat-select [formControl]="sucursalFiltroControl">
-              <mat-option [value]="null">Seleccionar sucursal</mat-option>
+              <mat-option [value]="null">Todas las sucursales</mat-option>
               <mat-option *ngFor="let sucursal of sucursales" [value]="sucursal.id">
                 {{ sucursal.id }} - {{ sucursal.nombre }}
               </mat-option>
@@ -369,7 +368,7 @@
                 <!-- Show sucursal data when loaded -->
                 <div *ngIf="producto?.sucursales" fxLayout="column" style="width: 100%">
                   <div style="text-align: center; margin-bottom: 10px">
-                    {{ sucursalFiltroControl.value && isSucursalSelectEnabled ?
+                    {{ sucursalFiltroControl.value ?
                     'Stock en Sucursal Seleccionada' : 'Stock por Sucursal' }}
                   </div>
                   <div style="max-height: 425px; overflow-y: auto;">

--- a/src/app/modules/productos/producto/list-producto/list-producto.component.ts
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.ts
@@ -245,7 +245,8 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
     if (!isCurrentlyExpanded) {
       this.selectedProducto = row;
 
-      if (this.sucursalFiltroControl.value && this.isSucursalSelectEnabled) {
+      if (this.sucursalFiltroControl.value) {
+        // Hay sucursal seleccionada (ya sea con filtro positivo, negativo o todos)
         const sucursalSeleccionada = this.sucursales.find(s => s.id === this.sucursalFiltroControl.value);
         if (sucursalSeleccionada) {
           const existencia = new ExistenciaCostoPorSucursal();
@@ -461,15 +462,15 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
 
   cargarSucursales() {
     this.sucursalService.onGetAllSucursales(true).subscribe(res => {
-      this.sucursales = res?.filter(sucursal => 
-        sucursal.nombre != "SERVIDOR");
-    })
+      this.sucursales = res?.filter(sucursal => {
+        if (sucursal.nombre === 'SERVIDOR') return false;
+        if (sucursal.nombre === 'COMPRAS' && !this.puedeVerStockCompras) return false;
+        return true;
+      });
+    });
   }
 
   onStockFiltroChange() {
-    if (this.stockFiltroControl.value === 'todos') {
-      this.sucursalFiltroControl.setValue(null);
-    }
     this.updateSucursalSelectEnabled();
   }
 
@@ -512,8 +513,7 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
   }
 
   getSucursalPreseleccionada(): Sucursal | undefined {
-    if ((this.stockFiltroControl.value === 'positivo' || this.stockFiltroControl.value === 'negativo') 
-        && this.sucursalFiltroControl.value) {
+    if (this.sucursalFiltroControl.value) {
       return this.sucursales.find(s => s.id === this.sucursalFiltroControl.value);
     }
     return undefined;
@@ -587,7 +587,7 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
       subfamiliaId: this.selectedSubfamilia?.id || null,
       familiaId: this.selectedFamilia?.id || null,
       stockFiltro: this.stockFiltroControl.value !== 'todos' ? this.stockFiltroControl.value : null,
-      sucursalId: (this.sucursalFiltroControl.value && this.isSucursalSelectEnabled) ? this.sucursalFiltroControl.value : null,
+      sucursalId: this.sucursalFiltroControl.value ? this.sucursalFiltroControl.value : null,
       usuarioId: this.mainService.usuarioActual.id,
       usuario: this.mainService.usuarioActual.nickname || this.mainService.usuarioActual.persona?.nombre || 'Usuario'
     };


### PR DESCRIPTION
# Descripcion del Pull Request

## Que resuelve

Este cambio implementa una mejora de accesibilidad y usabilidad en la interfaz de listado de productos, y resuelve una brecha de seguridad relacionada con la visibilidad del stock de la sucursal de compras (COMPRAS) para usuarios sin los permisos adecuados.

### Mejoras de Interfaz (Frontend)
* Se permite que el campo Sucursal este visible e interactivo siempre, incluso cuando el filtro de Stock esta en Todos. Esto permite filtrar los productos con stock (positivo, negativo o cero) de una sucursal especifica.
* Se cambio el texto por defecto de Seleccionar sucursal a Todas las sucursales para mejorar la claridad.
* El panel expandido de cada producto ahora muestra unicamente la sucursal seleccionada en el filtro si esta activa, mejorando la visualizacion.
* Se restringe que la sucursal COMPRAS aparezca en el desplegable de filtros si el usuario logueado no posee el rol ADMIN o VER STOCK COMPRAS.

---

## Como probarlo

### Requisitos previos
Tener dos usuarios de prueba:
1. Usuario A: Posee el rol ADMIN o VER STOCK COMPRAS.
2. Usuario B: Un usuario con permisos basicos (sin los roles mencionados).

### Prueba 1: Visualizacion y filtros de sucursal
1. Iniciar sesion con el Usuario B.
2. Ir a la lista de productos. El campo Sucursal debe estar siempre visible, sin importar que el campo Stock figure en Todos.
3. Desplegar el selector de Sucursal y verificar que la sucursal COMPRAS no este disponible en el listado.
4. Seleccionar una sucursal visible (ej. Sucursal Central con ID 1) y filtrar. Deberia mostrar el stock tanto positivo como negativo solo para esa sucursal en el panel expandido del producto.

### Prueba 2: Generacion de Reportes y exclusion de stock
1. Con el Usuario B, realizar una busqueda general y hacer clic en Generar Pdf.
2. Comprobar el PDF generado: las cantidades de stock del listado y el stock total consolidado no deben sumar los movimientos ni el stock de la sucursal COMPRAS.
3. Repetir el proceso con el Usuario A. Verificar que este usuario si puede ver la sucursal COMPRAS en el desplegable de filtros y que, al generar el reporte general, las cantidades consolidadas si sumen la sucursal COMPRAS.

---

## Impacto DB
No aplica. No se modifico la estructura de la base de datos, solo se realizaron ajustes en las consultas logicamente controladas a nivel de servicio.

---

## Riesgo
Bajo. Las modificaciones estan acotadas a la consulta de busqueda filtrada de productos y al metodo de exportacion de reportes de stock. La correccion del metodo getRoles() reactiva la consulta correcta de roles asociados a los usuarios, la cual fallaba previamente.
