### PR TITLE
feat(transferencias): add configuracion de transferencia stock negativo

### DIFF
--- a/src/app/modules/operaciones/operaciones.module.ts
+++ b/src/app/modules/operaciones/operaciones.module.ts
@@ -46,6 +46,7 @@ import { AcompanhanteComponent } from './transferencia/acompanhante/acompanhante
 import { RutaHojaComponent } from './transferencia/ruta-hoja/ruta-hoja.component';
 import { EntregadoresComponent } from './transferencia/entregadores/entregadores.component';
 import { GenericListVentaComponent } from './venta/generic-list-venta/generic-list-venta.component';
+import { ConfiguracionTransferenciaDialogComponent } from './transferencia/configuracion-transferencia-dialog/configuracion-transferencia-dialog.component';
 
 
 import { GestionComprasComponent } from './compra/gestion-compras/gestion-compras.component';
@@ -111,6 +112,7 @@ import { ImprimirPedidoDialogComponent } from './compra/gestion-compras/dialogs/
     AcompanhanteComponent,
     RutaHojaComponent,
     EntregadoresComponent,
+    ConfiguracionTransferenciaDialogComponent,
     GestionComprasComponent,
     AddEditItemDialogComponent,
     SelectSucursalesDialogComponent,

--- a/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia-dialog.component.html
+++ b/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia-dialog.component.html
@@ -1,0 +1,32 @@
+<h2 mat-dialog-title>Configuración de Transferencias</h2>
+
+<mat-dialog-content>
+    <div fxLayout="column" fxLayoutGap="15px" style="margin-top: 10px;">
+        <div class="config-item">
+            <div class="config-item-info">
+                <div class="config-item-title">Permitir stock negativo</div>
+                <div class="config-item-desc">
+                    Cuando está activado, se podrán ingresar productos con stock negativo en las transferencias.
+                    Si está desactivado, el sistema bloqueará el ingreso de dichos productos.
+                </div>
+            </div>
+            <div class="config-item-toggle">
+                <mat-slide-toggle
+                    [checked]="config.permitirStockNegativo"
+                    (change)="onToggleStockNegativo()"
+                    color="accent">
+                </mat-slide-toggle>
+                <span class="toggle-label" [class.active]="config.permitirStockNegativo" [class.desactive]="!config.permitirStockNegativo">
+                    {{ config.permitirStockNegativo ? 'ACTIVADO' : 'DESACTIVADO' }}
+                </span>
+            </div>
+        </div>
+    </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+    <button mat-button (click)="onCancelar()">Cancelar</button>
+    <button mat-raised-button color="primary" (click)="onGuardar()">
+        <mat-icon>save</mat-icon> Guardar
+    </button>
+</mat-dialog-actions>

--- a/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia-dialog.component.scss
+++ b/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia-dialog.component.scss
@@ -1,0 +1,58 @@
+.config-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px;
+  background-color: rgba(255, 255, 255, 0.05); /* Fondo más sutil */
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: border-color 0.2s ease;
+
+  &:hover {
+    border-color: #90caf9;
+  }
+}
+
+.config-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.config-item-title {
+  font-size: 18px; /* Aumentado ~3px desde 0.95rem */
+  font-weight: 500;
+  color: #e0e0e0;
+}
+
+.config-item-desc {
+  font-size: 15px; /* Aumentado ~3px desde 0.78rem */
+  color: #9e9e9e;
+  line-height: 1.4;
+}
+
+.config-item-toggle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 90px;
+}
+
+.toggle-label {
+  font-size: 14px; /* Aumentado ~3px desde 0.7rem */
+  font-weight: 600;
+  color: #757575;
+  letter-spacing: 0.5px;
+  transition: color 0.2s ease;
+
+  &.active {
+    color: #81c784;
+  }
+
+  &.desactive {
+    color: #f44336;
+  }
+}

