### PR TITLE
feat(menu): expansion del titulo en cabecera

### DIFF
--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -119,7 +119,7 @@ $header-height: 72px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 320px;
+    max-width: 550px;
   }
 
   &__brand-sub {
@@ -139,7 +139,7 @@ $header-height: 72px;
 
   &__tag {
     display: inline-block;
-    padding: 1px 6px;
+    padding: 3px 5px 1px 6px;
     border-radius: 3px;
     background: rgba(255, 255, 255, 0.22);
     font-size: 11px;


### PR DESCRIPTION
### Que resuelve
Se expandió la longitud del header-title del componente `header.component.html` para las sucursales con nombres largos. Anteriormente esas sucursales tenían sus nombres cortados en el título.