### PR TITLE
Feat/lucro por funcionario frontend

### DIFF
--- a/src/app/modules/grafico/venta-funcionario/venta-funcionario.component.html
+++ b/src/app/modules/grafico/venta-funcionario/venta-funcionario.component.html
@@ -1,5 +1,5 @@
 <div class="venta-funcionario-host">
-    <div class="header-filters">
+    <div class="header-filters" *ngIf="!modoExterno">
         <mat-form-field appearance="outline" class="filter-field">
             <mat-label>Sucursal</mat-label>
             <mat-select [formControl]="sucursalControl">

--- a/src/app/modules/grafico/venta-funcionario/venta-funcionario.component.ts
+++ b/src/app/modules/grafico/venta-funcionario/venta-funcionario.component.ts
@@ -1,5 +1,5 @@
 
-import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject, Input, ChangeDetectorRef } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { EChartsOption } from 'echarts';
 import { BehaviorSubject, Observable, map, tap, combineLatest, startWith, debounceTime, switchMap, finalize, distinctUntilChanged } from 'rxjs';
@@ -11,6 +11,15 @@ import { MatDialog } from '@angular/material/dialog';
 import { SearchListDialogComponent, SearchListtDialogData } from '../../../shared/components/search-list-dialog/search-list-dialog.component';
 import { UsuarioSearchGQL } from '../../personas/usuarios/graphql/usuarioSearch';
 import { Usuario } from '../../personas/usuarios/usuario.model';
+import { Tab } from '../../../layouts/tab/tab.model';
+
+export interface VentaFuncionarioDesdeLucroTabData {
+  source: 'lucro-por-funcionario';
+  datos: any[];
+  titulo?: string;
+  subtitulo?: string;
+  mostrarTodos?: boolean;
+}
 
 
 interface DatosGraficoProcesados {
@@ -27,9 +36,17 @@ interface DatosGraficoProcesados {
 })
 export class VentaFuncionarioComponent implements OnInit {
 
+  @Input() data: Tab;
+
+  modoExterno = false;
+  private tituloExterno: string | null = null;
+  private subtituloExterno: string | null = null;
+  private mostrarTodosExterno = false;
+
   private graficoService = inject(GraficoService);
   private dialog = inject(MatDialog);
   private usuarioSearchGQL = inject(UsuarioSearchGQL);
+  private cdr = inject(ChangeDetectorRef);
 
 
   private datosSubject = new BehaviorSubject<DatosGraficoProcesados | null>(null);
@@ -72,10 +89,22 @@ export class VentaFuncionarioComponent implements OnInit {
   ngOnInit(): void {
     this.inicializarAnhos();
 
+    const tabPayload = this.data?.tabData?.data as VentaFuncionarioDesdeLucroTabData | undefined;
+    if (tabPayload?.source === 'lucro-por-funcionario' && tabPayload.datos?.length) {
+      this.modoExterno = true;
+      this.allData = tabPayload.datos;
+      this.tituloExterno = tabPayload.titulo ?? null;
+      this.subtituloExterno = tabPayload.subtitulo ?? null;
+      this.mostrarTodosExterno = tabPayload.mostrarTodos ?? true;
+      this.actualizarGrafico();
+      this.cdr.markForCheck();
+      return;
+    }
+
     setTimeout(() => {
       this.cargarMetadata();
       this.configurarDataStream();
-    }, 100);
+    }, 0);
     this.mesControl.valueChanges.pipe(untilDestroyed(this)).subscribe(() => this.fechaControl.setValue(null, { emitEvent: false }));
     this.anhoControl.valueChanges.pipe(untilDestroyed(this)).subscribe(() => this.fechaControl.setValue(null, { emitEvent: false }));
   }
@@ -200,19 +229,23 @@ export class VentaFuncionarioComponent implements OnInit {
           sucursales: '-'
         }];
       }
-    } else {
+    } else if (!this.mostrarTodosExterno) {
       validas = validas.slice(0, 15);
     }
 
     const totalGeneral = validas.reduce((sum, item) => sum + (item.total || 0), 0);