--- a/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia-dialog.component.ts
+++ b/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia-dialog.component.ts
@@ -1,0 +1,65 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MainService } from '../../../../main.service';
+import { NotificacionSnackbarService } from '../../../../notificacion-snackbar.service';
+import { ConfiguracionTransferenciaService } from './configuracion-transferencia.service';
+import { ConfiguracionTransferencia, ConfiguracionTransferenciaInput } from './configuracion-transferencia.model';
+
+@Component({
+  selector: 'app-configuracion-transferencia-dialog',
+  templateUrl: './configuracion-transferencia-dialog.component.html',
+  styleUrls: ['./configuracion-transferencia-dialog.component.scss']
+})
+export class ConfiguracionTransferenciaDialogComponent implements OnInit {
+
+  config: ConfiguracionTransferencia = new ConfiguracionTransferencia();
+  isLoading = true;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: MatDialogRef<ConfiguracionTransferenciaDialogComponent>,
+    private configuracionService: ConfiguracionTransferenciaService,
+    private notificacionService: NotificacionSnackbarService,
+    public mainService: MainService
+  ) { }
+
+  ngOnInit(): void {
+    this.configuracionService.onGetConfiguracion().subscribe({
+      next: (res) => {
+        if (res != null) {
+          Object.assign(this.config, res);
+        }
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+        this.notificacionService.openAlgoSalioMal('Error al cargar la configuración');
+      }
+    });
+  }
+
+  onToggleStockNegativo(): void {
+    this.config.permitirStockNegativo = !this.config.permitirStockNegativo;
+  }
+
+  onGuardar(): void {
+    const input = this.config.toInput();
+    input.usuarioId = this.mainService.usuarioActual?.id;
+    this.configuracionService.onSaveConfiguracion(input).subscribe({
+      next: (res) => {
+        if (res != null) {
+          this.config = res;
+          this.notificacionService.openSucess('Configuración guardada correctamente');
+          this.dialogRef.close(this.config);
+        }
+      },
+      error: () => {
+        this.notificacionService.openAlgoSalioMal('Error al guardar la configuración');
+      }
+    });
+  }
+
+  onCancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia.model.ts
+++ b/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia.model.ts
@@ -1,0 +1,23 @@
+import { Usuario } from "../../../personas/usuarios/usuario.model";
+
+export class ConfiguracionTransferencia {
+  id: number;
+  permitirStockNegativo: boolean;
+  usuario: Usuario;
+  creadoEn: Date;
+  modificadoEn: Date;
+
+  toInput(): ConfiguracionTransferenciaInput {
+    let input = new ConfiguracionTransferenciaInput();
+    input.id = this?.id;
+    input.permitirStockNegativo = this?.permitirStockNegativo;
+    input.usuarioId = this?.usuario?.id;
+    return input;
+  }
+}
+
+export class ConfiguracionTransferenciaInput {
+  id?: number;
+  permitirStockNegativo?: boolean;
+  usuarioId?: number;
+}

--- a/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia.service.ts
+++ b/src/app/modules/operaciones/transferencia/configuracion-transferencia-dialog/configuracion-transferencia.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { GenericCrudService } from '../../../../generics/generic-crud.service';
+import { ConfiguracionTransferencia, ConfiguracionTransferenciaInput } from './configuracion-transferencia.model';
+import { GetConfiguracionTransferenciaGQL } from '../graphql/getConfiguracionTransferencia';
+import { SaveConfiguracionTransferenciaGQL } from '../graphql/saveConfiguracionTransferencia';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfiguracionTransferenciaService {
+
+  constructor(
+    private genericCrudService: GenericCrudService,
+    private getConfiguracionGQL: GetConfiguracionTransferenciaGQL,
+    private saveConfiguracionGQL: SaveConfiguracionTransferenciaGQL
+  ) { }
+
+  onGetConfiguracion(servidor = true): Observable<ConfiguracionTransferencia> {
+    return this.genericCrudService.onCustomQuery(this.getConfiguracionGQL, {}, servidor);
+  }
+
+  onSaveConfiguracion(input: ConfiguracionTransferenciaInput, servidor = true): Observable<ConfiguracionTransferencia> {
+    return this.genericCrudService.onSave(this.saveConfiguracionGQL, input, null, null, servidor);
+  }
+}

--- a/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
@@ -72,6 +72,7 @@ import {
   validarFecha,
 } from "../../../../commons/core/utils/dateUtils";
 import { NotificacionColor, NotificacionSnackbarService } from "../../../../notificacion-snackbar.service";
