### PR TITLE
Feat/gastos vincular activo

### DIFF
--- a/src/app/modules/financiero/gastos/dialogs/adicionar-gasto-dialog/adicionar-gasto-dialog.component.ts
+++ b/src/app/modules/financiero/gastos/dialogs/adicionar-gasto-dialog/adicionar-gasto-dialog.component.ts
@@ -44,7 +44,9 @@ import { NotificationHttpService } from "../../../../../shared/services/notifica
 import { TipoGasto } from "../../models/tipo-gasto.model";
 import { SearchListDialogComponent, SearchListtDialogData } from "../../../../../shared/components/search-list-dialog/search-list-dialog.component";
 import { TipoGastoSearchGQL } from "../../graphql/tipoGastosSearch";
-import { SolicitudGastoSimpleDialogComponent, SolicitudGastoSimpleData, SolicitudGastoSimpleResult } from "../solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component";
+import { SolicitudGastoSimpleDialogComponent } from "../solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component";
+import { SolicitudGastoSimpleData } from "../../interface/solicitud-gasto-simple-data.interface";
+import { SolicitudGastoSimpleResult } from "../../interface/solicitud-gasto-simple-result.interface";
 import { PreGasto, PreGastoInput } from "../../models/pre-gasto.model";
 @UntilDestroy({ checkProperties: true })
 @Component({

--- a/src/app/modules/financiero/gastos/dialogs/adicionar-gasto-dialog/adicionar-gasto-dialog.component.ts
+++ b/src/app/modules/financiero/gastos/dialogs/adicionar-gasto-dialog/adicionar-gasto-dialog.component.ts
@@ -355,6 +355,7 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
           data: {
             tipoGastoId: this.selectedTipoGasto.id,
             tipoGastoDescripcion: this.selectedTipoGasto.descripcion,
+            moduloPadre: this.selectedTipoGasto?.moduloPadre,
             requiereAutorizacion: this.selectedTipoGasto?.autorizacion === true,
             solicitanteId: this.selectedResponsable?.id,
             solicitanteNombre: this.selectedResponsable?.persona?.nombre
@@ -418,6 +419,7 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
       return;
     }
     input.tipoGastoId = res.tipoGastoId;
+    input.enteId = res.enteId ?? null;
     input.descripcion = res.descripcion;
     input.sucursalId = sucursalSolicitudId;
     input.funcionarioId = personaId;

--- a/src/app/modules/financiero/gastos/dialogs/solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component.html
+++ b/src/app/modules/financiero/gastos/dialogs/solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component.html
@@ -21,6 +21,32 @@
         </mat-form-field>
       </div>
 
+      <!-- Activo vinculado (vehículo, mueble o inmueble según módulo padre del tipo de gasto) -->
+      <ng-container *ngIf="requiereEnteActivo">
+        <div fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="start start">
+          <mat-form-field fxFlex="100%" class="beneficiario-bloqueado">
+            <mat-label>{{ etiquetaEnteActivo }}</mat-label>
+            <input
+              matInput
+              [formControl]="enteDisplayControl"
+              readonly
+              tabindex="-1"
+              [placeholder]="'Seleccione ' + (etiquetaEnteActivo | lowercase)"
+              required
+            />
+            <mat-icon matSuffix>{{ iconoEnteActivo }}</mat-icon>
+            <mat-error *ngIf="enteIdControl.hasError('required')">
+              Debe seleccionar {{ etiquetaEnteActivo | lowercase }}
+            </mat-error>
+          </mat-form-field>
+        </div>
+        <div fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px" class="beneficiario-acciones">
+          <button mat-stroked-button color="primary" type="button" (click)="abrirBuscadorEnteActivo()">
+            Buscar {{ etiquetaEnteActivo }}
+          </button>
+        </div>
+      </ng-container>
+
       <!-- Fila 2: Descripción -->
       <div fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="start start">
         <mat-form-field fxFlex="100%">

--- a/src/app/modules/financiero/gastos/dialogs/solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component.html
+++ b/src/app/modules/financiero/gastos/dialogs/solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component.html
@@ -31,18 +31,18 @@
               [formControl]="enteDisplayControl"
               readonly
               tabindex="-1"
-              [placeholder]="'Seleccione ' + (etiquetaEnteActivo | lowercase)"
+              [placeholder]="placeholderEnteActivo"
               required
             />
             <mat-icon matSuffix>{{ iconoEnteActivo }}</mat-icon>
-            <mat-error *ngIf="enteIdControl.hasError('required')">
-              Debe seleccionar {{ etiquetaEnteActivo | lowercase }}
+            <mat-error *ngIf="enteRequerido">
+              {{ mensajeErrorEnteActivo }}
             </mat-error>
           </mat-form-field>
         </div>
         <div fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px" class="beneficiario-acciones">
           <button mat-stroked-button color="primary" type="button" (click)="abrirBuscadorEnteActivo()">
-            Buscar {{ etiquetaEnteActivo }}
+            {{ textoBuscarEnteActivo }}
           </button>
         </div>
       </ng-container>
@@ -52,7 +52,7 @@
         <mat-form-field fxFlex="100%">
           <mat-label>Descripción del Gasto</mat-label>
           <input matInput [formControl]="descripcionControl" placeholder="Ingrese una descripción" required />
-          <mat-error *ngIf="descripcionControl.hasError('required')">
+          <mat-error *ngIf="descripcionRequerida">
             La descripción es requerida
           </mat-error>
         </mat-form-field>
@@ -65,30 +65,30 @@
           <input matInput [matDatepicker]="picker" [formControl]="vencimientoControl" required />
           <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
           <mat-datepicker #picker></mat-datepicker>
-          <mat-error *ngIf="vencimientoControl.hasError('required')">
+          <mat-error *ngIf="vencimientoRequerido">
             El vencimiento es requerido
           </mat-error>
         </mat-form-field>
       </div>
 
       <!-- Filas Moneda / Monto (múltiples) -->
-      <ng-container *ngFor="let fila of filasMonto.controls; let i = index; trackBy: trackByFilaMonto">
-        <div fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="start start" [formGroup]="$any(fila)">
+      <ng-container *ngFor="let fila of filasMontoView; let i = index">
+        <div fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="start start" [formGroup]="fila.grupo">
           <mat-form-field fxFlex="38%">
             <mat-label>Moneda</mat-label>
             <mat-select formControlName="monedaId" [attr.name]="'moneda-' + i" required>
               <mat-option
-                *ngFor="let moneda of listaMonedas"
-                [value]="moneda.id"
-                [disabled]="esMonedaOcupada(moneda.id, i)"
+                *ngFor="let opcion of fila.opcionesMoneda"
+                [value]="opcion.moneda.id"
+                [disabled]="opcion.deshabilitada"
               >
-                {{ moneda.denominacion }} ({{ moneda.simbolo }})
+                {{ opcion.moneda.denominacion }} ({{ opcion.moneda.simbolo }})
               </mat-option>
             </mat-select>
-            <mat-error *ngIf="fila.get('monedaId')?.hasError('required')">
+            <mat-error *ngIf="fila.errores.monedaRequerida">
               La moneda es requerida
             </mat-error>
-            <mat-error *ngIf="fila.get('monedaId')?.hasError('monedaDuplicada')">
+            <mat-error *ngIf="fila.errores.monedaDuplicada">
               Esta moneda ya fue seleccionada en otra línea
             </mat-error>
           </mat-form-field>
@@ -99,21 +99,21 @@
               matInput
               currencyMask
               [attr.name]="'monto-' + i"
-              [options]="currencyMaskOptionsForMonedaId(fila.get('monedaId')?.value)"
+              [options]="fila.opcionesCurrency"
               formControlName="monto"
               required
             />
-            <mat-error *ngIf="fila.get('monto')?.hasError('required')">
+            <mat-error *ngIf="fila.errores.montoRequerido">
               El monto es requerido
             </mat-error>
-            <mat-error *ngIf="fila.get('monto')?.hasError('min')">
+            <mat-error *ngIf="fila.errores.montoMinimo">
               El monto debe ser mayor a 0
             </mat-error>
           </mat-form-field>
 
           <div fxFlex="24%" fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="4px" class="fila-monto-acciones">
             <button
-              *ngIf="i === filasMonto.length - 1"
+              *ngIf="i === filasMontoView.length - 1"
               type="button"
               mat-mini-fab
               class="btn-add-monto-linea"
@@ -123,7 +123,7 @@
               <mat-icon>add</mat-icon>
             </button>
             <button
-              *ngIf="filasMonto.length > 1"
+              *ngIf="filasMontoView.length > 1"
               type="button"
               mat-icon-button
               (click)="quitarFilaMonto(i)"
@@ -149,7 +149,7 @@
           <mat-label>Beneficiario (Proveedor)</mat-label>
           <input matInput [formControl]="beneficiarioControl" readonly tabindex="-1" placeholder="Seleccione un proveedor" required />
           <mat-icon matSuffix>search</mat-icon>
-          <mat-error *ngIf="proveedorIdControl.hasError('required')">
+          <mat-error *ngIf="proveedorRequerido">
             El beneficiario es requerido
           </mat-error>
         </mat-form-field>
@@ -167,7 +167,7 @@
 
   <mat-dialog-actions align="end" class="solicitud-gasto-simple-actions">
     <button mat-button type="button" (click)="onCancelar()">Cancelar</button>
-    <button mat-raised-button color="primary" type="button" [disabled]="!esFormularioValido()" (click)="onSolicitar()">
+    <button mat-raised-button color="primary" type="button" [disabled]="!formularioValido" (click)="onSolicitar()">
       Solicitar
     </button>
   </mat-dialog-actions>

--- a/src/app/modules/financiero/gastos/dialogs/solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component.ts
+++ b/src/app/modules/financiero/gastos/dialogs/solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component.ts
@@ -12,33 +12,11 @@ import { EditProveedorComponent, EditProveedorResult } from '../../../../persona
 import { EnteService } from '../../../../activos/ente/service/ente.service';
 import { Ente } from '../../../../activos/ente/models/ente.model';
 import { TipoEnte } from '../../../../activos/ente/enums/tipo-ente.enum';
-
-export interface SolicitudGastoSimpleData {
-  tipoGastoId: number;
-  tipoGastoDescripcion: string;
-  moduloPadre?: string;
-  requiereAutorizacion?: boolean;
-  solicitanteId: number;
-  solicitanteNombre: string;
-}
-
-export interface SolicitudGastoSimpleMontoLinea {
-  monedaId: number;
-  monto: number;
-}
-
-export interface SolicitudGastoSimpleResult {
-  tipoGastoId: number;
-  solicitanteId: number;
-  descripcion: string;
-  vencimiento: Date;
-  montos: SolicitudGastoSimpleMontoLinea[];
-  monedaId?: number;
-  monto?: number;
-  sucursalRetiroId?: number;
-  proveedorId: number | null;
-  enteId?: number | null;
-}
+import { FilaMontoErrores } from '../../interface/fila-monto-errores.interface';
+import { FilaMontoVista } from '../../interface/fila-monto-vista.interface';
+import { SolicitudGastoSimpleData } from '../../interface/solicitud-gasto-simple-data.interface';
+import { SolicitudGastoSimpleMontoLinea } from '../../interface/solicitud-gasto-simple-monto-linea.interface';
+import { SolicitudGastoSimpleResult } from '../../interface/solicitud-gasto-simple-result.interface';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -61,6 +39,20 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
 
   listaMonedas: Moneda[] = [];
   selectedEnte: Ente | null = null;
+  filasMontoView: FilaMontoVista[] = [];
+
+  requiereEnteActivo = false;
+  etiquetaEnteActivo = 'Activo';
+  etiquetaEnteActivoMinuscula = 'activo';
+  iconoEnteActivo = 'directions_car';
+  placeholderEnteActivo = 'Seleccione activo';
+  mensajeErrorEnteActivo = 'Debe seleccionar activo';
+  textoBuscarEnteActivo = 'Buscar Activo';
+  formularioValido = false;
+  descripcionRequerida = false;
+  vencimientoRequerido = false;
+  enteRequerido = false;
+  proveedorRequerido = false;
 
   constructor(
     private matDialogRef: MatDialogRef<SolicitudGastoSimpleDialogComponent>,
@@ -79,7 +71,9 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
       this.solicitanteNombreControl.setValue(this.data.solicitanteNombre);
     }
 
+    this.inicializarPropiedadesEnteActivo();
     this.actualizarValidadoresEnte();
+    this.suscribirEstadoFormulario();
 
     if (this.mainService.sucursalActual) {
       this.sucursalRetiroControl.setValue(this.mainService.sucursalActual.nombre);
@@ -90,6 +84,8 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
         this.listaMonedas = res;
         if (this.filasMonto.length === 0) {
           this.agregarFilaMonto(false);
+        } else {
+          this.actualizarVistasFilasMonto();
         }
         this.cdr.markForCheck();
       }
@@ -104,7 +100,7 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
     return this.listaMonedas.find(m => this.esMonedaGuarani(m));
   }
 
-  currencyMaskOptionsForMonedaId(monedaId: number | null | undefined): object {
+  private opcionesCurrencyPorMonedaId(monedaId: number | null | undefined): object {
     const m = this.listaMonedas.find(x => x.id === monedaId);
     return m ? this.monedaService.currencyOptionsByMoneda(m) : this.monedaService.currencyOptionsGuarani;
   }
@@ -136,11 +132,35 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
       .subscribe(() => {
         this.aplicarValidadoresMontoPorMoneda(grupo);
         this.actualizarErroresMonedasDuplicadas();
+        this.actualizarVistasFilasMonto();
+        this.cdr.markForCheck();
+      });
+
+    grupo
+      .get('monedaId')!
+      .statusChanges.pipe(startWith(grupo.get('monedaId')!.status), untilDestroyed(this))
+      .subscribe(() => {
+        this.actualizarErroresVistaFilasMonto();
+        this.cdr.markForCheck();
+      });
+
+    grupo
+      .get('monto')!
+      .statusChanges.pipe(startWith(grupo.get('monto')!.status), untilDestroyed(this))
+      .subscribe(() => {
+        this.actualizarErroresVistaFilasMonto();
         this.cdr.markForCheck();
       });
 
     this.filasMonto.push(grupo);
+    this.filasMontoView.push({
+      grupo,
+      opcionesCurrency: this.opcionesCurrencyPorMonedaId(grupo.get('monedaId')?.value),
+      opcionesMoneda: [],
+      errores: this.erroresInicialesFilaMonto(),
+    });
     this.actualizarErroresMonedasDuplicadas();
+    this.actualizarVistasFilasMonto();
     if (markForCheck) {
       this.cdr.markForCheck();
     }
@@ -151,11 +171,13 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
       return;
     }
     this.filasMonto.removeAt(index);
+    this.filasMontoView.splice(index, 1);
     this.actualizarErroresMonedasDuplicadas();
+    this.actualizarVistasFilasMonto();
     this.cdr.markForCheck();
   }
 
