### PR TITLE
fix(facturacion): forzar seleccion iva en form + copiar iva al armar items desde venta

### DIFF
--- a/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
+++ b/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
@@ -204,6 +204,10 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
         facturaItem.total = v.cantidad * v.precio;
         facturaItem.presentacion = v.presentacion;
         facturaItem.producto = v.producto;
+        // Copiar iva del producto (o de la presentacion) al item.
+        // Antes se omitia y el dialog de item defaulteaba a 10, generando
+        // facturas con iva incorrecto cuando el producto era exento.
+        facturaItem.iva = v.producto?.iva ?? v.presentacion?.producto?.iva ?? null;
         facturaItemList.push(facturaItem);
       });
       this.cantidadHojas = Math.floor(facturaItemList.length / 7) + 1;

--- a/src/app/modules/financiero/factura-legal/edit-factura-legal-item/edit-factura-legal-item.component.ts
+++ b/src/app/modules/financiero/factura-legal/edit-factura-legal-item/edit-factura-legal-item.component.ts
@@ -25,7 +25,11 @@ export class EditFacturaLegalItemComponent implements OnInit {
   cantidadControl = new FormControl(1, Validators.required)
   precioUnitario = new FormControl(null, Validators.required)
   precioUnitarioExtranjero = new FormControl(null)
-  ivaControl = new FormControl(10, Validators.required)
+  // iva sin default: el usuario debe seleccionar explicitamente (0, 5 o 10).
+  // Validators.required + el botón Save ya esta deshabilitado cuando el form
+  // es invalido. Evita que el frontend envie iva=null al backend, lo que
+  // antes provocaba que items huerfanos cayeran al default 10 (sobre-declarando IVA).
+  ivaControl = new FormControl(null, Validators.required)
   unidadMedidaControl = new FormControl("Unidad", Validators.required)
   formGroup: FormGroup;
   isEditting = false;
@@ -151,7 +155,8 @@ export class EditFacturaLegalItemComponent implements OnInit {
     }
     this.actualizandoPrecioExtranjero = false;
     
-    this.ivaControl.setValue(this.selectedFacturaLegalItem.iva != null ? this.selectedFacturaLegalItem.iva : 10)
+    // Sin fallback a 10 — si el item viene sin iva, el usuario debe seleccionar.
+    this.ivaControl.setValue(this.selectedFacturaLegalItem.iva != null ? this.selectedFacturaLegalItem.iva : null)
     this.unidadMedidaControl.setValue(this.selectedFacturaLegalItem.unidadMedida || "Unidad")
     this.calcularTotales();
     this.formGroup.disable()


### PR DESCRIPTION
## Summary

El form de item de factura legal defaulteaba `iva=10` al crear nuevos items y al cargar items existentes sin iva. Esto enmascaraba el problema de iva incorrecto cuando el usuario tipeaba descripcion libre o cuando el item venia de un VentaItem sin que se copiase el iva del producto.

## Cambios

### `edit-factura-legal-item.component.ts`

- `ivaControl`: default `null` (no `10`). `Validators.required` + el boton Save ya deshabilita el form cuando es invalido, forzando al usuario a seleccionar 0/5/10.
- `cargarDatos`: eliminado fallback `: 10` cuando `item.iva` es null.

### `add-factura-legal-dialog.component.ts`

- `cargarDatos`: copiar `v.producto?.iva` (o `presentacion.producto.iva`) al `facturaItem.iva` al armar items desde `VentaItem`. Antes se omitia y el dialog de item caia al fallback default 10.

## Compatibilidad

- Backend nuevo (filial PR #47) tolera `iva=null` con cadena de fallback. Frontend nuevo nunca lo envia.
- Backend viejo (sin PR mergeado todavia): si el usuario selecciona iva valido (0/5/10), funciona igual.
- Frontend viejo en otros desktops: backend tolerante con log.warn.

## Relacionado

- PR filial: https://github.com/GabFrank/franco-system-backend-filial/pull/47
- PR central: https://github.com/GabFrank/franco-system-backend-servidor/pull/97

## Test plan

- [ ] `npm run check` OK
- [ ] Abrir dialog de item nuevo: campo IVA vacio, boton Save deshabilitado hasta seleccionar.
- [ ] Abrir factura legal desde PDV con items: cada item ya tiene iva del producto, dialog se abre con iva preseleccionado.
- [ ] Abrir factura legal con item legacy (sin iva en DB): campo IVA vacio, usuario debe elegir.
- [ ] Smoke: emitir factura legal estandar (con productos del catalogo), todo funciona como antes.