### PR TITLE
feat(productos): restringir costo en lista de productos

### DIFF
--- a/src/app/modules/productos/producto/list-producto/list-producto.component.html
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.html
@@ -265,16 +265,16 @@
           Costo medio
         </th>
         <td mat-cell *matCellDef="let producto" style="text-align: center">
-          {{ producto?.costo?.costoMedio | number : "1.0-0" }}
+          {{ puedeVerCostos ? (producto?.costo?.costoMedio | number : "1.0-0") : "-" }}
         </td>
       </ng-container>
-
+ 
       <ng-container matColumnDef="costoUltCompra">
         <th mat-header-cell *matHeaderCellDef style="text-align: center">
           Ult. costo
         </th>
         <td mat-cell *matCellDef="let producto" style="text-align: center">
-          {{ producto?.costo?.ultimoPrecioCompra | number : "1.0-0" }}
+          {{ puedeVerCostos ? (producto?.costo?.ultimoPrecioCompra | number : "1.0-0") : "-" }}
         </td>
       </ng-container>
 

--- a/src/app/modules/productos/producto/list-producto/list-producto.component.ts
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.ts
@@ -146,6 +146,7 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
   isAdicionarEnabled: boolean = false;
   isGenerarPdfDisabled: boolean = true;
   puedeVerStockCompras: boolean = false;
+  puedeVerCostos: boolean = false;
 
   constructor(
     private injector: Injector,
@@ -484,6 +485,10 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
     this.puedeVerStockCompras =
       this.mainService.usuarioActual?.roles?.includes(ROLES.ADMIN) ||
       this.mainService.usuarioActual?.roles?.includes(ROLES.VER_STOCK_COMPRAS) ||
+      false;
+    this.puedeVerCostos =
+      this.mainService.usuarioActual?.roles?.includes(ROLES.EDITAR_PRODUCTOS) ||
+      this.mainService.usuarioActual?.roles?.includes(ROLES.ADMIN) ||
       false;
   }
 


### PR DESCRIPTION
### Qué resuelve
Restringe la visualización de la información de costos en el listado de productos (específicamente las columnas de "Costo medio" y "Ult. costo"). A partir de esta modificación, solo los usuarios que posean los roles `ADMIN` o `EDITAR_PRODUCTOS` podrán ver los valores numéricos correspondientes. Los usuarios que no cuenten con estos roles verán un guion (-) en su lugar.

### Cómo probarlo

1. Inicie sesión en la aplicación con un usuario que no tenga asignados los roles `ADMIN` ni `EDITAR_PRODUCTOS`.
2. Diríjase a la sección del listado de productos y compruebe que en las columnas "Costo medio" y "Ult. costo" se muestra un guion (-) en lugar del valor numérico del costo.
3. Cierre sesión e ingrese con un usuario que sí cuente con el rol `ADMIN` o `EDITAR_PRODUCTOS`.
4. Vuelva al listado de productos y verifique que ahora sí se visualizan correctamente los valores de costo medio y último costo de compra.

### Impacto DB
No aplica. Es una modificación exclusiva de presentación en el frontend que reutiliza la lógica y los roles de usuario existentes.

### Riesgo
Bajo. El cambio está limitado únicamente a la lógica de visualización condicional dentro del componente de la tabla de productos en Angular.