-  esMonedaOcupada(monedaId: number | null | undefined, filaIndex: number): boolean {
+  private monedaOcupadaEnOtraFila(monedaId: number | null | undefined, filaIndex: number): boolean {
     if (monedaId == null) {
       return false;
     }
@@ -167,32 +189,111 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
     });
   }
 
-  get requiereEnteActivo(): boolean {
-    return this.tipoEnteDesdeModuloPadre() != null;
+  private actualizarVistasFilasMonto(): void {
+    this.filasMontoView.forEach((vista, filaIndex) => {
+      const monedaId = vista.grupo.get('monedaId')?.value as number | null | undefined;
+      vista.opcionesCurrency = this.opcionesCurrencyPorMonedaId(monedaId);
+      vista.opcionesMoneda = this.listaMonedas.map(moneda => ({
+        moneda,
+        deshabilitada: this.monedaOcupadaEnOtraFila(moneda.id, filaIndex),
+      }));
+    });
+    this.actualizarErroresVistaFilasMonto();
   }
 
-  get etiquetaEnteActivo(): string {
-    switch (this.data?.moduloPadre) {
+  private erroresInicialesFilaMonto(): FilaMontoErrores {
+    return {
+      monedaRequerida: false,
+      monedaDuplicada: false,
+      montoRequerido: false,
+      montoMinimo: false,
+    };
+  }
+
+  private actualizarErroresVistaFilasMonto(): void {
+    this.filasMontoView.forEach(vista => {
+      const monedaCtrl = vista.grupo.get('monedaId');
+      const montoCtrl = vista.grupo.get('monto');
+      vista.errores = {
+        monedaRequerida: !!monedaCtrl?.hasError('required'),
+        monedaDuplicada: !!monedaCtrl?.hasError('monedaDuplicada'),
+        montoRequerido: !!montoCtrl?.hasError('required'),
+        montoMinimo: !!montoCtrl?.hasError('min'),
+      };
+    });
+  }
+
+  private actualizarErroresFormulario(): void {
+    this.descripcionRequerida = this.descripcionControl.hasError('required');
+    this.vencimientoRequerido = this.vencimientoControl.hasError('required');
+    this.enteRequerido = this.enteIdControl.hasError('required');
+    this.proveedorRequerido = this.proveedorIdControl.hasError('required');
+  }
+
+  private inicializarPropiedadesEnteActivo(): void {
+    const modulo = this.data?.moduloPadre;
+    this.requiereEnteActivo = this.tipoEnteDesdeModuloPadre() != null;
+
+    switch (modulo) {
       case 'VEHICULO':
-        return 'Vehículo';
+        this.etiquetaEnteActivo = 'Vehículo';
+        break;
       case 'MUEBLE':
-        return 'Mueble';
+        this.etiquetaEnteActivo = 'Mueble';
+        break;
       case 'INMUEBLE':
-        return 'Inmueble';
+        this.etiquetaEnteActivo = 'Inmueble';
+        break;
       default:
-        return 'Activo';
+        this.etiquetaEnteActivo = 'Activo';
     }
+
+    switch (modulo) {
+      case 'MUEBLE':
+        this.iconoEnteActivo = 'chair';
+        break;
+      case 'INMUEBLE':
+        this.iconoEnteActivo = 'domain';
+        break;
+      default:
+        this.iconoEnteActivo = 'directions_car';
+    }
+
+    this.etiquetaEnteActivoMinuscula = this.etiquetaEnteActivo.toLowerCase();
+    this.placeholderEnteActivo = `Seleccione ${this.etiquetaEnteActivoMinuscula}`;
+    this.mensajeErrorEnteActivo = `Debe seleccionar ${this.etiquetaEnteActivoMinuscula}`;
+    this.textoBuscarEnteActivo = `Buscar ${this.etiquetaEnteActivo}`;
   }
 
-  get iconoEnteActivo(): string {
-    switch (this.data?.moduloPadre) {
-      case 'MUEBLE':
-        return 'chair';
-      case 'INMUEBLE':
-        return 'domain';
-      default:
-        return 'directions_car';
-    }
+  private suscribirEstadoFormulario(): void {
+    const controles = [
+      this.descripcionControl,
+      this.vencimientoControl,
+      this.proveedorIdControl,
+      this.enteIdControl,
+    ];
+
+    controles.forEach(control => {
+      control.statusChanges
+        .pipe(startWith(control.status), untilDestroyed(this))
+        .subscribe(() => this.actualizarFormularioValido());
+    });
+
+    this.filasMonto.statusChanges
+      .pipe(startWith(this.filasMonto.status), untilDestroyed(this))
+      .subscribe(() => this.actualizarFormularioValido());
+  }
+
+  private actualizarFormularioValido(): void {
+    this.formularioValido =
+      this.descripcionControl.valid &&
+      this.vencimientoControl.valid &&
+      this.filasMonto.valid &&
+      this.proveedorIdControl.valid &&
+      this.enteIdControl.valid;
+    this.actualizarErroresFormulario();
+    this.actualizarErroresVistaFilasMonto();
+    this.cdr.markForCheck();
   }
 
   private tipoEnteDesdeModuloPadre(): TipoEnte | null {
@@ -285,44 +386,28 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
   }
 
   onSolicitar(): void {
-    if (
-      this.descripcionControl.valid &&
-      this.vencimientoControl.valid &&
-      this.filasMonto.valid &&
-      this.proveedorIdControl.valid &&
-      this.enteIdControl.valid
-    ) {
-      const lineas: SolicitudGastoSimpleMontoLinea[] = this.filasMonto.controls
-        .map(c => (c as FormGroup).value as { monedaId: number; monto: number })
-        .filter(v => v.monedaId != null && v.monto != null);
-
-      const primera = lineas[0];
-      const resultado: SolicitudGastoSimpleResult = {
-        tipoGastoId: this.data.tipoGastoId,
-        solicitanteId: this.data.solicitanteId,
-        descripcion: this.descripcionControl.value,
-        vencimiento: this.vencimientoControl.value,
-        montos: lineas,
-        monedaId: primera?.monedaId,
-        monto: primera?.monto,
-        sucursalRetiroId: this.mainService.sucursalActual?.id,
-        proveedorId: this.proveedorIdControl.value,
-        enteId: this.enteIdControl.value ?? null,
-      };
-      this.matDialogRef.close(resultado);
+    if (!this.formularioValido) {
+      return;
     }
-  }
 
-  esFormularioValido(): boolean {
-    return this.descripcionControl.valid &&
-           this.vencimientoControl.valid &&
-           this.filasMonto.valid &&
-           this.proveedorIdControl.valid &&
-           this.enteIdControl.valid;
-  }
+    const lineas: SolicitudGastoSimpleMontoLinea[] = this.filasMonto.controls
+      .map(c => (c as FormGroup).value as { monedaId: number; monto: number })
+      .filter(v => v.monedaId != null && v.monto != null);
 
-  trackByFilaMonto(index: number, fila: FormGroup): FormGroup {
-    return fila;
+    const primera = lineas[0];
+    const resultado: SolicitudGastoSimpleResult = {
+      tipoGastoId: this.data.tipoGastoId,
+      solicitanteId: this.data.solicitanteId,
+      descripcion: this.descripcionControl.value,
+      vencimiento: this.vencimientoControl.value,
+      montos: lineas,
+      monedaId: primera?.monedaId,
+      monto: primera?.monto,
+      sucursalRetiroId: this.mainService.sucursalActual?.id,
+      proveedorId: this.proveedorIdControl.value,
+      enteId: this.enteIdControl.value ?? null,
+    };
+    this.matDialogRef.close(resultado);
   }
 
   private actualizarErroresMonedasDuplicadas(): void {
@@ -344,6 +429,7 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
       const duplicada = monedaId != null && (cantidadPorMoneda.get(monedaId) ?? 0) > 1;
       this.setControlError(monedaIdControl, 'monedaDuplicada', duplicada);
     });
+    this.actualizarErroresVistaFilasMonto();
   }
 
   private setControlError(control: AbstractControl, key: string, enabled: boolean): void {

--- a/src/app/modules/financiero/gastos/dialogs/solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component.ts
+++ b/src/app/modules/financiero/gastos/dialogs/solicitud-gasto-simple-dialog/solicitud-gasto-simple-dialog.component.ts
@@ -9,10 +9,14 @@ import { Moneda } from '../../../moneda/moneda.model';
 import { MonedaService } from '../../../moneda/moneda.service';
 import { ProveedoresSearchByPersonaPageGQL } from '../../../../personas/proveedor/graphql/proveedorSearchByPersonaPage';
 import { EditProveedorComponent, EditProveedorResult } from '../../../../personas/proveedor/edit-proveedor/edit-proveedor.component';
+import { EnteService } from '../../../../activos/ente/service/ente.service';
+import { Ente } from '../../../../activos/ente/models/ente.model';
+import { TipoEnte } from '../../../../activos/ente/enums/tipo-ente.enum';
 
 export interface SolicitudGastoSimpleData {
   tipoGastoId: number;
   tipoGastoDescripcion: string;
+  moduloPadre?: string;
   requiereAutorizacion?: boolean;
   solicitanteId: number;
   solicitanteNombre: string;
@@ -33,6 +37,7 @@ export interface SolicitudGastoSimpleResult {
   monto?: number;
   sucursalRetiroId?: number;
   proveedorId: number | null;
+  enteId?: number | null;
 }
 
 @UntilDestroy({ checkProperties: true })
@@ -51,8 +56,11 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
   sucursalRetiroControl = new FormControl({ value: '', disabled: true });
   beneficiarioControl = new FormControl('', Validators.required);
   proveedorIdControl = new FormControl<number | null>(null, Validators.required);
+  enteDisplayControl = new FormControl('');
+  enteIdControl = new FormControl<number | null>(null);
 
   listaMonedas: Moneda[] = [];
+  selectedEnte: Ente | null = null;
 
   constructor(
     private matDialogRef: MatDialogRef<SolicitudGastoSimpleDialogComponent>,
@@ -61,6 +69,7 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
     private mainService: MainService,
     private matDialog: MatDialog,
     private proveedoresSearchByPersonaPageGQL: ProveedoresSearchByPersonaPageGQL,
+    private enteService: EnteService,
     private cdr: ChangeDetectorRef
   ) {}
 
@@ -68,7 +77,9 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
     if (this.data) {
       this.tipoGastoDescripcionControl.setValue(this.data.tipoGastoDescripcion);
       this.solicitanteNombreControl.setValue(this.data.solicitanteNombre);
-    }  
+    }
+
+    this.actualizarValidadoresEnte();
 
     if (this.mainService.sucursalActual) {
       this.sucursalRetiroControl.setValue(this.mainService.sucursalActual.nombre);
@@ -156,6 +167,76 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
     });
   }
 
+  get requiereEnteActivo(): boolean {
+    return this.tipoEnteDesdeModuloPadre() != null;
+  }
+
+  get etiquetaEnteActivo(): string {
+    switch (this.data?.moduloPadre) {
+      case 'VEHICULO':
+        return 'Vehículo';
+      case 'MUEBLE':
+        return 'Mueble';
+      case 'INMUEBLE':
+        return 'Inmueble';
+      default:
+        return 'Activo';
+    }
+  }
+
+  get iconoEnteActivo(): string {
+    switch (this.data?.moduloPadre) {
+      case 'MUEBLE':
+        return 'chair';
+      case 'INMUEBLE':
+        return 'domain';
+      default:
+        return 'directions_car';
+    }
+  }
+
+  private tipoEnteDesdeModuloPadre(): TipoEnte | null {
+    const modulo = this.data?.moduloPadre;
+    if (modulo === 'VEHICULO' || modulo === 'MUEBLE' || modulo === 'INMUEBLE') {
+      return modulo as TipoEnte;
+    }
+    return null;
+  }
+
+  private actualizarValidadoresEnte(): void {
+    const tipo = this.tipoEnteDesdeModuloPadre();
+    this.enteIdControl.clearValidators();
+    if (tipo != null) {
+      this.enteIdControl.addValidators(Validators.required);
+    }
+    this.enteIdControl.updateValueAndValidity();
+  }
+
+  abrirBuscadorEnteActivo(): void {
+    const tipo = this.tipoEnteDesdeModuloPadre();
+    if (!tipo) {
+      return;
+    }
+    this.enteService.abrirBuscadorEnte(tipo).pipe(untilDestroyed(this)).subscribe(ente => {
+      if (ente?.id) {
+        this.selectedEnte = ente;
+        this.enteIdControl.setValue(ente.id);
+        this.enteDisplayControl.setValue(this.descripcionEnte(ente));
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  private descripcionEnte(ente: Ente): string {
+    const tipo = ente.tipoEnte ?? this.data?.moduloPadre ?? '';
+    const ref = ente.referenciaId != null ? `#${ente.referenciaId}` : '';
+    const desc = ente.descripcion?.trim();
+    if (desc) {
+      return `[${tipo}] ${desc}`;
+    }
+    return `[${tipo}] Ente ${ente.id}${ref ? ' — Ref. ' + ref : ''}`;
+  }
+
   abrirBuscadorProveedor(): void {
     const data = new SearchListtDialogData();
     data.titulo = 'Seleccionar Proveedor';
@@ -208,7 +289,8 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
       this.descripcionControl.valid &&
       this.vencimientoControl.valid &&
       this.filasMonto.valid &&
-      this.proveedorIdControl.valid
+      this.proveedorIdControl.valid &&
+      this.enteIdControl.valid
     ) {
       const lineas: SolicitudGastoSimpleMontoLinea[] = this.filasMonto.controls
         .map(c => (c as FormGroup).value as { monedaId: number; monto: number })
@@ -224,7 +306,8 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
         monedaId: primera?.monedaId,
         monto: primera?.monto,
         sucursalRetiroId: this.mainService.sucursalActual?.id,
-        proveedorId: this.proveedorIdControl.value
+        proveedorId: this.proveedorIdControl.value,
+        enteId: this.enteIdControl.value ?? null,
       };
       this.matDialogRef.close(resultado);
     }
@@ -234,7 +317,8 @@ export class SolicitudGastoSimpleDialogComponent implements OnInit {
     return this.descripcionControl.valid &&
            this.vencimientoControl.valid &&
            this.filasMonto.valid &&
-           this.proveedorIdControl.valid;
+           this.proveedorIdControl.valid &&
+           this.enteIdControl.valid;
   }
 
   trackByFilaMonto(index: number, fila: FormGroup): FormGroup {

--- a/src/app/modules/financiero/gastos/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/gastos/graphql/graphql-query.ts
@@ -265,6 +265,7 @@ export const tipoGastosSearch = gql`
       autorizacion
       activo
       activoEnSucursales
+      moduloPadre
     }
   }
 `;
@@ -406,6 +407,13 @@ export const filterPreGastosQuery = gql`
         }
         tipoGasto {
           id
+          descripcion
+          moduloPadre
+        }
+        ente {
+          id
+          tipoEnte
+          referenciaId
           descripcion
         }
         descripcion

--- a/src/app/modules/financiero/gastos/interface/fila-monto-errores.interface.ts
+++ b/src/app/modules/financiero/gastos/interface/fila-monto-errores.interface.ts
@@ -1,0 +1,6 @@
+export interface FilaMontoErrores {
+  monedaRequerida: boolean;
+  monedaDuplicada: boolean;
+  montoRequerido: boolean;
+  montoMinimo: boolean;
+}

--- a/src/app/modules/financiero/gastos/interface/fila-monto-vista.interface.ts
+++ b/src/app/modules/financiero/gastos/interface/fila-monto-vista.interface.ts
@@ -1,0 +1,10 @@
+import { FormGroup } from '@angular/forms';
+import { FilaMontoErrores } from './fila-monto-errores.interface';
+import { MonedaSelectOpcion } from './moneda-select-opcion.interface';
+
+export interface FilaMontoVista {
+  grupo: FormGroup;
+  opcionesCurrency: object;
+  opcionesMoneda: MonedaSelectOpcion[];
+  errores: FilaMontoErrores;
+}

--- a/src/app/modules/financiero/gastos/interface/moneda-select-opcion.interface.ts
+++ b/src/app/modules/financiero/gastos/interface/moneda-select-opcion.interface.ts
@@ -1,0 +1,6 @@
+import { Moneda } from '../../moneda/moneda.model';
+
+export interface MonedaSelectOpcion {
+  moneda: Moneda;
+  deshabilitada: boolean;
+}

--- a/src/app/modules/financiero/gastos/interface/solicitud-gasto-simple-data.interface.ts
+++ b/src/app/modules/financiero/gastos/interface/solicitud-gasto-simple-data.interface.ts
@@ -1,0 +1,8 @@
+export interface SolicitudGastoSimpleData {
+  tipoGastoId: number;
+  tipoGastoDescripcion: string;
+  moduloPadre?: string;
+  requiereAutorizacion?: boolean;
+  solicitanteId: number;
+  solicitanteNombre: string;
+}

--- a/src/app/modules/financiero/gastos/interface/solicitud-gasto-simple-monto-linea.interface.ts
+++ b/src/app/modules/financiero/gastos/interface/solicitud-gasto-simple-monto-linea.interface.ts
@@ -1,0 +1,4 @@
+export interface SolicitudGastoSimpleMontoLinea {
+  monedaId: number;
+  monto: number;
+}

--- a/src/app/modules/financiero/gastos/interface/solicitud-gasto-simple-result.interface.ts
+++ b/src/app/modules/financiero/gastos/interface/solicitud-gasto-simple-result.interface.ts
@@ -1,0 +1,14 @@
+import { SolicitudGastoSimpleMontoLinea } from './solicitud-gasto-simple-monto-linea.interface';
+
+export interface SolicitudGastoSimpleResult {
+  tipoGastoId: number;
+  solicitanteId: number;
+  descripcion: string;
+  vencimiento: Date;
+  montos: SolicitudGastoSimpleMontoLinea[];
+  monedaId?: number;
+  monto?: number;
+  sucursalRetiroId?: number;
+  proveedorId: number | null;
+  enteId?: number | null;
+}

--- a/src/app/modules/financiero/gastos/models/pre-gasto.model.ts
+++ b/src/app/modules/financiero/gastos/models/pre-gasto.model.ts
@@ -31,10 +31,18 @@ export class PreGastoGastoRendicion {
   vueltoDs: number;
 }
 
+export class EnteResumen {
+  id: number;
+  tipoEnte?: string;
+  referenciaId?: number;
+  descripcion?: string;
+}
+
 export class PreGasto {
   id: number;
   sucursalId: number;
   funcionario: Persona;
+  ente?: EnteResumen;
   tipoGasto: TipoGasto;
   descripcion: string;
   moneda: Moneda;

--- a/src/app/modules/financiero/gastos/pages/list-pre-gastos/list-pre-gastos.component.html
+++ b/src/app/modules/financiero/gastos/pages/list-pre-gastos/list-pre-gastos.component.html
@@ -131,6 +131,10 @@
             <span style="color: #aaa">Tipo:</span>
             <span>{{ seleccionado.tipoGasto?.descripcion }}</span>
           </div>
+          <div fxLayout="row" fxLayoutAlign="space-between start" *ngIf="seleccionado.ente">
+            <span style="color: #aaa">Activo:</span>
+            <span>{{ seleccionado.ente?.descripcion || (seleccionado.ente?.tipoEnte + ' #' + seleccionado.ente?.referenciaId) }}</span>
+          </div>
           <div fxLayout="row" fxLayoutAlign="space-between start">
             <span style="color: #aaa">Concepto:</span>
             <span>{{ seleccionado.descripcion }}</span>


### PR DESCRIPTION
## Summary
- Permite vincular un activo (vehículo, mueble o inmueble) al crear una solicitud de gasto simple según el moduloPadre del tipo de gasto.
- Extiende el flujo de pre-gasto con enteId en GraphQL y modelo, y muestra la referencia del activo en el listado de pre-gastos.
- Refactoriza solicitud-gasto-simple-dialog: interfaces en gastos/interface/ y template sin getters ni funciones para OnPush.
## Test plan
- [ ] Tipo de gasto con moduloPadre VEHICULO/MUEBLE/INMUEBLE: aparece campo de activo con etiqueta e icono correctos.
- [ ] Buscar y seleccionar activo; la solicitud se guarda con enteId.
- [ ] Tipo de gasto sin módulo padre: no se muestra el campo de activo.
- [ ] Filas moneda/monto: monedas duplicadas deshabilitadas, máscara por moneda, botón Solicitar solo con formulario válido.
- [ ] Listado de pre-gastos muestra el activo vinculado.
- [ ] Ejecutar npm run check antes del merge.