-    const titulo = this.funcionarioSeleccionado
-      ? `Ventas de: ${this.funcionarioSeleccionado.persona?.nombre || this.funcionarioSeleccionado.nickname}`
-      : 'Ventas por Funcionario (Top 15)';
+    const titulo = this.tituloExterno
+      ?? (this.funcionarioSeleccionado
+        ? `Ventas de: ${this.funcionarioSeleccionado.persona?.nombre || this.funcionarioSeleccionado.nickname}`
+        : 'Ventas por Funcionario (Top 15)');
+    const subtext = this.subtituloExterno
+      ? `${this.subtituloExterno} · Total: ₲ ${totalGeneral.toLocaleString('es-PY')}`
+      : `Total Mostrado: ₲ ${totalGeneral.toLocaleString('es-PY')}`;
 
     const opciones: EChartsOption = {
       title: {
         text: titulo,
-        subtext: `Total Mostrado: ₲ ${totalGeneral.toLocaleString('es-PY')}`,
+        subtext: subtext,
         left: 'center', top: 10,
         textStyle: { color: this.colores.text, fontSize: 18, fontWeight: 'bold' },
         subtextStyle: { color: this.colores.textSecondary, fontSize: 12 }

--- a/src/app/modules/operaciones/operaciones.module.ts
+++ b/src/app/modules/operaciones/operaciones.module.ts
@@ -71,6 +71,7 @@ import { AdicionarNotaDialogComponent } from './solicitud-pago/adicionar-nota-di
 import { AdicionarFormaPagoDialogComponent } from './solicitud-pago/adicionar-forma-pago-dialog/adicionar-forma-pago-dialog.component';
 import { GestionPagoDialogComponent } from './solicitud-pago/gestion-pago-dialog/gestion-pago-dialog.component';
 import { ImprimirPedidoDialogComponent } from './compra/gestion-compras/dialogs/imprimir-pedido-dialog/imprimir-pedido-dialog.component';
+import { LucroPorFuncionarioComponent } from './venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component';
 
 @NgModule({
   declarations: [
@@ -134,7 +135,8 @@ import { ImprimirPedidoDialogComponent } from './compra/gestion-compras/dialogs/
     AdicionarNotaDialogComponent,
     AdicionarFormaPagoDialogComponent,
     GestionPagoDialogComponent,
-    GenericListVentaComponent
+    GenericListVentaComponent,
+    LucroPorFuncionarioComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/operaciones/venta/graphql/graphql-query.ts
+++ b/src/app/modules/operaciones/venta/graphql/graphql-query.ts
@@ -476,3 +476,78 @@ export const reporteGenericVentasQuery = gql`
     )
   }
 `;
+
+export const lucroPorFuncionarioQuery = gql`
+  query lucroPorFuncionario(
+    $fechaInicio: String
+    $fechaFin: String
+    $sucursalIdList: [ID]
+    $usuarioId: ID!
+    $usuarioIdList: [ID]
+    $productoIdList: [ID]
+    $subfamiliaId: ID
+    $familiaId: ID
+  ) {
+    data: lucroPorFuncionario(
+      fechaInicio: $fechaInicio
+      fechaFin: $fechaFin
+      sucursalIdList: $sucursalIdList
+      usuarioId: $usuarioId
+      usuarioIdList: $usuarioIdList
+      productoIdList: $productoIdList
+      subfamiliaId: $subfamiliaId
+      familiaId: $familiaId
+    )
+  }
+`;
+
+export const lucroPorFuncionarioListQuery = gql`
+  query lucroPorFuncionarioList(
+    $fechaInicio: String
+    $fechaFin: String
+    $sucursalIdList: [ID]
+    $usuarioIdList: [ID]
+    $productoIdList: [ID]
+    $subfamiliaId: ID
+    $page: Int
+    $size: Int
+    $familiaId: ID
+  ) {
+    data: lucroPorFuncionarioList(
+      fechaInicio: $fechaInicio
+      fechaFin: $fechaFin
+      sucursalIdList: $sucursalIdList
+      usuarioIdList: $usuarioIdList
+      productoIdList: $productoIdList
+      subfamiliaId: $subfamiliaId
+      page: $page
+      size: $size
+      familiaId: $familiaId
+    ) {
+      content {
+        usuarioId
+        nombreFuncionario
+        cantidad
+        costoTotal
+        costoUnitario
+        totalVenta
+        lucro
+        percent
+        ventaMedia
+        margen
+        totalDescuento
+        totalAumento
+      }
+      totalElements
+      summary {
+        cantidad
+        costoTotal
+        totalVenta
+        lucro
+        margen
+        totalDescuento
+        totalAumento
+      }
+    }
+  }
+`;

--- a/src/app/modules/operaciones/venta/graphql/lucroPorFuncionarioList.ts
+++ b/src/app/modules/operaciones/venta/graphql/lucroPorFuncionarioList.ts
@@ -1,0 +1,10 @@
+import { Injectable } from "@angular/core";
+import { Query } from "apollo-angular";
+import { lucroPorFuncionarioListQuery } from "./graphql-query";
+
+@Injectable({
+  providedIn: "root",
+})
+export class LucroPorFuncionarioListGQL extends Query<any> {
+  document = lucroPorFuncionarioListQuery;
+}

--- a/src/app/modules/operaciones/venta/graphql/reporteLucroPorFuncionario.ts
+++ b/src/app/modules/operaciones/venta/graphql/reporteLucroPorFuncionario.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { lucroPorFuncionarioQuery } from './graphql-query';
+
+export class Response {
+  data: string
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ReporteLucroPorFuncionarioGQL extends Query<Response> {
+  document = lucroPorFuncionarioQuery;
+}

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.html
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.html
@@ -272,6 +272,17 @@
               >clear</mat-icon
             >
           </div>
+          <div
+            fxLayout="row"
+            fxLayoutAlign="center center"
+            fxLayoutGap="4px"
+            class="ver-grafico-action"
+            matTooltip="Ver gráfico de ventas por funcionario con los datos del reporte"
+            (click)="onIrAGraficoVentas()"
+          >
+            <mat-icon class="icon">bar_chart</mat-icon>
+            <span class="ver-grafico-label">Ver gráfico</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.html
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.html
@@ -110,33 +110,51 @@
           </mat-select>
         </mat-form-field>
       </div>
-      <div fxFlex="30%" fxLayout="row" fxLayoutAlign="start center">
-        <div fxFlex="80%">
-          <mat-form-field style="width: 100%">
-            <mat-label>Buscar funcionario</mat-label>
-            <input
-              #funcionarioInput
-              type="text"
-              matInput
-              [formControl]="buscarFuncionarioControl"
-              (keyup.enter)="onBuscarFuncionario()"
-            />
-          </mat-form-field>
-        </div>
-        <div fxFlex="10%" style="text-align: center">
-          <mat-icon class="icon" (click)="onBuscarFuncionario()"
-            >search</mat-icon
+      <div fxFlex="30%" fxLayout="column" fxLayoutGap="5px">
+        <div fxLayout="row" fxLayoutAlign="start center">
+          <div fxFlex="80%">
+            <mat-form-field style="width: 100%">
+              <mat-label>Buscar funcionario</mat-label>
+              <input
+                #funcionarioInput
+                type="text"
+                matInput
+                [formControl]="buscarFuncionarioControl"
+                (keyup.enter)="onBuscarFuncionario()"
+              />
+            </mat-form-field>
+          </div>
+          <div fxFlex="10%" style="text-align: center">
+            <mat-icon class="icon" (click)="onBuscarFuncionario()"
+              >search</mat-icon
+            >
+          </div>
+          <div
+            fxFlex="10%"
+            style="text-align: center"
+            *ngIf="funcionarioList.length > 0"
           >
+            <mat-icon style="font-size: 2em" (click)="onClearFuncionario()"
+            class="highlight-hover-danger"
+              >clear</mat-icon
+            >
+          </div>
         </div>
         <div
-          fxFlex="10%"
-          style="text-align: center"
-          *ngIf="selectedUsuario != null"
+          fxLayout="row"
+          *ngFor="let funcionario of funcionarioList; let index = index"
         >
-          <mat-icon style="font-size: 2em" (click)="onClearFuncionario()"
-          class="highlight-hover-danger"
-            >clear</mat-icon
-          >
+          <div fxFlex="80%">
+            {{ funcionario.id }} - {{ getFuncionarioDisplayName(funcionario) }}
+          </div>
+          <div fxFlex="10%" style="text-align: center">
+            <mat-icon
+              style="font-size: 2em"
+              (click)="onClearFuncionario(index)"
+              class="highlight-hover-danger"
+              >clear</mat-icon
+            >
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.html
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.html
@@ -1,0 +1,499 @@
+<app-generic-list
+  [data]="dataSource.data"
+  (cargarMasDatos)="cargarMasDatos()"
+  [isLastPage]="isLastPage"
+  (filtrar)="onFiltrar()"
+  (resetFiltro)="resetFiltro()"
+  [isCustom]="true"
+  customName="Generar Pdf"
+  (customFunction)="onGenerarPdf()"
+>
+  <div filtros>
+    <div
+      fxLayout="row"
+      fxLayoutAlign="start center"
+      fxLayoutGap="10px"
+      style="width: 100%"
+    >
+      <div fxFlex="20%">
+        <mat-form-field style="width: 100%">
+          <mat-label>Rango de fecha</mat-label>
+          <mat-date-range-input
+            [formGroup]="fechaFormGroup"
+            [rangePicker]="picker"
+            style="width: 100%"
+          >
+            <input
+              matStartDate
+              formControlName="inicio"
+              placeholder="Inicio"
+              [max]="today"
+            />
+            <input
+              matEndDate
+              formControlName="fin"
+              placeholder="Fin"
+              [max]="fechaInicioControl.value"
+            />
+          </mat-date-range-input>
+          <mat-datepicker-toggle
+            matSuffix
+            [for]="picker"
+          ></mat-datepicker-toggle>
+          <mat-date-range-picker #picker></mat-date-range-picker>
+
+          <mat-error
+            *ngIf="
+              fechaFormGroup.controls.inicio.hasError('matStartDateInvalid')
+            "
+            >Fecha inicial inválida</mat-error
+          >
+          <mat-error
+            *ngIf="fechaFormGroup.controls.fin.hasError('matEndDateInvalid')"
+            >Fecha final inválida</mat-error
+          >
+        </mat-form-field>
+      </div>
+      <div fxFlex="10%">
+        <mat-form-field style="width: 100%;">
+          <mat-label>Inicio Hora</mat-label>
+          <input
+            matInput
+            [formControl]="horaInicioControl"
+            type="time"
+            placeholder="Hora inicio"
+          />
+        </mat-form-field>
+      </div>
+      <div fxFlex="10%">
+        <mat-form-field style="width: 100%;">
+          <mat-label>Fin Hora</mat-label>
+          <input
+            matInput
+            [formControl]="horaFinalControl"
+            type="time"
+            placeholder="Hora fin"
+          />
+        </mat-form-field>
+      </div>
+      <div fxFlex="25%">
+        <mat-form-field style="width: 100%">
+          <mat-label>Sucursales</mat-label>
+          <mat-select #sucursalSelect [formControl]="sucursalControl" multiple>
+            <mat-select-trigger>
+              {{(sucursalControl.value?.[0]?.nombre || '')}}
+              <span
+                *ngIf="(sucursalControl.value?.length || 0) > 1"
+                class="example-additional-selection"
+              >
+                (+{{ (sucursalControl.value?.length || 0) - 1 }}
+                {{ sucursalControl.value?.length === 2 ? "otro" : "otros" }})
+              </span>
+            </mat-select-trigger>
+            <div
+              style="
+                width: 100%;
+                text-align: end;
+                padding-right: 10px;
+                padding-top: 10px;
+                font-size: 0.8em;
+                color: white;
+              "
+            >
+              <mat-icon (click)="sucursalSelect.close()">clear</mat-icon>
+            </div>
+            <mat-option [value]="null">Todas</mat-option>
+            <mat-option *ngFor="let sucursal of sucursalList" [value]="sucursal"
+              >{{ sucursal?.id }} -
+              {{ sucursal?.nombre | titlecase }}</mat-option
+            >
+          </mat-select>
+        </mat-form-field>
+      </div>
+      <div fxFlex="30%" fxLayout="row" fxLayoutAlign="start center">
+        <div fxFlex="80%">
+          <mat-form-field style="width: 100%">
+            <mat-label>Buscar funcionario</mat-label>
+            <input
+              #funcionarioInput
+              type="text"
+              matInput
+              [formControl]="buscarFuncionarioControl"
+              (keyup.enter)="onBuscarFuncionario()"
+            />
+          </mat-form-field>
+        </div>
+        <div fxFlex="10%" style="text-align: center">
+          <mat-icon class="icon" (click)="onBuscarFuncionario()"
+            >search</mat-icon
+          >
+        </div>
+        <div
+          fxFlex="10%"
+          style="text-align: center"
+          *ngIf="selectedUsuario != null"
+        >
+          <mat-icon style="font-size: 2em" (click)="onClearFuncionario()"
+          class="highlight-hover-danger"
+            >clear</mat-icon
+          >
+        </div>
+      </div>
+    </div>
+    <div
+      fxLayout="row"
+      fxLayoutAlign="start start"
+      fxLayoutGap="10px"
+      style="width: 100%"
+    >
+      <!-- Columna Producto -->
+      <div fxFlex="33%" fxLayout="column" fxLayoutGap="10px">
+        <div fxFlex fxLayoutAlign="start center">
+          <div fxFlex="80%">
+            <mat-form-field style="width: 100%">
+              <mat-label>Buscar producto</mat-label>
+              <input
+                #buscadorInput
+                type="text"
+                matInput
+                [formControl]="buscarProductoControl"
+                (keyup.enter)="onBuscarProducto()"
+              />
+            </mat-form-field>
+          </div>
+          <div fxFlex="10%" style="text-align: center">
+            <mat-icon class="icon" (click)="onBuscarProducto()"
+              >search</mat-icon
+            >
+          </div>
+          <div fxFlex="10%" style="text-align: center">
+            <mat-icon style="font-size: 2em" (click)="onAddProducto()"
+              >add</mat-icon
+            >
+          </div>
+        </div>
+        <div
+          fxFlex
+          fxLayout="row"
+          *ngFor="let producto of productoList; let index = index"
+        >
+          <div fxFlex="80%">{{ producto.id }} - {{ producto.descripcion }}</div>
+          <div fxFlex="10%" style="text-align: center">
+            <mat-icon
+              style="font-size: 2em"
+              (click)="onClearProducto(producto, index)"
+              class="highlight-hover-danger"
+              >clear</mat-icon
+            >
+          </div>
+        </div>
+      </div>
+
+      <!-- Columna Familia -->
+      <div fxFlex="25%" fxLayout="column">
+        <div fxFlex fxLayoutAlign="start center">
+          <div fxFlex="80%">
+            <mat-form-field style="width: 100%">
+              <mat-label>Buscar familia</mat-label>
+              <input
+                #familiaInput
+                type="text"
+                matInput
+                [formControl]="buscarFamiliaControl"
+                (keyup.enter)="onBuscarFamilia()"
+              />
+            </mat-form-field>
+          </div>
+          <div fxFlex="10%" style="text-align: center">
+            <mat-icon
+              class="icon"
+              (click)="onBuscarFamilia(); $event.stopPropagation()"
+              >search</mat-icon
+            >
+          </div>
+          <div style="text-align: center">
+            <mat-icon
+              style="font-size: 2em"
+              (click)="onClearFamilia()"
+              *ngIf="selectedFamilia != null"
+              class="highlight-hover-danger"
+              >clear</mat-icon
+            >
+          </div>
+        </div>
+      </div>
+
+      <!-- Columna Subfamilia -->
+      <div fxFlex="25%" fxLayout="column">
+        <div fxFlex fxLayoutAlign="start center">
+          <div fxFlex="80%">
+            <mat-form-field style="width: 100%">
+              <mat-label>Buscar subfamilia</mat-label>
+              <input
+                #subfamiliaInput
+                type="text"
+                matInput
+                [formControl]="buscarSubfamiliaControl"
+                (keyup.enter)="onBuscarSubFamilia()"
+              />
+            </mat-form-field>
+          </div>
+          <div fxFlex="10%" style="text-align: center">
+            <mat-icon
+              class="icon"
+              (click)="onBuscarSubFamilia(); $event.stopPropagation()"
+              >search</mat-icon
+            >
+          </div>
+          <div style="text-align: center">
+            <mat-icon
+              style="font-size: 2em"
+              (click)="onClearSubFamilia()"
+              *ngIf="selectedSubFamilia != null"
+              class="highlight-hover-danger"
+              >clear</mat-icon
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div table fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between start"
+    style="height: 80vh; width: 100%; overflow: hidden;">
+    <div fxFlex="20" fxLayout="column" fxLayoutGap="10px" class="resumen-container"
+      style="
+        background-color: rgb(32, 32, 32); 
+        height: 100%; 
+        overflow-y: auto; 
+        padding-right: 5px;
+      "
+    >
+      <br/>
+      <div class="titulo-center">Resumen</div>
+      
+      <div fxLayout="column" fxLayoutGap="10px" style="padding: 10px;">
+        <div fxLayout="row" fxLayoutAlign="space-between center">
+          <div class="titulo">Venta Total:</div>
+          <div>
+            {{ totalVenta | number : "1.0-0" }} Gs.
+          </div>
+        </div>
+        <div fxLayout="row" fxLayoutAlign="space-between center">
+          <div class="titulo">Costo Total:</div>
+          <div>
+            {{ totalCosto | number : "1.0-0" }} Gs.
+          </div>
+        </div>
+        <mat-divider></mat-divider>
+        <div fxLayout="row" fxLayoutAlign="space-between center">
+          <div class="titulo">Descuento Total:</div>
+          <div>
+            {{ totalDescuento | number : "1.0-0" }} Gs.
+          </div>
+        </div>
+        <div fxLayout="row" fxLayoutAlign="space-between center">
+          <div class="titulo">Aumento Total:</div>
+          <div>
+            {{ totalAumento | number : "1.0-0" }} Gs.
+          </div>
+        </div>
+        <mat-divider></mat-divider>
+        <div fxLayout="row" fxLayoutAlign="space-between center">
+          <div class="titulo">Lucro Total:</div>
+          <div style="font-weight: bold; color: #4caf50;">
+            {{ totalLucro | number : "1.0-0" }} Gs.
+          </div>
+        </div>
+        <div fxLayout="row" fxLayoutAlign="space-between center">
+          <div class="titulo">Margen s/ costo:</div>
+          <div>
+            {{ margenCostoPromedio | number : "1.2-2" }} %
+          </div>
+        </div>
+        <div fxLayout="row" fxLayoutAlign="space-between center">
+          <div class="titulo">Margen s/ venta:</div>
+          <div>
+            {{ margenPromedio | number : "1.2-2" }} %
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div 
+      fxFlex="80" 
+      style="
+        height: 100%; 
+        background-color: rgb(70, 70, 70); 
+        height: 100%; 
+        overflow-y: auto;" 
+      fxLayout="column" 
+      fxLayoutAlign="space-between start"
+    >
+      <div style="flex: 1; overflow: auto; width: 100%">
+        <table mat-table [dataSource]="dataSource" class="mat-elevation-z8" style="width: 100%">
+          
+          <!-- ID Column -->
+          <ng-container matColumnDef="id">
+            <th 
+              mat-header-cell 
+              *matHeaderCellDef 
+              style="
+                text-align: center; 
+                width: 5%; 
+                padding: 0
+              "
+            > 
+              ID 
+            </th>
+            <td 
+              mat-cell 
+              *matCellDef="let funcionario" 
+              style="
+                text-align: center; 
+                width: 5%; 
+                padding: 0
+              "
+            > 
+              {{funcionario.usuarioId}} 
+            </td>
+          </ng-container>
+
+          <!-- Funcionario Column -->
+          <ng-container matColumnDef="nombreFuncionario">
+            <th mat-header-cell *matHeaderCellDef> 
+              Funcionario 
+            </th>
+            <td mat-cell *matCellDef="let funcionario"> 
+              {{funcionario.nombreFuncionario}} 
+            </td>
+          </ng-container>
+
+          <!-- Quantity Column -->
+          <ng-container matColumnDef="cantidad">
+            <th 
+              mat-header-cell 
+              *matHeaderCellDef 
+              style="text-align: center; padding: 0"
+            > 
+              Cantidad 
+            </th>
+            <td 
+              mat-cell 
+              *matCellDef="let funcionario" 
+              style="text-align: center; padding: 0"
+            > 
+              {{funcionario.cantidad | number: '1.0-2'}} 
+            </td>
+          </ng-container>
+
+          <!-- Medium Cost Column -->
+          <ng-container matColumnDef="costoUnitario">
+            <th mat-header-cell *matHeaderCellDef class="cellAlignment"> 
+              Costo Medio 
+            </th>
+            <td mat-cell *matCellDef="let funcionario" class="cellAlignment"> 
+              {{funcionario.costoUnitario | number: '1.0-0'}} Gs. 
+            </td>
+          </ng-container>
+
+          <!-- Medium Sale Column -->
+          <ng-container matColumnDef="ventaMedia">
+            <th mat-header-cell *matHeaderCellDef class="cellAlignment"> 
+              Venta Media 
+            </th>
+            <td mat-cell *matCellDef="let funcionario" class="cellAlignment"> 
+              {{ funcionario.ventaMedia | number: '1.0-0' }} Gs. 
+            </td>
+          </ng-container>
+
+          <!-- Total Cost Column -->
+          <ng-container matColumnDef="costoTotal">
+            <th mat-header-cell *matHeaderCellDef class="cellAlignment"> 
+              Costo Total 
+            </th>
+            <td mat-cell *matCellDef="let funcionario" class="cellAlignment"> 
+              {{funcionario.costoTotal | number: '1.0-0'}} Gs. 
+            </td>
+          </ng-container>
+
+          <!-- Total Sale Column -->
+          <ng-container matColumnDef="totalVenta">
+            <th mat-header-cell *matHeaderCellDef class="cellAlignment"> 
+              Venta Total 
+            </th>
+            <td mat-cell *matCellDef="let funcionario" class="cellAlignment"> 
+              {{funcionario.totalVenta | number: '1.0-0'}} Gs. 
+            </td>
+          </ng-container>
+
+          <!-- Discount Column -->
+          <ng-container matColumnDef="totalDescuento">
+            <th mat-header-cell *matHeaderCellDef class="cellAlignment"> 
+              Descuento 
+            </th>
+            <td mat-cell *matCellDef="let funcionario" class="cellAlignment"> 
+              {{funcionario.totalDescuento | number: '1.0-0'}} Gs. 
+            </td>
+          </ng-container>
+
+          <!-- Increase Column -->
+          <ng-container matColumnDef="totalAumento">
+            <th mat-header-cell *matHeaderCellDef class="cellAlignment"> 
+              Aumento 
+            </th>
+            <td mat-cell *matCellDef="let funcionario" class="cellAlignment"> 
+              {{funcionario.totalAumento | number: '1.0-0'}} Gs. 
+            </td>
+          </ng-container>
+
+          <!-- Profit Column -->
+          <ng-container matColumnDef="lucro">
+            <th mat-header-cell *matHeaderCellDef class="cellAlignment"> 
+              Lucro 
+            </th>
+            <td mat-cell *matCellDef="let funcionario" class="cellAlignment" 
+              [style.color]="funcionario.lucro >= 0 ? '#4caf50' : '#f44336'"
+              style="font-weight: bold;"
+            > 
+              {{funcionario.lucro | number: '1.0-0'}} Gs. 
+            </td>
+          </ng-container>
+
+          <!-- Margen sobre costo -->
+          <ng-container matColumnDef="margenCosto">
+            <th mat-header-cell *matHeaderCellDef class="cellAlignment"> 
+              Margen s/ costo % 
+            </th>
+            <td mat-cell *matCellDef="let funcionario" class="cellAlignment"> 
+              {{funcionario.margen | number: '1.2-2'}} % 
+            </td>
+          </ng-container>
+
+          <!-- Margen sobre venta -->
+          <ng-container matColumnDef="margenVenta">
+            <th mat-header-cell *matHeaderCellDef class="cellAlignment"> 
+              Margen s/ venta % 
+            </th>
+            <td mat-cell *matCellDef="let funcionario" class="cellAlignment"> 
+              {{funcionario.percent | number: '1.2-2'}} % 
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+      </div>
+      <mat-paginator
+        [length]="totalElements"
+        [pageSize]="size"
+        [pageIndex]="page"
+        [pageSizeOptions]="[10, 20, 50, 100]"
+        (page)="handlePageEvent($event)"
+        showFirstLastButtons
+        aria-label="Select page"
+        style="width: 100%"
+      >
+      </mat-paginator>
+    </div>
+  </div>
+</app-generic-list>

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.scss
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.scss
@@ -11,6 +11,25 @@ input {
   font-size: 2em;
 }
 
+.ver-grafico-action {
+  cursor: pointer;
+  white-space: nowrap;
+  padding: 0 4px;
+
+  &:hover {
+    color: rgb(0, 172, 46);
+
+    .ver-grafico-label {
+      color: rgb(0, 172, 46);
+    }
+  }
+}
+
+.ver-grafico-label {
+  font-size: 0.85em;
+  user-select: none;
+}
+
 .cellAlignment {
   text-align: center;
   width: 8%;

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.scss
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.scss
@@ -1,0 +1,18 @@
+input {
+  text-transform: uppercase;
+}
+
+.icon:hover {
+  color: rgb(0, 172, 46);
+  cursor: pointer;
+}
+
+.icon {
+  font-size: 2em;
+}
+
+.cellAlignment {
+  text-align: center;
+  width: 8%;
+  padding: 0
+}

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.spec.ts
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LucroPorFuncionarioComponent } from './lucro-por-funcionario.component';
+
+describe('LucroPorFuncionarioComponent', () => {
+  let component: LucroPorFuncionarioComponent;
+  let fixture: ComponentFixture<LucroPorFuncionarioComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LucroPorFuncionarioComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LucroPorFuncionarioComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.ts
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.ts
@@ -3,7 +3,7 @@ import { MatTableDataSource } from "@angular/material/table";
 import { LucroPorFuncionario } from "./lucro-por-funcionario.model";
 import { FormControl, FormGroup } from "@angular/forms";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import { Observable, of } from "rxjs";
+import { Observable, forkJoin, of } from "rxjs";
 import { map, switchMap } from "rxjs/operators";
 import { Sucursal } from "../../../../empresarial/sucursal/sucursal.model";
 import { SucursalService } from "../../../../empresarial/sucursal/sucursal.service";
@@ -27,7 +27,6 @@ import {
   TableData,
 } from "../../../../../shared/components/search-list-dialog/search-list-dialog.component";
 import { UsuarioService } from "../../../../personas/usuarios/usuario.service";
-import { Usuario } from "../../../../personas/usuarios/usuario.model";
 import { Subfamilia } from "../../../../productos/sub-familia/sub-familia.model";
 import { SubfamiliasSearchGQL } from "../../../../productos/sub-familia/graphql/subfamiliasSearch";
 import { SearchSubfamiliaByDescripcionGQL } from "../../../../productos/sub-familia/graphql/searchByDescripcion";
@@ -35,7 +34,6 @@ import { FuncionariosWithPageGQL } from "../../../../personas/funcionarios/graph
 import { Funcionario } from "../../../../personas/funcionarios/funcionario.model";
 import { Familia } from "../../../../productos/familia/familia.model";
 import { FamiliasSearchGQL } from "../../../../productos/familia/graphql/familiasSearch";
-import { FuncionarioService } from "../../../../personas/funcionarios/funcionario.service";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -65,12 +63,10 @@ export class LucroPorFuncionarioComponent implements OnInit {
   selectedProducto: Producto;
   productoList: Producto[] = [];
   buscarFuncionarioControl = new FormControl();
-  selectedUsuario: Usuario;
-  selectedFuncionario: Funcionario;
+  funcionarioList: Funcionario[] = [];
   selectedSubFamilia: Subfamilia;
   selectedFamilia: Familia;
   buscarFamiliaControl = new FormControl();
-  funcionarioIdList: number[];
 
   displayedColumns: string[] = [
     "id",
@@ -110,8 +106,7 @@ export class LucroPorFuncionarioComponent implements OnInit {
     private searchSubfamilia: SearchSubfamiliaByDescripcionGQL,
     private searchSubfamiliaFiltered: SubfamiliasSearchGQL,
     private searchFamilia: FamiliasSearchGQL,
-    private matDialog: MatDialog,
-    private funcionarioService: FuncionarioService
+    private matDialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -201,7 +196,6 @@ export class LucroPorFuncionarioComponent implements OnInit {
       this.resolveUsuarioIdList()
         .pipe(
           switchMap((usuarioIdList) => {
-            this.funcionarioIdList = usuarioIdList;
             return this.ventaService.onGetLucroPorFuncionario(
               fechaInicio,
               fechaFin,
@@ -229,59 +223,43 @@ export class LucroPorFuncionarioComponent implements OnInit {
   }
 
   private resolveUsuarioIdList(): Observable<number[]> {
-    if (this.selectedUsuario?.id != null) {
-      return of([this.selectedUsuario.id]);
-    }
-
-    const text = this.buscarFuncionarioControl.value?.trim();
-    if (!text) {
+    if (this.funcionarioList.length === 0) {
       return of([]);
     }
 
-    const match = text.match(/^(\d+)\s*-/);
-    if (!match) {
-      this.notificacionService.openWarn(
-        "Seleccione un funcionario de la lista para aplicar el filtro"
-      );
-      return of([]);
-    }
-
-    const funcionarioId = parseInt(match[1], 10);
-    return this.funcionarioService.onGetFuncionarioById(funcionarioId).pipe(
-      switchMap((funcionario) => this.resolveUsuarioFromFuncionario(funcionario))
+    return forkJoin(
+      this.funcionarioList.map((funcionario) =>
+        this.resolveUsuarioIdFromFuncionario(funcionario)
+      )
+    ).pipe(
+      map((usuarioIds) => {
+        const validIds = usuarioIds.filter((id) => id != null) as number[];
+        if (validIds.length < this.funcionarioList.length) {
+          this.notificacionService.openWarn(
+            "Algunos funcionarios seleccionados no tienen un usuario asociado"
+          );
+        }
+        return validIds;
+      })
     );
   }
 
-  private resolveUsuarioFromFuncionario(
+  private resolveUsuarioIdFromFuncionario(
     funcionario: Funcionario
-  ): Observable<number[]> {
+  ): Observable<number | null> {
     if (funcionario?.persona?.id) {
       return this.usuarioService
         .onGetUsuarioPorPersonaId(funcionario.persona.id)
         .pipe(
           map((usuario) => {
             if (usuario?.id) {
-              this.selectedFuncionario = funcionario;
-              this.selectedUsuario = usuario;
-              return [usuario.id];
+              return usuario.id;
             }
-            return this.applyFuncionarioUsuarioFallback(funcionario);
+            return funcionario?.usuario?.id ?? null;
           })
         );
     }
-    return of(this.applyFuncionarioUsuarioFallback(funcionario));
-  }
-
-  private applyFuncionarioUsuarioFallback(funcionario: Funcionario): number[] {
-    if (funcionario?.usuario?.id) {
-      this.selectedFuncionario = funcionario;
-      this.selectedUsuario = { id: funcionario.usuario.id } as Usuario;
-      return [funcionario.usuario.id];
-    }
-    this.notificacionService.openWarn(
-      "El funcionario seleccionado no tiene un usuario asociado"
-    );
-    return [];
+    return of(funcionario?.usuario?.id ?? null);
   }
 
   handlePageEvent(e: any) {
@@ -317,8 +295,7 @@ export class LucroPorFuncionarioComponent implements OnInit {
     this.buscarSubfamiliaControl.setValue(null);
     this.buscarFamiliaControl.setValue(null);
     this.buscarFuncionarioControl.setValue(null);
-    this.selectedUsuario = null;
-    this.selectedFuncionario = null;
+    this.funcionarioList = [];
     this.selectedSubFamilia = null;
     this.selectedFamilia = null;
     this.productoList = [];
@@ -460,6 +437,8 @@ export class LucroPorFuncionarioComponent implements OnInit {
       queryData: { nombre: this.buscarFuncionarioControl.value },
       inicialSearch: true,
       paginator: true,
+      multiple: true,
+      seleccionadosIniciales: [...this.funcionarioList],
     };
     this.dialog
       .open(SearchListDialogComponent, {
@@ -469,38 +448,22 @@ export class LucroPorFuncionarioComponent implements OnInit {
       })
       .afterClosed()
       .pipe(untilDestroyed(this))
-      .subscribe((res: Funcionario) => {
-        if (res != null) {
-          this.selectedFuncionario = res;
-          this.selectedUsuario = null;
-          const nombre = res.persona?.nombre || res.nickname || "";
-          this.buscarFuncionarioControl.setValue(res.id + " - " + nombre);
-
-          if (res.persona?.id) {
-            this.usuarioService
-              .onGetUsuarioPorPersonaId(res.persona.id)
-              .pipe(untilDestroyed(this))
-              .subscribe((resUsuario) => {
-                if (resUsuario?.id) {
-                  this.selectedUsuario = resUsuario;
-                } else if (res.usuario?.id) {
-                  this.selectedUsuario = { id: res.usuario.id } as Usuario;
-                } else {
-                  this.notificacionService.openWarn(
-                    "Nombre de usuario no encontrado"
-                  );
-                  this.buscadorFuncionarioInput.nativeElement.select();
-                }
-              });
-          } else if (res.usuario?.id) {
-            this.selectedUsuario = { id: res.usuario.id } as Usuario;
-          } else {
-            this.notificacionService.openWarn(
-              "El funcionario seleccionado no tiene un usuario asociado"
-            );
-          }
+      .subscribe((res: Funcionario[] | Funcionario) => {
+        if (Array.isArray(res)) {
+          this.aplicarFuncionariosFiltro(res);
+        } else if (res != null) {
+          this.aplicarFuncionariosFiltro([res]);
         }
       });
+  }
+
+  aplicarFuncionariosFiltro(funcionarios: Funcionario[]) {
+    this.funcionarioList = funcionarios || [];
+    this.buscarFuncionarioControl.setValue(null);
+  }
+
+  getFuncionarioDisplayName(funcionario: Funcionario): string {
+    return funcionario?.persona?.nombre || funcionario?.nickname || "";
   }
 
   onBuscarFamilia() {
@@ -581,9 +544,12 @@ export class LucroPorFuncionarioComponent implements OnInit {
     this.buscarSubfamiliaControl.setValue(null);
   }
 
-  onClearFuncionario() {
-    this.selectedUsuario = null;
-    this.selectedFuncionario = null;
+  onClearFuncionario(index?: number) {
+    if (index != null) {
+      this.funcionarioList.splice(index, 1);
+      return;
+    }
+    this.funcionarioList = [];
     this.buscarFuncionarioControl.setValue(null);
     this.buscadorFuncionarioInput.nativeElement.focus();
   }

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.ts
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.ts
@@ -1,0 +1,590 @@
+import { Component, ElementRef, OnInit, ViewChild } from "@angular/core";
+import { MatTableDataSource } from "@angular/material/table";
+import { LucroPorFuncionario } from "./lucro-por-funcionario.model";
+import { FormControl, FormGroup } from "@angular/forms";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { Observable, of } from "rxjs";
+import { map, switchMap } from "rxjs/operators";
+import { Sucursal } from "../../../../empresarial/sucursal/sucursal.model";
+import { SucursalService } from "../../../../empresarial/sucursal/sucursal.service";
+import {
+  combineDateTime,
+  dateToString,
+} from "../../../../../commons/core/utils/dateUtils";
+import { VentaService } from "../../venta.service";
+import { MatDialog } from "@angular/material/dialog";
+import { Producto } from "../../../../productos/producto/producto.model";
+import { ProductoService } from "../../../../productos/producto/producto.service";
+import {
+  PdvSearchProductoData,
+  PdvSearchProductoDialogComponent,
+  PdvSearchProductoResponseData,
+} from "../../../../productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component";
+import { NotificacionSnackbarService } from "../../../../../notificacion-snackbar.service";
+import {
+  SearchListDialogComponent,
+  SearchListtDialogData,
+  TableData,
+} from "../../../../../shared/components/search-list-dialog/search-list-dialog.component";
+import { UsuarioService } from "../../../../personas/usuarios/usuario.service";
+import { Usuario } from "../../../../personas/usuarios/usuario.model";
+import { Subfamilia } from "../../../../productos/sub-familia/sub-familia.model";
+import { SubfamiliasSearchGQL } from "../../../../productos/sub-familia/graphql/subfamiliasSearch";
+import { SearchSubfamiliaByDescripcionGQL } from "../../../../productos/sub-familia/graphql/searchByDescripcion";
+import { FuncionariosWithPageGQL } from "../../../../personas/funcionarios/graphql/funcionarios-with-page";
+import { Funcionario } from "../../../../personas/funcionarios/funcionario.model";
+import { Familia } from "../../../../productos/familia/familia.model";
+import { FamiliasSearchGQL } from "../../../../productos/familia/graphql/familiasSearch";
+import { FuncionarioService } from "../../../../personas/funcionarios/funcionario.service";
+
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: "app-lucro-por-funcionario",
+  templateUrl: "./lucro-por-funcionario.component.html",
+  styleUrls: ["./lucro-por-funcionario.component.scss"],
+})
+export class LucroPorFuncionarioComponent implements OnInit {
+  @ViewChild("buscadorInput", { static: true }) buscadorInput: ElementRef;
+  @ViewChild("funcionarioInput", { static: true })
+  buscadorFuncionarioInput: ElementRef;
+
+  dataSource = new MatTableDataSource<LucroPorFuncionario>([]);
+  isLastPage = true;
+  sucursalControl = new FormControl();
+  fechaFormGroup: FormGroup;
+  today = new Date();
+  fechaInicioControl = new FormControl();
+  fechaFinalControl = new FormControl();
+  horaInicioControl = new FormControl("00:00");
+  horaFinalControl = new FormControl("23:59");
+  sucursalList: Sucursal[];
+  sucursalIdList: number[];
+  previousSelectedSucursales: any[] = [];
+  buscarProductoControl = new FormControl();
+  buscarSubfamiliaControl = new FormControl();
+  selectedProducto: Producto;
+  productoList: Producto[] = [];
+  buscarFuncionarioControl = new FormControl();
+  selectedUsuario: Usuario;
+  selectedFuncionario: Funcionario;
+  selectedSubFamilia: Subfamilia;
+  selectedFamilia: Familia;
+  buscarFamiliaControl = new FormControl();
+  funcionarioIdList: number[];
+
+  displayedColumns: string[] = [
+    "id",
+    "nombreFuncionario",
+    "cantidad",
+    "costoUnitario",
+    "ventaMedia",
+    "costoTotal",
+    "totalVenta",
+    "totalDescuento",
+    "totalAumento",
+    "lucro",
+    "margenCosto",
+    "margenVenta",
+  ];
+
+  totalVenta = 0;
+  totalCosto = 0;
+  totalLucro = 0;
+  totalDescuento = 0;
+  totalAumento = 0;
+  margenPromedio = 0;
+  margenCostoPromedio = 0;
+
+  page = 0;
+  size = 20;
+  totalElements = 0;
+
+  constructor(
+    private sucursalService: SucursalService,
+    private ventaService: VentaService,
+    private productoService: ProductoService,
+    private dialog: MatDialog,
+    private notificacionService: NotificacionSnackbarService,
+    private funcionariosWithPage: FuncionariosWithPageGQL,
+    private usuarioService: UsuarioService,
+    private searchSubfamilia: SearchSubfamiliaByDescripcionGQL,
+    private searchSubfamiliaFiltered: SubfamiliasSearchGQL,
+    private searchFamilia: FamiliasSearchGQL,
+    private matDialog: MatDialog,
+    private funcionarioService: FuncionarioService
+  ) {}
+
+  ngOnInit(): void {
+    let hoy = new Date();
+    let aux = new Date();
+    aux.setDate(hoy.getDate() - 2);
+
+    this.fechaInicioControl.setValue(aux);
+    this.fechaFinalControl.setValue(hoy);
+
+    this.fechaFormGroup = new FormGroup({
+      inicio: this.fechaInicioControl,
+      fin: this.fechaFinalControl,
+      inicioHora: this.horaInicioControl,
+      finHora: this.horaFinalControl,
+    });
+
+    this.sucursalControl.valueChanges
+      .pipe(untilDestroyed(this))
+      .subscribe((selectedValues: any[]) => {
+        if (!selectedValues) return;
+        const hasTodas = selectedValues.includes(null);
+        if (hasTodas && selectedValues.length > 1) {
+          const prevValues = this.previousSelectedSucursales || [];
+          const hadTodasPrev = prevValues.includes(null);
+
+          if (!hadTodasPrev) {
+            this.previousSelectedSucursales = [null];
+            this.sucursalControl.setValue([null], { emitEvent: false });
+          } else {
+            const newSelection = selectedValues.filter(val => val !== null);
+            this.previousSelectedSucursales = newSelection;
+            this.sucursalControl.setValue(newSelection, { emitEvent: false });
+          }
+        } else {
+          this.previousSelectedSucursales = selectedValues;
+        }
+      });
+
+    this.sucursalList = [];
+    this.sucursalIdList = [];
+
+    setTimeout(() => {
+      this.sucursalService
+        .onGetAllSucursales()
+        .pipe(untilDestroyed(this))
+        .subscribe((res) => {
+          this.sucursalList = res.filter((s) => {
+            if (s.id != 0) {
+              this.sucursalIdList.push(s.id);
+              return s;
+            }
+          });
+        });
+    });
+  }
+
+  onFiltrar(isPagination: boolean = false) {
+    if (!isPagination) {
+      this.page = 0;
+    }
+    if (this.fechaFormGroup.valid && this.sucursalControl.valid) {
+      if (this.horaInicioControl.value == null)
+        this.horaInicioControl.setValue("07:00");
+      if (this.horaFinalControl.value == null)
+        this.horaFinalControl.setValue("06:59");
+      this.fechaInicioControl.setValue(
+        combineDateTime(
+          this.fechaInicioControl.value,
+          this.horaInicioControl.value
+        )
+      );
+      this.fechaFinalControl.setValue(
+        combineDateTime(
+          this.fechaFinalControl.value,
+          this.horaFinalControl.value
+        )
+      );
+      let fechaInicio = dateToString(this.fechaInicioControl.value);
+      let fechaFin = dateToString(this.fechaFinalControl.value);
+      let productoIdList: number[];
+      this.productoList.forEach((p) => {
+        if (productoIdList == null) productoIdList = [];
+        productoIdList.push(p.id);
+      });
+
+      this.resolveUsuarioIdList()
+        .pipe(
+          switchMap((usuarioIdList) => {
+            this.funcionarioIdList = usuarioIdList;
+            return this.ventaService.onGetLucroPorFuncionario(
+              fechaInicio,
+              fechaFin,
+              this.toSucursalesId(this.sucursalControl.value),
+              usuarioIdList,
+              productoIdList,
+              this.selectedSubFamilia?.id,
+              this.page,
+              this.size,
+              this.selectedFamilia?.id
+            );
+          }),
+          untilDestroyed(this)
+        )
+        .subscribe((res) => {
+          if (res) {
+            this.dataSource.data = res.content || [];
+            this.totalElements = res.totalElements || 0;
+            if (res.summary) {
+              this.populateSummary(res.summary);
+            }
+          }
+        });
+    }
+  }
+
+  private resolveUsuarioIdList(): Observable<number[]> {
+    if (this.selectedUsuario?.id != null) {
+      return of([this.selectedUsuario.id]);
+    }
+
+    const text = this.buscarFuncionarioControl.value?.trim();
+    if (!text) {
+      return of([]);
+    }
+
+    const match = text.match(/^(\d+)\s*-/);
+    if (!match) {
+      this.notificacionService.openWarn(
+        "Seleccione un funcionario de la lista para aplicar el filtro"
+      );
+      return of([]);
+    }
+
+    const funcionarioId = parseInt(match[1], 10);
+    return this.funcionarioService.onGetFuncionarioById(funcionarioId).pipe(
+      switchMap((funcionario) => this.resolveUsuarioFromFuncionario(funcionario))
+    );
+  }
+
+  private resolveUsuarioFromFuncionario(
+    funcionario: Funcionario
+  ): Observable<number[]> {
+    if (funcionario?.persona?.id) {
+      return this.usuarioService
+        .onGetUsuarioPorPersonaId(funcionario.persona.id)
+        .pipe(
+          map((usuario) => {
+            if (usuario?.id) {
+              this.selectedFuncionario = funcionario;
+              this.selectedUsuario = usuario;
+              return [usuario.id];
+            }
+            return this.applyFuncionarioUsuarioFallback(funcionario);
+          })
+        );
+    }
+    return of(this.applyFuncionarioUsuarioFallback(funcionario));
+  }
+
+  private applyFuncionarioUsuarioFallback(funcionario: Funcionario): number[] {
+    if (funcionario?.usuario?.id) {
+      this.selectedFuncionario = funcionario;
+      this.selectedUsuario = { id: funcionario.usuario.id } as Usuario;
+      return [funcionario.usuario.id];
+    }
+    this.notificacionService.openWarn(
+      "El funcionario seleccionado no tiene un usuario asociado"
+    );
+    return [];
+  }
+
+  handlePageEvent(e: any) {
+    this.page = e.pageIndex;
+    this.size = e.pageSize;
+    this.onFiltrar(true);
+  }
+
+  populateSummary(summary: any) {
+    this.totalVenta = summary.totalVenta || 0;
+    this.totalCosto = summary.costoTotal || 0;
+    this.totalLucro = summary.lucro || 0;
+    this.totalDescuento = summary.totalDescuento || 0;
+    this.totalAumento = summary.totalAumento || 0;
+    this.margenPromedio = summary.margen || 0;
+    this.margenCostoPromedio =
+      this.totalCosto > 0 ? (this.totalLucro / this.totalCosto) * 100 : 0;
+  }
+
+  cargarMasDatos() {}
+
+  resetFiltro() {
+    let hoy = new Date();
+    let aux = new Date();
+    aux.setDate(hoy.getDate() - 2);
+
+    this.fechaInicioControl.setValue(aux);
+    this.fechaFinalControl.setValue(hoy);
+    this.horaInicioControl.setValue("00:00");
+    this.horaFinalControl.setValue("23:59");
+    this.sucursalControl.setValue(null);
+    this.buscarProductoControl.setValue(null);
+    this.buscarSubfamiliaControl.setValue(null);
+    this.buscarFamiliaControl.setValue(null);
+    this.buscarFuncionarioControl.setValue(null);
+    this.selectedUsuario = null;
+    this.selectedFuncionario = null;
+    this.selectedSubFamilia = null;
+    this.selectedFamilia = null;
+    this.productoList = [];
+    this.dataSource.data = [];
+    this.totalElements = 0;
+
+    this.totalVenta = 0;
+    this.totalCosto = 0;
+    this.totalLucro = 0;
+    this.totalDescuento = 0;
+    this.totalAumento = 0;
+    this.margenPromedio = 0;
+    this.margenCostoPromedio = 0;
+  }
+
+  onGenerarPdf() {
+    if (this.horaInicioControl.value == null)
+      this.horaInicioControl.setValue("07:00");
+    if (this.horaFinalControl.value == null)
+      this.horaFinalControl.setValue("06:59");
+    this.fechaInicioControl.setValue(
+      combineDateTime(
+        this.fechaInicioControl.value,
+        this.horaInicioControl.value
+      )
+    );
+    this.fechaFinalControl.setValue(
+      combineDateTime(this.fechaFinalControl.value, this.horaFinalControl.value)
+    );
+    let fechaInicio = dateToString(this.fechaInicioControl.value);
+    let fechaFin = dateToString(this.fechaFinalControl.value);
+    let productoIdList: number[];
+    this.productoList.forEach((p) => {
+      if (productoIdList == null) productoIdList = [];
+      productoIdList.push(p.id);
+    });
+    this.resolveUsuarioIdList()
+      .pipe(untilDestroyed(this))
+      .subscribe((usuarioIdList) => {
+        this.ventaService.onImprimirReporteLucroPorFuncionario(
+          fechaInicio,
+          fechaFin,
+          this.toSucursalesId(this.sucursalControl.value),
+          usuarioIdList,
+          productoIdList,
+          this.selectedSubFamilia?.id,
+          true,
+          this.selectedFamilia?.id
+        );
+      });
+  }
+
+  toSucursalesId(sucursales: Sucursal[]) {
+    let idList = [];
+    if (sucursales == null) sucursales = this.sucursalList;
+    sucursales?.forEach((s) => idList.push(s?.id));
+    return idList;
+  }
+
+  onBuscarProducto() {
+    let text: string = this.buscarProductoControl.value;
+    if (
+      this.selectedProducto != null &&
+      text.includes(this.selectedProducto.descripcion)
+    ) {
+      this.onAddProducto();
+    } else {
+      this.onSearchPorCodigo();
+    }
+  }
+
+  onSearchPorCodigo() {
+    let text = this.buscarProductoControl.value;
+    let codigo;
+    if (text?.length == 13 && text.substring(0, 2) == "20") {
+      codigo = text.substring(2, 7);
+      text = codigo;
+    }
+    if (text != null) {
+      this.productoService.onGetProductoPorCodigo(text).subscribe((res) => {
+        if (res != null) {
+          this.selectedProducto = res;
+          this.buscarProductoControl.setValue(
+            this.selectedProducto.id + " - " + this.selectedProducto.descripcion
+          );
+        } else {
+          this.openSearchProducto(text);
+        }
+      });
+    } else {
+      this.openSearchProducto(text);
+    }
+  }
+
+  openSearchProducto(texto?) {
+    let data: PdvSearchProductoData = {
+      texto: texto,
+      cantidad: 1,
+      mostrarOpciones: false,
+      mostrarStock: true,
+      conservarUltimaBusqueda: true,
+    };
+    this.dialog
+      .open(PdvSearchProductoDialogComponent, {
+        data: data,
+        height: "80%",
+      })
+      .afterClosed()
+      .subscribe((res) => {
+        let response: PdvSearchProductoResponseData = res;
+        this.selectedProducto = response.producto;
+        this.onAddProducto();
+      });
+  }
+
+  onAddProducto() {
+    this.productoList.push(this.selectedProducto);
+    this.buscarProductoControl.setValue(null);
+    this.selectedProducto = null;
+    this.buscadorInput.nativeElement.focus();
+  }
+
+  onClearProducto(producto: Producto, index) {
+    this.productoList.splice(index, 1);
+  }
+
+  onBuscarFuncionario() {
+    let data: SearchListtDialogData = {
+      titulo: "Buscar Funcionario",
+      query: this.funcionariosWithPage,
+      tableData: [
+        { id: "id", nombre: "Id", width: "10%" },
+        { id: "persona.nombre", nombre: "Nombre", width: "45%" },
+        { id: "nickname", nombre: "Nickname", width: "45%" },
+      ],
+      texto: this.buscarFuncionarioControl.value,
+      search: true,
+      searchFieldName: "nombre",
+      queryData: { nombre: this.buscarFuncionarioControl.value },
+      inicialSearch: true,
+      paginator: true,
+    };
+    this.dialog
+      .open(SearchListDialogComponent, {
+        data,
+        width: "50%",
+        height: "80%",
+      })
+      .afterClosed()
+      .pipe(untilDestroyed(this))
+      .subscribe((res: Funcionario) => {
+        if (res != null) {
+          this.selectedFuncionario = res;
+          this.selectedUsuario = null;
+          const nombre = res.persona?.nombre || res.nickname || "";
+          this.buscarFuncionarioControl.setValue(res.id + " - " + nombre);
+
+          if (res.persona?.id) {
+            this.usuarioService
+              .onGetUsuarioPorPersonaId(res.persona.id)
+              .pipe(untilDestroyed(this))
+              .subscribe((resUsuario) => {
+                if (resUsuario?.id) {
+                  this.selectedUsuario = resUsuario;
+                } else if (res.usuario?.id) {
+                  this.selectedUsuario = { id: res.usuario.id } as Usuario;
+                } else {
+                  this.notificacionService.openWarn(
+                    "Nombre de usuario no encontrado"
+                  );
+                  this.buscadorFuncionarioInput.nativeElement.select();
+                }
+              });
+          } else if (res.usuario?.id) {
+            this.selectedUsuario = { id: res.usuario.id } as Usuario;
+          } else {
+            this.notificacionService.openWarn(
+              "El funcionario seleccionado no tiene un usuario asociado"
+            );
+          }
+        }
+      });
+  }
+
+  onBuscarFamilia() {
+    let tableData: TableData[] = [
+      { id: "id", nombre: "Id" },
+      { id: "nombre", nombre: "Nombre" }
+    ];
+    let data: SearchListtDialogData = {
+      query: this.searchFamilia,
+      tableData: tableData,
+      titulo: "Buscar Familia",
+      search: true,
+      queryData: { texto: this.buscarFamiliaControl.value },
+      inicialSearch: true,
+      paginator: true,
+    };
+    this.matDialog
+      .open(SearchListDialogComponent, {
+        data: data,
+        width: "60%",
+        height: "80%",
+      })
+      .afterClosed()
+      .subscribe((res: Familia | any) => {
+        if (res != null) {
+          this.selectedFamilia = { id: parseInt(res.id, 10), nombre: res.nombre } as Familia;
+          this.buscarFamiliaControl.setValue(res.nombre);
+        }
+      });
+  }
+
+  onClearFamilia() {
+    this.selectedFamilia = null;
+    this.buscarFamiliaControl.setValue(null);
+  }
+
+  onBuscarSubFamilia() {
+    let tableData: TableData[] = [
+      { id: "id", nombre: "Id" },
+      { id: "nombre", nombre: "Nombre" },
+      { id: "familia.nombre", nombre: "Familia" },
+    ];
+
+    const querySubfamilia = this.selectedFamilia
+      ? this.searchSubfamiliaFiltered
+      : this.searchSubfamilia;
+
+    const queryData = this.selectedFamilia
+      ? { texto: this.buscarSubfamiliaControl.value, familiaId: this.selectedFamilia.id }
+      : { texto: this.buscarSubfamiliaControl.value };
+
+    let data: SearchListtDialogData = {
+      query: querySubfamilia,
+      tableData: tableData,
+      titulo: "Buscar Subfamilia",
+      search: true,
+      queryData: queryData,
+      inicialSearch: true,
+      paginator: true,
+    };
+    this.matDialog
+      .open(SearchListDialogComponent, {
+        data: data,
+        width: "60%",
+        height: "80%",
+      })
+      .afterClosed()
+      .subscribe((res: Subfamilia | any) => {
+        if (res != null) {
+          this.selectedSubFamilia = { id: parseInt(res.id, 10), nombre: res.nombre } as Subfamilia;
+          this.buscarSubfamiliaControl.setValue(res.nombre);
+        }
+      });
+  }
+
+  onClearSubFamilia() {
+    this.selectedSubFamilia = null;
+    this.buscarSubfamiliaControl.setValue(null);
+  }
+
+  onClearFuncionario() {
+    this.selectedUsuario = null;
+    this.selectedFuncionario = null;
+    this.buscarFuncionarioControl.setValue(null);
+    this.buscadorFuncionarioInput.nativeElement.focus();
+  }
+}

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.ts
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component.ts
@@ -4,7 +4,7 @@ import { LucroPorFuncionario } from "./lucro-por-funcionario.model";
 import { FormControl, FormGroup } from "@angular/forms";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Observable, forkJoin, of } from "rxjs";
-import { map, switchMap } from "rxjs/operators";
+import { map, switchMap, tap } from "rxjs/operators";
 import { Sucursal } from "../../../../empresarial/sucursal/sucursal.model";
 import { SucursalService } from "../../../../empresarial/sucursal/sucursal.service";
 import {
@@ -34,6 +34,12 @@ import { FuncionariosWithPageGQL } from "../../../../personas/funcionarios/graph
 import { Funcionario } from "../../../../personas/funcionarios/funcionario.model";
 import { Familia } from "../../../../productos/familia/familia.model";
 import { FamiliasSearchGQL } from "../../../../productos/familia/graphql/familiasSearch";
+import { TabService, TabData } from "../../../../../layouts/tab/tab.service";
+import { Tab } from "../../../../../layouts/tab/tab.model";
+import {
+  VentaFuncionarioComponent,
+  VentaFuncionarioDesdeLucroTabData,
+} from "../../../../grafico/venta-funcionario/venta-funcionario.component";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -95,6 +101,10 @@ export class LucroPorFuncionarioComponent implements OnInit {
   size = 20;
   totalElements = 0;
 
+  private cachedChartRows: LucroPorFuncionario[] | null = null;
+  private cachedChartQueryKey: string | null = null;
+  private cachedUsuarioIdList: number[] | null = null;
+
   constructor(
     private sucursalService: SucursalService,
     private ventaService: VentaService,
@@ -106,7 +116,8 @@ export class LucroPorFuncionarioComponent implements OnInit {
     private searchSubfamilia: SearchSubfamiliaByDescripcionGQL,
     private searchSubfamiliaFiltered: SubfamiliasSearchGQL,
     private searchFamilia: FamiliasSearchGQL,
-    private matDialog: MatDialog
+    private matDialog: MatDialog,
+    private tabService: TabService
   ) {}
 
   ngOnInit(): void {
@@ -193,9 +204,19 @@ export class LucroPorFuncionarioComponent implements OnInit {
         productoIdList.push(p.id);
       });
 
+      const queryKey = this.buildChartQueryKey(
+        fechaInicio,
+        fechaFin,
+        productoIdList
+      );
+      if (!isPagination) {
+        this.invalidateChartCache();
+      }
+
       this.resolveUsuarioIdList()
         .pipe(
           switchMap((usuarioIdList) => {
+            this.cachedUsuarioIdList = usuarioIdList;
             return this.ventaService.onGetLucroPorFuncionario(
               fechaInicio,
               fechaFin,
@@ -216,6 +237,15 @@ export class LucroPorFuncionarioComponent implements OnInit {
             this.totalElements = res.totalElements || 0;
             if (res.summary) {
               this.populateSummary(res.summary);
+            }
+            if (!isPagination) {
+              this.updateChartCacheAfterSearch(
+                res,
+                queryKey,
+                fechaInicio,
+                fechaFin,
+                productoIdList
+              );
             }
           }
         });
@@ -309,6 +339,171 @@ export class LucroPorFuncionarioComponent implements OnInit {
     this.totalAumento = 0;
     this.margenPromedio = 0;
     this.margenCostoPromedio = 0;
+    this.invalidateChartCache();
+  }
+
+  private invalidateChartCache(): void {
+    this.cachedChartRows = null;
+    this.cachedChartQueryKey = null;
+    this.cachedUsuarioIdList = null;
+  }
+
+  private buildChartQueryKey(
+    fechaInicio: string,
+    fechaFin: string,
+    productoIdList?: number[]
+  ): string {
+    const sucIds = this.toSucursalesId(this.sucursalControl.value)
+      .slice()
+      .sort((a, b) => a - b)
+      .join(",");
+    const funcIds = this.funcionarioList
+      .map((f) => f.id)
+      .sort((a, b) => a - b)
+      .join(",");
+    const prodIds = (productoIdList || [])
+      .slice()
+      .sort((a, b) => a - b)
+      .join(",");
+    return [
+      fechaInicio,
+      fechaFin,
+      sucIds,
+      funcIds,
+      prodIds,
+      this.selectedSubFamilia?.id ?? "",
+      this.selectedFamilia?.id ?? "",
+    ].join("|");
+  }
+
+  private updateChartCacheAfterSearch(
+    res: any,
+    queryKey: string,
+    fechaInicio: string,
+    fechaFin: string,
+    productoIdList?: number[]
+  ): void {
+    const total = res?.totalElements || 0;
+    const content: LucroPorFuncionario[] = res?.content || [];
+    this.cachedChartQueryKey = queryKey;
+
+    if (total > 0 && content.length >= total) {
+      this.cachedChartRows = content;
+      return;
+    }
+
+    if (total > this.size && this.cachedUsuarioIdList != null) {
+      this.prefetchChartRows(
+        queryKey,
+        total,
+        fechaInicio,
+        fechaFin,
+        this.cachedUsuarioIdList,
+        productoIdList
+      );
+    }
+  }
+
+  private prefetchChartRows(
+    queryKey: string,
+    total: number,
+    fechaInicio: string,
+    fechaFin: string,
+    usuarioIdList: number[],
+    productoIdList?: number[]
+  ): void {
+    this.ventaService
+      .onGetLucroPorFuncionario(
+        fechaInicio,
+        fechaFin,
+        this.toSucursalesId(this.sucursalControl.value),
+        usuarioIdList,
+        productoIdList,
+        this.selectedSubFamilia?.id,
+        0,
+        total,
+        this.selectedFamilia?.id
+      )
+      .pipe(untilDestroyed(this))
+      .subscribe((res) => {
+        const content: LucroPorFuncionario[] = res?.content || [];
+        if (
+          content.length > 0 &&
+          this.cachedChartQueryKey === queryKey &&
+          content.length >= (res?.totalElements || 0)
+        ) {
+          this.cachedChartRows = content;
+        }
+      });
+  }
+
+  private prepareFechasConsulta(): {
+    fechaInicio: string;
+    fechaFin: string;
+  } | null {
+    if (!this.fechaFormGroup.valid || !this.sucursalControl.valid) {
+      return null;
+    }
+    if (this.horaInicioControl.value == null) this.horaInicioControl.setValue("07:00");
+    if (this.horaFinalControl.value == null) this.horaFinalControl.setValue("06:59");
+    this.fechaInicioControl.setValue(
+      combineDateTime(this.fechaInicioControl.value, this.horaInicioControl.value)
+    );
+    this.fechaFinalControl.setValue(
+      combineDateTime(this.fechaFinalControl.value, this.horaFinalControl.value)
+    );
+    return {
+      fechaInicio: dateToString(this.fechaInicioControl.value),
+      fechaFin: dateToString(this.fechaFinalControl.value),
+    };
+  }
+
+  private getProductoIdList(): number[] | undefined {
+    let productoIdList: number[];
+    this.productoList.forEach((p) => {
+      if (productoIdList == null) productoIdList = [];
+      productoIdList.push(p.id);
+    });
+    return productoIdList;
+  }
+
+  private getChartRowsInstant(queryKey: string): LucroPorFuncionario[] | null {
+    if (
+      this.cachedChartRows?.length &&
+      this.cachedChartQueryKey === queryKey
+    ) {
+      return this.cachedChartRows;
+    }
+    if (
+      this.totalElements > 0 &&
+      this.dataSource.data.length >= this.totalElements
+    ) {
+      return this.dataSource.data;
+    }
+    return null;
+  }
+
+  private abrirTabGrafico(
+    rows: LucroPorFuncionario[],
+    fechaInicio: string,
+    fechaFin: string
+  ): void {
+    const tabPayload: VentaFuncionarioDesdeLucroTabData = {
+      source: "lucro-por-funcionario",
+      datos: this.mapLucroToChartData(rows),
+      titulo: "Ventas por Funcionario (Lucro por funcionario)",
+      subtitulo: `Período: ${fechaInicio} — ${fechaFin}`,
+      mostrarTodos: true,
+    };
+
+    this.tabService.addTab(
+      new Tab(
+        VentaFuncionarioComponent,
+        "Ventas por Funcionario",
+        new TabData(null, tabPayload),
+        LucroPorFuncionarioComponent
+      )
+    );
   }
 
   onGenerarPdf() {
@@ -542,6 +737,93 @@ export class LucroPorFuncionarioComponent implements OnInit {
   onClearSubFamilia() {
     this.selectedSubFamilia = null;
     this.buscarSubfamiliaControl.setValue(null);
+  }
+
+  onIrAGraficoVentas() {
+    const totalRegistros = this.totalElements || this.dataSource.data.length;
+    if (totalRegistros === 0) {
+      this.notificacionService.openWarn(
+        "Primero debe buscar datos en la tabla de lucro por funcionario"
+      );
+      return;
+    }
+
+    const fechas = this.prepareFechasConsulta();
+    if (!fechas) {
+      this.notificacionService.openWarn("Complete los filtros de fecha y sucursal");
+      return;
+    }
+
+    const { fechaInicio, fechaFin } = fechas;
+    const productoIdList = this.getProductoIdList();
+    const queryKey = this.buildChartQueryKey(
+      fechaInicio,
+      fechaFin,
+      productoIdList
+    );
+
+    const cachedRows = this.getChartRowsInstant(queryKey);
+    if (cachedRows?.length) {
+      this.abrirTabGrafico(cachedRows, fechaInicio, fechaFin);
+      return;
+    }
+
+    const usuarioIdList$ =
+      this.cachedUsuarioIdList != null &&
+      this.cachedChartQueryKey === queryKey
+        ? of(this.cachedUsuarioIdList)
+        : this.resolveUsuarioIdList();
+
+    usuarioIdList$
+      .pipe(
+        tap((usuarioIdList) => {
+          this.cachedUsuarioIdList = usuarioIdList;
+        }),
+        switchMap((usuarioIdList) =>
+          this.ventaService.onGetLucroPorFuncionario(
+            fechaInicio,
+            fechaFin,
+            this.toSucursalesId(this.sucursalControl.value),
+            usuarioIdList,
+            productoIdList,
+            this.selectedSubFamilia?.id,
+            0,
+            totalRegistros,
+            this.selectedFamilia?.id
+          )
+        ),
+        untilDestroyed(this)
+      )
+      .subscribe((res) => {
+        const rows: LucroPorFuncionario[] = res?.content || [];
+        if (rows.length === 0) {
+          this.notificacionService.openWarn("No hay datos para generar el gráfico");
+          return;
+        }
+        this.cachedChartRows = rows;
+        this.cachedChartQueryKey = queryKey;
+        this.abrirTabGrafico(rows, fechaInicio, fechaFin);
+      });
+  }
+
+  private mapLucroToChartData(rows: LucroPorFuncionario[]) {
+    const sucursalesLabel = this.getSucursalesLabel();
+    return rows.map((row) => ({
+      id: row.usuarioId,
+      funcionario: row.nombreFuncionario,
+      total: row.totalVenta || 0,
+      cantidad: row.cantidad || 0,
+      productoMasVendido: "N/A",
+      sucursales: sucursalesLabel,
+    }));
+  }
+
+  private getSucursalesLabel(): string {
+    const selected = this.sucursalControl.value as Sucursal[] | null;
+    if (!selected?.length || selected.includes(null as any)) {
+      return "Todas";
+    }
+    return selected.map((s) => s?.nombre).filter(Boolean).join(", ");
   }
 
   onClearFuncionario(index?: number) {

--- a/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.model.ts
+++ b/src/app/modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.model.ts
@@ -1,0 +1,14 @@
+export class LucroPorFuncionario {
+  usuarioId: number;
+  nombreFuncionario: string;
+  costoUnitario: number;
+  costoTotal: number;
+  cantidad: number;
+  totalVenta: number;
+  lucro: number;
+  percent: number;
+  ventaMedia: number;
+  margen: number;
+  totalDescuento: number;
+  totalAumento: number;
+}

--- a/src/app/modules/operaciones/venta/venta.service.ts
+++ b/src/app/modules/operaciones/venta/venta.service.ts
@@ -43,6 +43,8 @@ import { ReporteService } from "../../reportes/reporte.service";
 import { TabService } from "../../../layouts/tab/tab.service";
 import { Tab } from "../../../layouts/tab/tab.model";
 import { ReportesComponent } from "../../reportes/reportes/reportes.component";
+import { LucroPorFuncionarioListGQL } from "./graphql/lucroPorFuncionarioList";
+import { ReporteLucroPorFuncionarioGQL } from "./graphql/reporteLucroPorFuncionario";
 
 @UntilDestroy({ checkProperties: true })
 @Injectable({
@@ -76,7 +78,9 @@ export class VentaService {
     private ventasGenericFilter: VentasGenericFilterGQL,
     private reporteGenericVentas: ReporteGenericVentasGQL,
     private reporteService: ReporteService,
-    private tabService: TabService
+    private tabService: TabService,
+    private lucroPorFuncionarioList: LucroPorFuncionarioListGQL,
+    private reporteLucroPorFuncionario: ReporteLucroPorFuncionarioGQL
   ) { }
 
   // $venta:VentaInput!, $venteItemList: [VentaItemInput], $cobro: CobroInput, $cobroDetalleList: [CobroDetalleInput]
@@ -391,5 +395,65 @@ export class VentaService {
       ventas[index] = ventaObs;
       this.ventasBS.next([...ventas]);
     }
+  }
+
+  onImprimirReporteLucroPorFuncionario(
+    fechaInicio: string,
+    fechaFin: string,
+    sucursalIdList?: number[],
+    usuarioIdList?: number[],
+    productoIdList?: number[],
+    subfamiliaId?: number,
+    servidor = true,
+    familiaId?: number
+  ) {
+    this.genericService
+      .onCustomQuery(
+        this.reporteLucroPorFuncionario,
+        {
+          fechaInicio,
+          fechaFin,
+          sucursalIdList,
+          usuarioId: this.mainService.usuarioActual.id,
+          usuarioIdList,
+          productoIdList,
+          subfamiliaId,
+          familiaId
+        },
+        servidor
+      )
+      .subscribe((res) => {
+        if (res != null) {
+          this.reporteService.onAdd("Lucro por funcionario " + Date.now(), res);
+          this.tabService.addTab(
+            new Tab(ReportesComponent, "Reportes", null, null)
+          );
+        }
+      });
+  }
+
+  onGetLucroPorFuncionario(
+    fechaInicio: string,
+    fechaFin: string,
+    sucursalIdList: number[],
+    usuarioIdList: number[],
+    productoIdList: number[],
+    subfamiliaId?: number,
+    page?: number,
+    size?: number,
+    familiaId?: number,
+    servidor = true
+  ): Observable<any> {
+    return this.genericService.onCustomQuery(this.lucroPorFuncionarioList, {
+      fechaInicio,
+      fechaFin,
+      sucursalIdList,
+      usuarioIdList,
+      productoIdList,
+      subfamiliaId,
+      page,
+      size,
+      familiaId
+    }, servidor);
   }
 }

--- a/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.css
+++ b/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.css
@@ -37,10 +37,6 @@ tr.mat-row.row-seleccionada {
   width: 100%;
 }
 
-.apply-btn {
-  margin-right: auto;
-}
-
 .header-section .dialog-title {
   margin: 0;
   font-size: 1.8rem;

--- a/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.html
+++ b/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.html
@@ -406,6 +406,13 @@
   <div class="footer-section">
     <div class="footer-buttons">
       <button
+        mat-button
+        (click)="dialogRef.close()"
+        class="exit-btn">
+        <mat-icon>close</mat-icon>
+        Salir
+      </button>
+      <button
         *ngIf="modoSeleccionMultiple"
         mat-raised-button
         color="primary"
@@ -414,13 +421,6 @@
         class="apply-btn">
         <mat-icon>check</mat-icon>
         Aplicar filtro ({{ cantidadSeleccionados() }})
-      </button>
-      <button
-        mat-button
-        (click)="dialogRef.close()"
-        class="exit-btn">
-        <mat-icon>close</mat-icon>
-        Salir
       </button>
     </div>
   </div>

--- a/src/app/shared/components/search-list-dialog/search-list-dialog.component.html
+++ b/src/app/shared/components/search-list-dialog/search-list-dialog.component.html
@@ -40,6 +40,18 @@
         <mat-card-content>
           <div class="table-container">
             <table mat-table #table [dataSource]="dataSource" class="results-table">
+              <ng-container matColumnDef="seleccion" *ngIf="data?.multiple">
+                <th mat-header-cell *matHeaderCellDef style="width: 48px"></th>
+                <td mat-cell *matCellDef="let element" class="table-cell">
+                  <mat-checkbox
+                    [checked]="isSeleccionado(element)"
+                    (click)="$event.stopPropagation()"
+                    (change)="toggleSeleccion(element)"
+                    color="primary">
+                  </mat-checkbox>
+                </td>
+              </ng-container>
+
               <ng-container *ngFor="let item of data?.tableData">
                 <ng-container [matColumnDef]="
                     item?.nestedColumnId != null ? item?.nestedColumnId : item?.id
@@ -62,7 +74,10 @@
 
               <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns" (click)="onRowSelect(row)"
-                (keyup.enter)="onRowSelect(row)" [class.selected-row]="selectedItem == row" #tableRows tabindex="0"
+                (keyup.enter)="onRowSelect(row)"
+                [class.selected-row]="selectedItem == row"
+                [class.row-seleccionada]="data?.multiple && isSeleccionado(row)"
+                #tableRows tabindex="0"
                 class="table-row"></tr>
             </table>
 
@@ -85,17 +100,24 @@
 
   <!-- Dialog Actions -->
   <div class="dialog-actions">
-    <div class="actions-left">
-      <!-- Space for additional actions if needed -->
-    </div>
-
     <div class="actions-right">
       <button mat-raised-button (click)="onCancelar()" class="cancel-btn">
         <mat-icon>close</mat-icon>
         Cancelar
       </button>
 
-      <button mat-raised-button color="primary" (click)="onAceptar()" [disabled]="selectedItem == null">
+      <button
+        *ngIf="data?.multiple"
+        mat-raised-button
+        color="primary"
+        (click)="onAplicarFiltro()"
+        [disabled]="cantidadSeleccionados() === 0"
+        class="apply-btn">
+        <mat-icon>check</mat-icon>
+        Aplicar filtro ({{ cantidadSeleccionados() }})
+      </button>
+
+      <button *ngIf="!data?.multiple" mat-raised-button color="primary" (click)="onAceptar()" [disabled]="selectedItem == null">
         <mat-icon>check</mat-icon>
         Aceptar
       </button>

--- a/src/app/shared/components/search-list-dialog/search-list-dialog.component.scss
+++ b/src/app/shared/components/search-list-dialog/search-list-dialog.component.scss
@@ -275,6 +275,19 @@
         background-color: rgba(76, 175, 80, 0.3);
       }
     }
+
+    &.row-seleccionada {
+      background-color: rgba(244, 67, 54, 0.12);
+    }
+  }
+}
+
+.apply-btn {
+  background-color: #f44336 !important;
+  color: #ffffff !important;
+
+  &:hover:not(:disabled) {
+    background-color: #d32f2f !important;
   }
 }
 
@@ -341,16 +354,12 @@
   padding: 16px 24px;
   border-top: 1px solid rgba(255, 255, 255, 0.12);
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   gap: 16px;
   flex-shrink: 0;
   background-color: rgba(255, 255, 255, 0.02);
   border-radius: 0 0 12px 12px;
-
-  .actions-left {
-    flex: 1;
-  }
 
   .actions-right {
     display: flex;

--- a/src/app/shared/components/search-list-dialog/search-list-dialog.component.ts
+++ b/src/app/shared/components/search-list-dialog/search-list-dialog.component.ts
@@ -37,6 +37,7 @@ export class SearchListtDialogData {
   tableData: TableData[];
   query: Query;
   multiple? = false;
+  seleccionadosIniciales?: any[];
   search? = true;
   inicialSearch? = false;
   inicialData?: any;
@@ -71,6 +72,7 @@ export class SearchListDialogComponent implements OnInit, AfterViewInit {
   selectedPageInfo: PageInfo<any> = new PageInfo<any>();
   pageIndex = 0;
   pageSize = 15;
+  seleccionadosMap = new Map<number, any>();
 
   // **PERFORMANCE**: Computed properties for template usage (avoid getters/functions in template)
   dialogTitleComputed = '';
@@ -125,6 +127,16 @@ export class SearchListDialogComponent implements OnInit, AfterViewInit {
     if (this.displayedColumns.length === 0) {
       this.displayedColumns = ['id', 'nombre'];
     }
+
+    if (this.data?.multiple) {
+      this.displayedColumns = ['seleccion', ...this.displayedColumns];
+      (this.data.seleccionadosIniciales || []).forEach((item) => {
+        if (item?.id != null) {
+          this.seleccionadosMap.set(item.id, item);
+        }
+      });
+    }
+
     // **PERFORMANCE**: Initialize computed properties
     this.updateComputedProperties();
 
@@ -282,6 +294,13 @@ export class SearchListDialogComponent implements OnInit, AfterViewInit {
   }
 
   onRowSelect(row): void {
+    if (this.data?.multiple) {
+      this.toggleSeleccion(row);
+      this.selectedItem = row;
+      this.updateComputedProperties();
+      return;
+    }
+
     if (row == this.selectedItem) {
       // Double-click behavior: close dialog with selection
       this.matDialogRef.close(row)
@@ -292,7 +311,35 @@ export class SearchListDialogComponent implements OnInit, AfterViewInit {
     this.updateComputedProperties();
   }
 
+  toggleSeleccion(item: any, event?: Event): void {
+    event?.stopPropagation();
+    if (item?.id == null) return;
+    if (this.seleccionadosMap.has(item.id)) {
+      this.seleccionadosMap.delete(item.id);
+    } else {
+      this.seleccionadosMap.set(item.id, item);
+    }
+    this.updateComputedProperties();
+    this.cdr.markForCheck();
+  }
+
+  isSeleccionado(item: any): boolean {
+    return item?.id != null && this.seleccionadosMap.has(item.id);
+  }
+
+  cantidadSeleccionados(): number {
+    return this.seleccionadosMap.size;
+  }
+
+  onAplicarFiltro(): void {
+    this.matDialogRef.close(Array.from(this.seleccionadosMap.values()));
+  }
+
   onAceptar(): void {
+    if (this.data?.multiple) {
+      this.onAplicarFiltro();
+      return;
+    }
     this.matDialogRef.close(this.selectedItem)
   }
 
@@ -322,7 +369,9 @@ export class SearchListDialogComponent implements OnInit, AfterViewInit {
     this.hasDataComputed = this.dataSource.data.length > 0;
 
     // Selection state
-    this.hasSelectedItemComputed = this.selectedItem != null;
+    this.hasSelectedItemComputed = this.data?.multiple
+      ? this.seleccionadosMap.size > 0
+      : this.selectedItem != null;
 
     // Pagination
     this.showPaginatorComputed = this.data?.paginator === true && this.selectedPageInfo != null;

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -15,6 +15,7 @@ import { DeliveryDashboardComponent } from '../../../modules/operaciones/deliver
 import { EntradaSalidaComponent } from "../../../modules/operaciones/entrada-salida/entrada-salida.component";
 import { ListMovimientoStockComponent } from "../../../modules/operaciones/movimiento-stock/list-movimiento-stock/list-movimiento-stock.component";
 import { LucroPorProductoComponent } from '../../../modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component';
+import { LucroPorFuncionarioComponent } from '../../../modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component';
 import { UltimasCajasDialogComponent } from '../../../modules/pdv/comercial/venta-touch/ultimas-cajas-dialog/ultimas-cajas-dialog.component';
 import { VentaTouchComponent } from "../../../modules/pdv/comercial/venta-touch/venta-touch.component";
 import { ClienteDashboardComponent } from '../../../modules/personas/clientes/cliente-dashboard/cliente-dashboard.component';
@@ -271,6 +272,12 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
           name: 'Maletines',
           icon: 'work',
           action: 'list-maletin',
+          visibilityRoles: [ROLES.ADMIN]
+        },
+        {
+          name: 'Lucro por funcionario',
+          icon: 'groups',
+          action: 'lucro-por-funcionario',
           visibilityRoles: [ROLES.ADMIN]
         },
         {
@@ -687,6 +694,9 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
         break;
       case "delivery-dashboard":
         this.tabService.addTab(new Tab(DeliveryDashboardComponent, "Delivery Dash", null, null));
+        break;
+      case "lucro-por-funcionario":
+        this.tabService.addTab(new Tab(LucroPorFuncionarioComponent, "Lucro por funcionario", null, null));
         break;
       case "lucro-por-producto":
         this.tabService.addTab(new Tab(LucroPorProductoComponent, "Lucro por producto", null, null));

--- a/src/app/shared/components/side/side.component.html
+++ b/src/app/shared/components/side/side.component.html
@@ -119,6 +119,8 @@
       <a mat-list-item (click)="onItemClick('list-retiros')">Retiros</a>
       <a mat-list-item (click)="onItemClick('list-facturas')">Facturas</a>
       <a mat-list-item (click)="onItemClick('list-maletin')">Maletines</a>
+      <a mat-list-item (click)="onItemClick('lucro-por-funcionario')"
+        *ngIf="mainService.usuarioActual?.roles.includes('ADMIN')">Lucro por funcionario</a>
       <a mat-list-item (click)="onItemClick('lucro-por-producto')"
         *ngIf="mainService.usuarioActual?.roles.includes('ADMIN')">Lucro por producto</a>
     </mat-expansion-panel>

--- a/src/app/shared/components/side/side.component.ts
+++ b/src/app/shared/components/side/side.component.ts
@@ -19,6 +19,7 @@ import { DeliveryDashboardComponent } from '../../../modules/operaciones/deliver
 import { EntradaSalidaComponent } from "../../../modules/operaciones/entrada-salida/entrada-salida.component";
 import { ListMovimientoStockComponent } from "../../../modules/operaciones/movimiento-stock/list-movimiento-stock/list-movimiento-stock.component";
 import { LucroPorProductoComponent } from '../../../modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component';
+import { LucroPorFuncionarioComponent } from '../../../modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component';
 import { UltimasCajasDialogComponent } from '../../../modules/pdv/comercial/venta-touch/ultimas-cajas-dialog/ultimas-cajas-dialog.component';
 import { VentaTouchComponent } from "../../../modules/pdv/comercial/venta-touch/venta-touch.component";
 import { ClienteDashboardComponent } from '../../../modules/personas/clientes/cliente-dashboard/cliente-dashboard.component';
@@ -426,6 +427,11 @@ export class SideComponent implements OnInit {
         else {
           this.notificacionService.openWarn('No tenés acceso a esta opción. ')
         }
+        break;
+      case "lucro-por-funcionario":
+        this.tabService.addTab(
+          new Tab(LucroPorFuncionarioComponent, "Lucro por funcionario", null, null)
+        );
         break;
       case "lucro-por-producto":
         this.tabService.addTab(

--- a/src/app/shared/widgets/search-bar-dialog/search-bar.service.ts
+++ b/src/app/shared/widgets/search-bar-dialog/search-bar.service.ts
@@ -23,6 +23,7 @@ import { ListClientesComponent } from '../../../modules/personas/clientes/list-c
 import { ListRetiroComponent } from '../../../modules/financiero/retiro/list-retiro/list-retiro.component';
 import { ListGastosComponent } from '../../../modules/financiero/gastos/pages/list-gastos/list-gastos.component';
 import { LucroPorProductoComponent } from '../../../modules/operaciones/venta/reportes/lucro-por-producto/lucro-por-producto.component';
+import { LucroPorFuncionarioComponent } from '../../../modules/operaciones/venta/reportes/lucro-por-funcionario/lucro-por-funcionario.component';
 
 export enum TIPO_SEARCH {
   COMPONENTE = 'COMPONENTE',
@@ -59,6 +60,7 @@ export const componenteList: SearchData[] =
     { title: 'Lista de clientes', component: ListClientesComponent, visibilityRoles: [ROLES.VER_PERSONAS] },
     { title: 'Lista de retiros', component: ListRetiroComponent, visibilityRoles: [ROLES.ANALISIS_DE_CAJA] },
     { title: 'Lista de gastos', component: ListGastosComponent, visibilityRoles: [ROLES.ANALISIS_DE_CAJA] },
+    { title: 'Lucro por funcionario', component: LucroPorFuncionarioComponent, visibilityRoles: [ROLES.ADMIN] },
     { title: 'Lucro por producto', component: LucroPorProductoComponent, visibilityRoles: [ROLES.ADMIN] }
   ]
 


### PR DESCRIPTION
Summary
Se agrega la pantalla Lucro por funcionario, complemento del reporte existente Lucro por producto.
Permite analizar rentabilidad (venta, costo, descuento, aumento, lucro y márgenes) agrupada por funcionario/usuario del PDV.
Incluye filtros avanzados, tabla paginada con resumen, exportación a PDF e integración con el gráfico Ventas por Funcionario.
Requiere el backend correspondiente: [franco-system-backend-servidor#102](https://github.com/GabFrank/franco-system-backend-servidor/pull/102)
Frontend
Nuevo reporte (LucroPorFuncionarioComponent)
Pantalla alineada con el patrón de lucro por producto:

Filtros

Rango de fechas y horas (inicio/fin)
Sucursales (multi-select con opción “Todas”)
Productos (búsqueda por código o diálogo PDV, selección múltiple)
Familia y subfamilia
Funcionarios (selección múltiple vía diálogo de búsqueda)
Resolución funcionario → usuario

Antes de consultar, convierte cada funcionario seleccionado a usuarioId mediante UsuarioService.onGetUsuarioPorPersonaId.
Si algún funcionario no tiene usuario asociado, muestra advertencia y excluye los inválidos del filtro.
Tabla paginada

Columnas: ID usuario, nombre, cantidad, costo medio, venta media, costo total, venta total, descuento, aumento, lucro, margen s/costo y margen s/venta.
Paginación configurable (10, 20, 50, 100).
Colores en columna de lucro (positivo/negativo).
Panel de resumen

Totales de venta, costo, descuento, aumento y lucro.
Margen promedio s/costo y s/venta.
Acciones

Generar PDF: llama a lucroPorFuncionario y abre el visor de reportes.
Ver gráfico: abre VentaFuncionarioComponent en un tab con los datos del reporte.