### PR TITLE
feat(productos): dialogo search pdv descripcion + codigo mejorados

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -2215,7 +2215,7 @@ export class GestionComprasComponent
       cantidad: 1,
       mostrarStock: true,
       mostrarOpciones: false,
-      conservarUltimaBusqueda: true,
+      conservarUltimaBusqueda: false,
     };
 
     const searchDialogRef = this.dialog.open(PdvSearchProductoDialogComponent, {
@@ -2225,8 +2225,10 @@ export class GestionComprasComponent
 
     searchDialogRef.afterClosed().subscribe((searchResult: PdvSearchProductoResponseData) => {
       if (searchResult && searchResult.producto) {
-        if (searchResult.presentacion?.codigoPrincipal?.codigo) {
-          this.lastItemSearchText = searchResult.presentacion.codigoPrincipal.codigo;
+        // Conservar el texto que el usuario escribió en el buscador (ej: "FANTA")
+        // en lugar de la descripción completa del producto (ej: "FANTA NARANJA 3LTS")
+        if (searchResult.searchText) {
+          this.lastItemSearchText = searchResult.searchText;
         } else if (searchResult.producto.descripcion) {
           this.lastItemSearchText = searchResult.producto.descripcion;
         }

--- a/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.html
+++ b/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.html
@@ -71,6 +71,16 @@
                 oninput="(this.value == ' ') ? this.value = null : null ;this.value = this.value.toUpperCase()"
                 (keydown)="keydownEvent($event.key)"
               />
+              <button
+                *ngIf="formGroup.get('buscarControl')?.value"
+                matSuffix
+                mat-icon-button
+                type="button"
+                aria-label="Limpiar búsqueda"
+                (click)="limpiarBusqueda()"
+              >
+                <mat-icon>close</mat-icon>
+              </button>
             </mat-form-field>
           </div>
         </div>

--- a/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.ts
+++ b/src/app/modules/productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component.ts
@@ -41,6 +41,8 @@ import {
 import { SelectPrecioDialogComponent } from "../../precio-por-sucursal/select-precio-dialog/select-precio-dialog.component";
 import { MovimientoStockService } from "../../../operaciones/movimiento-stock/movimiento-stock.service";
 import { ProductoComponent } from "../edit-producto/producto.component";
+import { forkJoin, of } from "rxjs";
+import { catchError, map } from "rxjs/operators";
 
 export interface PdvSearchProductoData {
   texto?: any;
@@ -63,6 +65,8 @@ export interface PdvSearchProductoResponseData {
   precio?: PrecioPorSucursal;
   cantidad?: number;
   productos?: Producto[];
+  /** Texto que el usuario escribió en el campo de búsqueda al momento de seleccionar */
+  searchText?: string;
 }
 
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
@@ -220,12 +224,9 @@ export class PdvSearchProductoDialogComponent implements OnInit, AfterViewInit {
   }
 
   onSearchProducto(text: string, offset?: number) {
-    let isPesable = false;
-    let peso;
-    let codigo;
     this.isSearching = true;
     const soloStock = this.formGroup.get("soloStock").value;
-    
+
     if (this.data.conservarUltimaBusqueda == true)
       this.productoService.lastSearchText = text;
     if (this.onSearchTimer != null) {
@@ -241,23 +242,51 @@ export class PdvSearchProductoDialogComponent implements OnInit, AfterViewInit {
       this.dataSource != undefined ? (this.dataSource.data = []) : null;
       this.isSearching = false;
     } else {
-      // if (text.length == 13 && text.substring(0, 2) == "20") {
-      //   isPesable = true;
-      //   codigo = text.substring(2, 7);
-      //   peso = +text.substring(7, 12) / 1000;
-      //   text = codigo;
-      //   this.formGroup.get("cantidad").setValue(peso);
-      // }
       this.onSearchTimer = setTimeout(() => {
-        this.productoService
+        // Determinar si el texto parece un código de barras (solo dígitos con ≥3 caracteres)
+        const esCodigo = /^\d{3,}$/.test(text.trim());
+
+        // Siempre buscar por descripción
+        const busquedaDescripcion$ = this.productoService
           .onSearch(text, offset, sucursalIdParaFiltro, soloStock, true, this.data.servidor)
+          .pipe(catchError(() => of([])));
+
+        // Si parece código de barras, buscar también por código en paralelo
+        const busquedaCodigo$ = esCodigo
+          ? this.productoService
+              .onGetProductoPorCodigo(text.trim(), this.data.servidor)
+              .pipe(
+                map((p: Producto) => (p ? [p] : [])),
+                catchError(() => of([]))
+              )
+          : of([]);
+
+        forkJoin([busquedaDescripcion$, busquedaCodigo$])
           .pipe(untilDestroyed(this))
-          .subscribe((res) => {
+          .subscribe(([porDescripcion, porCodigo]: [Producto[], Producto[]]) => {
+            // Combinar resultados evitando duplicados (por id)
+            const idsVistos = new Set<number>();
+            const combinados: Producto[] = [];
+
+            // Primero agregar los del código (mayor prioridad)
+            for (const p of porCodigo) {
+              if (p?.id && !idsVistos.has(p.id)) {
+                idsVistos.add(p.id);
+                combinados.push(p);
+              }
+            }
+            // Luego los de descripción
+            for (const p of porDescripcion) {
+              if (p?.id && !idsVistos.has(p.id)) {
+                idsVistos.add(p.id);
+                combinados.push(p);
+              }
+            }
+
             if (offset == null) {
-              this.dataSource.data = res;
+              this.dataSource.data = combinados;
             } else {
-              const arr = [...this.dataSource.data.concat(res)];
-              this.dataSource.data = arr;
+              this.dataSource.data = [...this.dataSource.data, ...combinados];
             }
 
             if (this.isTransferencia) {
@@ -510,6 +539,14 @@ export class PdvSearchProductoDialogComponent implements OnInit, AfterViewInit {
     );
   }
 
+  limpiarBusqueda(): void {
+    this.formGroup.get('buscarControl')?.setValue(null);
+    this.dataSource.data = [];
+    setTimeout(() => {
+      this.buscarInput?.nativeElement?.focus();
+    }, 50);
+  }
+
   onPresentacionClick(
     presentacion?: Presentacion,
     producto?: Producto,
@@ -519,11 +556,13 @@ export class PdvSearchProductoDialogComponent implements OnInit, AfterViewInit {
     if (precio == null && presentacion?.precios != null) {
       precio = this.selectedPrecio;
     }
+    const searchText = this.formGroup.controls.buscarControl.value || '';
     let response: PdvSearchProductoResponseData = {
       producto,
       presentacion,
       cantidad: this.formGroup.controls.cantidad.value,
       precio,
+      searchText,
     };
 
     if (producto != null && presentacion != null && precio != null) {


### PR DESCRIPTION
### Que resuelve
Se corrigieron tres problemas en el dialogo de busqueda de productos (PdvSearchProductoDialogComponent) utilizado en el flujo de gestion de compras y otros modulos del sistema:

1. Campo de busqueda con valor incorrecto al reabrir el dialogo: Al buscar un producto escribiendo, por ejemplo, "FANTA", seleccionar "FANTA NARANJA 3LTS" y volver a abrir el dialogo, el campo mostraba el codigo de barras del producto seleccionado en lugar del texto original de la busqueda. Ahora se devuelve en la respuesta del dialogo el texto exacto que el usuario escribio (searchText), y ese valor es el que se conserva para la siguiente apertura.
2. Limpieza del campo de busqueda caracter por caracter: No habia forma de borrar el contenido del campo de busqueda de una sola vez. Se agrego un boton de limpieza (icono "X") como sufijo del campo, visible unicamente cuando hay texto ingresado.
3. Busqueda limitada a descripcion del producto: El buscador solo filtraba por descripcion del producto, ignorando el codigo de barras. Ahora, cuando el texto ingresado es exclusivamente numerico (3 o mas digitos), el dialogo realiza dos busquedas en paralelo: una por descripcion y otra por codigo de barras. Los resultados se combinan sin duplicados, priorizando los encontrados por codigo.

### Como probarlo

1. Prueba 1: Buscar "FANTA", seleccionar "FANTA NARANJA 3LTS", guardar el item y volver a abrir el dialogo. El campo debe mostrar "FANTA", no el codigo de barras ni el nombre completo.
2. Prueba 2: Escribir cualquier texto en el buscador, hacer clic en el icono "X" que aparece como sufijo y verificar que el campo se limpia de inmediato.
3. Prueba 3: Ingresar un codigo de barras numerico (minimo 3 digitos) y verificar que el producto con ese codigo aparece en la lista de resultados.

### Impacto DB
No aplica. Todos los cambios son exclusivamente en el frontend. Las consultas productoSearch y productoPorCodigo ya existian en el sistema.

### Riesgo
Bajo. Los cambios en la interfaz son aditivos (campo opcional), la busqueda dual se activa solo con texto numerico, los errores en cualquiera de las busquedas paralelas se manejan con catchError, y no hay cambios en el backend ni en la base de datos.