+import { ConfiguracionTransferenciaService } from '../configuracion-transferencia-dialog/configuracion-transferencia.service';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -208,7 +209,8 @@ export class EditTransferenciaComponent implements OnInit {
     private tabService: TabService,
     private presentacionService: PresentacionService,
     private dialogoService: DialogosService,
-    private notificacionService: NotificacionSnackbarService
+    private notificacionService: NotificacionSnackbarService,
+    private configuracionTransferenciaService: ConfiguracionTransferenciaService
   ) { }
 
   ngOnInit(): void {
@@ -1353,15 +1355,31 @@ export class EditTransferenciaComponent implements OnInit {
       this.productoService.onGetStockPorProductoAndSucursal(productoId, sucursalOrigenId, true)
         .subscribe({
           next: (stock) => {
-            this.cargandoService.closeDialog();
             if (stock != null && stock < 0) {
-              this.notificacionService.openWarn(
-                `El producto tiene stock negativo (${stock}) y no puede ser transferido.`
-              );
-              this.onClear();
-              return;
+              this.configuracionTransferenciaService.onGetConfiguracion().subscribe({
+                next: (config) => {
+                  this.cargandoService.closeDialog();
+                  if (!config?.permitirStockNegativo) {
+                    this.notificacionService.openWarn(
+                      `El producto tiene stock negativo (${stock}) y no puede ser transferido.`
+                    );
+                    this.onClear();
+                    return;
+                  }
+                  this.procederConGuardadoItem();
+                },
+                error: () => {
+                  this.cargandoService.closeDialog();
+                  this.notificacionService.openWarn(
+                    `El producto tiene stock negativo (${stock}) y no puede ser transferido.`
+                  );
+                  this.onClear();
+                }
+              });
+            } else {
+              this.cargandoService.closeDialog();
+              this.procederConGuardadoItem();
             }
-            this.procederConGuardadoItem();
           },
           error: (err) => {
             this.cargandoService.closeDialog();

--- a/src/app/modules/operaciones/transferencia/graphql/getConfiguracionTransferencia.ts
+++ b/src/app/modules/operaciones/transferencia/graphql/getConfiguracionTransferencia.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { configuracionTransferenciaQuery } from './graphql-query';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class GetConfiguracionTransferenciaGQL extends Query<any> {
+    document = configuracionTransferenciaQuery;
+}

--- a/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
+++ b/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
@@ -1271,3 +1271,38 @@ export const hojaRutaPorFechaQuery = gql`
     }
   }
 `;
+
+export const configuracionTransferenciaQuery = gql`
+  {
+    data: configuracionTransferencia {
+      id
+      permitirStockNegativo
+      usuario {
+        id
+        persona {
+          nombre
+        }
+      }
+      creadoEn
+      modificadoEn
+    }
+  }
+`;
+
+export const saveConfiguracionTransferencia = gql`
+  mutation saveConfiguracionTransferencia($entity: ConfiguracionTransferenciaInput!) {
+    data: saveConfiguracionTransferencia(input: $entity) {
+      id
+      permitirStockNegativo
+      usuario {
+        id
+        persona {
+          nombre
+        }
+      }
+      creadoEn
+      modificadoEn
+    }
+  }
+`;
+

--- a/src/app/modules/operaciones/transferencia/graphql/saveConfiguracionTransferencia.ts
+++ b/src/app/modules/operaciones/transferencia/graphql/saveConfiguracionTransferencia.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { saveConfiguracionTransferencia } from './graphql-query';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class SaveConfiguracionTransferenciaGQL extends Mutation<any> {
+    document = saveConfiguracionTransferencia;
+}

--- a/src/app/modules/operaciones/transferencia/transferencia.component.html
+++ b/src/app/modules/operaciones/transferencia/transferencia.component.html
@@ -12,8 +12,12 @@
       <div fxFlex="30%" style="height: 250px">
         <app-boton nombre="Entregadores" icon="move_up" [iconSize]="4" (clickEvent)="onEntregadores()"></app-boton>
       </div>
-      <div fxFlex="30%" style="height: 250px">
-        <app-boton nombre="Configurar Transferencias" icon="tune" [iconSize]="4"></app-boton>
+      <div fxFlex="30%" style="height: 250px" *ngIf="
+                mainService.usuarioActual?.roles.includes(
+                  ROLES.ADMIN
+                )
+              ">
+        <app-boton nombre="Configurar Transferencias" icon="tune" [iconSize]="4" (clickEvent)="onAbrirConfiguracion()"></app-boton>
       </div>
     </div>
   </div>

--- a/src/app/modules/operaciones/transferencia/transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/transferencia.component.ts
@@ -4,6 +4,10 @@ import { Component, OnInit } from '@angular/core';
 import { Tab } from '../../../layouts/tab/tab.model';
 import { ListTransferenciaComponent } from './list-transferencia/list-transferencia.component';
 import { EntregadoresComponent } from './entregadores/entregadores.component';
+import { ConfiguracionTransferenciaDialogComponent } from './configuracion-transferencia-dialog/configuracion-transferencia-dialog.component';
+import { MatDialog } from '@angular/material/dialog';
+import { MainService } from '../../../main.service';
+import { ROLES } from '../../personas/roles/roles.enum';
 
 @Component({
   selector: 'app-transferencia',
@@ -11,8 +15,8 @@ import { EntregadoresComponent } from './entregadores/entregadores.component';
   styleUrls: ['./transferencia.component.scss']
 })
 export class TransferenciaComponent implements OnInit {
-
-  constructor(private tabService: TabService) { }
+  readonly ROLES = ROLES;
+  constructor(private tabService: TabService, private matDialog: MatDialog, public mainService: MainService) { }
 
   ngOnInit(): void {
 
@@ -30,4 +34,11 @@ export class TransferenciaComponent implements OnInit {
     this.tabService.addTab(new Tab(EntregadoresComponent, 'Entregadores', null, TransferenciaComponent))
   }
 
+  onAbrirConfiguracion() {
+    this.matDialog.open(ConfiguracionTransferenciaDialogComponent, {
+      width: '560px',
+      disableClose: false,
+      panelClass: 'custom-dialog-container'
+    });
+  }
 }


### PR DESCRIPTION
## Qué resuelve
Este PR migra la configuración de la restricción de stock negativo en las transferencias de un estado local a uno global y persistente. 

Anteriormente, el sistema bloqueaba por defecto el ingreso de productos con stock negativo o dependía de configuraciones locales. Con este desarrollo, se ha introducido una tabla en la base de datos para manejar esta restricción como una configuración global de la aplicación. Desde el frontend, los usuarios con permisos de administrador pueden activar o desactivar esta restricción mediante un nuevo diálogo de configuración accesible desde el panel de transferencias. Además, se guarda un registro del `usuario_id` correspondiente a la persona que realizó la última modificación en la configuración.

## Cómo probarlo
1. Ingresar a la aplicación con un usuario que posea el rol de Administrador.
2. Navegar hacia el módulo de Transferencias.
3. Hacer clic en el botón "Configurar Transferencias".
4. En el diálogo que aparece, alternar el estado de "Permitir transferencias con stock negativo" y guardar.
5. Iniciar la creación o edición de una transferencia.
6. Intentar agregar un ítem a la transferencia cuyo producto posea actualmente un stock negativo en la sucursal de origen.
7. Verificar que el sistema permite o bloquea el registro del producto respetando estrictamente el valor configurado en el paso 4.
8. (Opcional) Consultar la tabla `operaciones.configuracion_transferencia` en la base de datos para verificar que el campo `usuario_id` fue actualizado con el ID del usuario que realizó la acción.

## Impacto DB
Aplica. 

Se introduce el script de migración Flyway correspondiente (`V129.1`) que realiza lo siguiente:
- Crea la tabla `operaciones.configuracion_transferencia` con los campos `id`, `permitir_stock_negativo`, `usuario_id`, `creado_en` y `modificado_en`.
- Establece una Foreign Key (`fk_configuracion_transferencia_usuario`) que referencia a `personas.usuario(id)`.
- Ejecuta una sentencia `INSERT` inicial para crear un registro único (Singleton) con valores por defecto y evitar nulos al arrancar el sistema.

## Riesgo
Bajo. 

La tabla, la entidad JPA, los servicios y los esquemas GraphQL creados son totalmente nuevos e independientes, por lo cual no modifican la estructura de los datos actuales. En cuanto al frontend, la intervención en el flujo principal (`edit-transferencia`) consiste únicamente en una consulta preventiva (vía HTTP/GraphQL) antes del guardado del ítem, la cual además cuenta con una regla de seguridad (fail-safe) que bloquea la transferencia del producto si la consulta a la configuración llegase a fallar.
