### PR TITLE
fix(compras): corregir scroll y paginacion en tablas de gestion de co…

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
@@ -1172,6 +1172,7 @@
                 </div>
 
                 <div class="table-container mat-elevation-z4">
+                  <div class="table-content-wrapper">
                   <table
                     mat-table
                     [dataSource]="itemsPendientesDataSource"
@@ -1264,6 +1265,7 @@
                       "
                     ></tr>
                   </table>
+                  </div>
 
                   <!-- Paginador para ítems pendientes -->
                   <mat-paginator
@@ -1317,6 +1319,7 @@
                   </div>
                 </div>
                 <div class="table-container mat-elevation-z4">
+                  <div class="table-content-wrapper">
                   <table
                     mat-table
                     [dataSource]="notasRecepcionDataSource"
@@ -1416,6 +1419,7 @@
                       [class.selected-row]="row.isSelectedComputed"
                     ></tr>
                   </table>
+                  </div>
 
                   <!-- Paginador para notas de recepción -->
                   <mat-paginator

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.scss
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.scss
@@ -232,6 +232,12 @@
 
   h3 {
     margin: 0 0 12px 0;
+    flex-shrink: 0;
+  }
+
+  .two-panel-layout {
+    flex: 1;
+    min-height: 0;
   }
 
   // Estilos para el campo de búsqueda
@@ -735,29 +741,32 @@
 // Step 3: Layout de dos paneles según manual
 .two-panel-layout {
   display: flex;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
   margin-right: 16px;
+
+  .left-panel,
+  .right-panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    border-radius: 8px;
+    overflow: hidden;
+    background-color: #2d2d2d;
+  }
 
   .left-panel {
     flex: 0 0 60%;
-    display: flex;
-    flex-direction: column;
-    border-radius: 8px;
-    overflow: hidden;
     margin-right: 16px;
-    background-color: #2d2d2d;
   }
 
   .right-panel {
     flex: 0 0 40%;
-    display: flex;
-    flex-direction: column;
-    border-radius: 8px;
-    overflow: hidden;
-    background-color: #2d2d2d;
   }
 
   .panel-header {
+    flex-shrink: 0;
     padding: 16px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.12);
 
@@ -816,10 +825,22 @@
 
   .table-container {
     flex: 1;
-    height: 100%;
+    min-height: 0;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    overflow: hidden;
+
+    .table-content-wrapper {
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+      overflow-x: hidden;
+    }
+
+    mat-paginator {
+      flex-shrink: 0;
+      border-top: 1px solid rgba(255, 255, 255, 0.12);
+    }
   }
 
   .panel-footer {
@@ -983,10 +1004,12 @@
     flex-shrink: 0;
   }
 
-  .items-table-scroll-wrapper {
+  .items-table-scroll-wrapper,
+  .table-content-wrapper {
     flex: 1;
     min-height: 0;
     overflow-y: auto;
+    overflow-x: hidden;
   }
 
   .no-items-container {

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -4,7 +4,6 @@ import {
   OnDestroy,
   ViewChild,
   Input,
-  AfterViewInit,
 } from "@angular/core";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { MatTableDataSource } from "@angular/material/table";
@@ -213,7 +212,7 @@ type TabState = "disabled" | "readonly" | "editable";
   styleUrls: ["./gestion-compras.component.scss"],
 })
 export class GestionComprasComponent
