### PR TITLE
Feat/productos ajustar stock mejoras

### DIFF
--- a/src/app/modules/productos/producto/ajustar-stock-dialog/ajustar-stock-dialog.component.html
+++ b/src/app/modules/productos/producto/ajustar-stock-dialog/ajustar-stock-dialog.component.html
@@ -64,6 +64,7 @@
             step="0.01"
             formControlName="cantidad"
             style="text-align: center;"
+            (keyup.enter)="onGuardar()"
           />
           <mat-error *ngIf="cantidadControl.hasError('required')">
             La cantidad es requerida

--- a/src/app/modules/productos/producto/ajustar-stock-dialog/ajustar-stock-dialog.component.ts
+++ b/src/app/modules/productos/producto/ajustar-stock-dialog/ajustar-stock-dialog.component.ts
@@ -91,7 +91,7 @@ export class AjustarStockDialogComponent implements OnInit {
   cargarSucursales() {
     this.sucursalService.onGetAllSucursales(true).subscribe(res => {
       this.sucursales = res?.filter(sucursal => 
-        sucursal.nombre != "SERVIDOR" && sucursal.nombre != "COMPRAS");
+        sucursal.nombre != "SERVIDOR");
       
       if (this.data.sucursalPreseleccionada && this.selectedSucursal) {
         this.cargarStockActual();


### PR DESCRIPTION
### Qué resuelve

- Se habilita la posibilidad de realizar ajustes de stock para la sucursal "COMPRAS", la cual anteriormente se encontraba excluida del listado de sucursales disponibles en el diálogo.
- Se mejora la experiencia del usuario al permitir ejecutar la acción de guardar presionando la tecla "Enter" directamente desde el campo de ingreso de cantidad.

### Cómo probarlo

- Navegar al módulo de productos y abrir el diálogo de ajuste de stock para cualquier producto.
- Desplegar la lista de sucursales y verificar que la sucursal "COMPRAS" ahora está visible y se puede seleccionar.
- Seleccionar una sucursal, ingresar una cantidad en el campo correspondiente y presionar la tecla "Enter" en el teclado.
- Confirmar que el ajuste de stock se procesa correctamente sin necesidad de hacer clic manualmente en el botón de guardar.

### Impacto DB
No aplica. Los cambios son exclusivos a nivel de comportamiento e interfaz en el frontend, sin modificaciones en la estructura de la base de datos.

### Riesgo
Bajo. Las modificaciones introducidas consisten en agregar un evento de teclado en la vista y ajustar un filtro en la lógica del componente. No afectan flujos críticos del sistema ni alteran transacciones complejas.