-  implements OnInit, OnDestroy, AfterViewInit
+  implements OnInit, OnDestroy
 {
   @ViewChild("monedaSelect", { read: MatSelect }) monedaSelect!: MatSelect;
   @ViewChild("proveedorInput") proveedorInput!: any;
@@ -479,22 +478,6 @@ export class GestionComprasComponent
 
     // Configurar navegación con teclado para productos del proveedor
     this.setupKeyboardNavigation();
-  }
-
-  ngAfterViewInit() {
-    this.itemsDataSource.paginator = this.paginator;
-    
-    // Configurar paginador para ítems pendientes
-    if (this.itemsPendientesPaginator) {
-      this.itemsPendientesDataSource.paginator = this.itemsPendientesPaginator;
-    }
-
-    // Configurar paginador para notas de recepción
-    if (this.notasRecepcionPaginator) {
-      this.notasRecepcionDataSource.paginator = this.notasRecepcionPaginator;
-    }
-
-    // Estado de tabs configurado
   }
 
   ngOnDestroy(): void {

--- a/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.html
@@ -175,6 +175,7 @@
           </div>
 
           <div *ngIf="notaSeleccionada" class="items-container">
+            <div class="table-content-wrapper">
             <table mat-table [dataSource]="itemsDataSource" class="items-table">
               <!-- Checkbox Column -->
               <ng-container matColumnDef="seleccionar">
@@ -427,6 +428,7 @@
               <mat-icon>inventory_2</mat-icon>
               <span>No hay ítems en esta nota de recepción</span>
             </div>
+            </div>
 
             <!-- Paginador para ítems -->
             <mat-paginator
@@ -446,7 +448,7 @@
       </mat-card>
 
       <!-- Panel Derecho: Lista de Notas -->
-      <div style="flex: 1; display: flex; flex-direction: column">
+      <div class="right-panel-column">
         <mat-card class="panel right-panel">
           <mat-card-header>
             <mat-card-title>
@@ -458,8 +460,9 @@
             </mat-card-subtitle>
           </mat-card-header>
 
-          <mat-card-content>
-            <div style="flex: 1">
+          <mat-card-content class="notas-panel-content">
+            <div class="table-container">
+              <div class="table-content-wrapper">
               <table
                 mat-table
                 [dataSource]="notasDataSource"
@@ -530,7 +533,7 @@
                   [class.selected-row]="notaSeleccionada?.id === row.id"
                 ></tr>
               </table>
-            </div>
+              </div>
 
             <!-- Indicador de carga -->
             <div *ngIf="loadingNotas" class="loading-indicator">
@@ -551,15 +554,13 @@
             <mat-paginator
               #notasPaginator
               [pageSizeOptions]="[5, 10, 25, 50]"
-              [pageSize]="notasPageSize"
-              [pageIndex]="notasPageIndex"
-              [length]="notasTotalElements"
+              [pageSize]="10"
               [disabled]="loadingNotas"
               showFirstLastButtons
               aria-label="Seleccionar página de notas"
-              (page)="onNotasPageChange($event)"
             >
             </mat-paginator>
+            </div>
           </mat-card-content>
         </mat-card>
         <div style="text-align: right">

--- a/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.scss
+++ b/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.scss
@@ -1,10 +1,12 @@
 .recepcion-mercaderia-container {
   width: 100%;
   height: 100%;
+  min-height: 0;
   color: #ffffff;
   display: flex;
   flex-direction: column;
   gap: 10px;
+  overflow: hidden;
 
   // Header Card - Siguiendo patrón del proyecto
   .header-card {
@@ -144,17 +146,31 @@
   .verificacion-section {
     // Dos Paneles Layout - Siguiendo patrón del proyecto
     flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
     .dos-paneles-container {
-      height: 100%;
+      flex: 1;
+      min-height: 0;
       display: flex;
       gap: 20px;
+      overflow: hidden;
 
       .panel {
         flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
         background: #2d2d2d;
         border: 1px solid #444;
         border-radius: 8px;
         overflow: hidden;
+
+        .mat-mdc-card-header {
+          flex-shrink: 0;
+        }
 
         .panel-header {
           padding: 16px;
@@ -307,14 +323,34 @@
           }
         }
 
-        .mat-mdc-card-content {
+        .mat-mdc-card-content,
+        .notas-panel-content {
           padding: 0;
           flex: 1;
+          min-height: 0;
           overflow: hidden;
           display: flex;
           flex-direction: column;
-          justify-content: space-between;
+        }
 
+        .table-container {
+          flex: 1;
+          min-height: 0;
+          display: flex;
+          flex-direction: column;
+          overflow: hidden;
+
+          .table-content-wrapper {
+            flex: 1;
+            min-height: 0;
+            overflow-y: auto;
+            overflow-x: hidden;
+          }
+
+          mat-paginator {
+            flex-shrink: 0;
+            border-top: 1px solid rgba(255, 255, 255, 0.12);
+          }
         }
       }
 
@@ -326,6 +362,19 @@
       .right-panel {
         background-color: #2d2d2d;
         flex: 1;
+      }
+
+      .right-panel-column {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+
+        .right-panel {
+          flex: 1;
+          min-height: 0;
+        }
       }
     }
 
@@ -675,10 +724,23 @@
 } 
 
 .items-container {
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  overflow: hidden;
+
+  .table-content-wrapper {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  mat-paginator {
+    flex-shrink: 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+  }
 }
 
   .cantidad-esperada {

--- a/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/recepcion-mercaderia/recepcion-mercaderia.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, OnInit, OnDestroy, ViewChild, EventEmitter } from '@angular/core';
+import { Component, Input, Output, OnInit, OnDestroy, AfterViewInit, ViewChild, EventEmitter } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
@@ -65,7 +65,7 @@ export interface RecepcionMercaderiaNota {
   templateUrl: './recepcion-mercaderia.component.html',
   styleUrls: ['./recepcion-mercaderia.component.scss']
 })
-export class RecepcionMercaderiaComponent implements OnInit, OnDestroy {
+export class RecepcionMercaderiaComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() pedidoId: number;
   @Input() pedido: Pedido;
   @Output() recepcionFinalizada = new EventEmitter<void>();
@@ -203,6 +203,10 @@ export class RecepcionMercaderiaComponent implements OnInit, OnDestroy {
     this.loadNotasRecepcion(); // Cargar datos directamente
     this.loadEtapaActual(); // Cargar etapa actual del proceso
     this.updateComputedProperties();
+  }
+
+  ngAfterViewInit(): void {
+    this.notasDataSource.paginator = this.notasPaginator;
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Summary
En Gestión de compras y Recepción de mercadería, las tablas no permitían desplazarse cuando había muchas filas y el paginador quedaba oculto o no funcionaba bien.

Problema
Scroll: Los contenedores usaban overflow: hidden sin una zona interna con scroll. Las filas se cortaban al final del panel y no aparecía barra de desplazamiento.
Paginador fuera de vista: En el layout de dos paneles (tab 3 – Recepción documental), justify-content: space-between y alturas fijas empujaban el mat-paginator fuera del área visible, sobre todo en “Notas de Recepción Registradas”.
Paginación incorrecta:
En gestión de compras, se enlazaba MatTableDataSource.paginator con paginación server-side ([length], (page)), lo que cortaba mal los datos en cliente y desincronizaba el total.
En recepción de mercadería, las notas se cargaban todas juntas pero el paginador usaba [length]="0" y un handler que recargaba sin paginar en cliente.
Solución
Contenedor table-content-wrapper con overflow-y: auto y layout flex (flex: 1, min-height: 0) para que la tabla haga scroll y el paginador quede fijo abajo.
Eliminado el enlace dataSource.paginator en tablas con paginación del backend (ítems pendientes, notas de recepción, ítems del pedido).
En recepción de mercadería: paginador de notas en modo cliente (notasDataSource.paginator); ítems de la nota siguen con paginación server-side.
Archivos tocados
gestion-compras.component.{html,scss,ts}
recepcion-mercaderia.component.{html,scss,ts}