### PR TITLE
feat(gastos): mejora en el filtrado de sucursal id

### DIFF
--- a/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.html
+++ b/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.html
@@ -19,7 +19,7 @@
       <div fxFlex="25%">
         <mat-form-field style="width: 100%">
           <mat-label>Sucursal de Origen</mat-label>
-          <mat-select [formControl]="sucOrigenControl">
+          <mat-select [formControl]="sucOrigenControl" [compareWith]="compareSucursal">
             <mat-option
               *ngFor="let sucursal of (sucursalList$ | async)"
               [value]="sucursal"

--- a/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.ts
+++ b/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.ts
@@ -81,11 +81,18 @@ export class ListGastosComponent implements OnInit {
     if (this.data?.tabData?.data?.caja?.id) {
       this.idCajaControl.setValue(this.data.tabData.data.caja.id);
     }
-    if (this.data?.tabData?.data?.sucursal?.id) {
+    if (this.data?.tabData?.data?.sucursal) {
+      this.sucOrigenControl.setValue(this.data.tabData.data.sucursal);
+    } else if (this.data?.tabData?.data?.sucursal?.id) {
       this.sucursalList$.subscribe(res => {
-        this.sucOrigenControl.setValue(res.find(s => s.id == this.data?.tabData?.data?.sucursal?.id))
+        this.sucOrigenControl.setValue(res.find(s => s.id == this.data?.tabData?.data?.sucursal?.id));
+        this.onFiltrar();
       })
     }
+  }
+
+  compareSucursal(s1: Sucursal, s2: Sucursal): boolean {
+    return s1 && s2 ? s1.id === s2.id : s1 === s2;
   }
 
   onFiltrar() {


### PR DESCRIPTION
### Qué resuelve
Se corrigió un error en el componente de listado de gastos donde no se estaba aplicando el filtro por sucursal de origen al acceder desde los detalles de una caja en el módulo de ventas. Esto provocaba que se mostraran gastos asociados al mismo ID de caja pertenecientes a múltiples sucursales simultáneamente. El problema se originaba por una condición de carrera asíncrona; la petición GraphQL se disparaba antes de que se asignara el valor de la sucursal al control del formulario. Se solucionó configurando una asignación síncrona del objeto Sucursal durante el `ngOnInit` e implementando la directiva `compareWith` (`compareSucursal`) en el selector de Angular Material para garantizar la correcta selección visual y funcional del filtro.

### Cómo probarlo
1. Ingresar al sistema y dirigirse al módulo de Operaciones > Ventas.
2. Seleccionar una caja específica (ej. de la sucursal central) que posea registros de gastos.
3. Expandir los detalles de la caja y hacer clic en el botón "Ir a gastos" dentro del panel de Gastos.
4. Confirmar que, en la nueva pestaña de gastos, la tabla se renderiza mostrando exclusivamente los registros que corresponden tanto al ID de la caja seleccionada como a la sucursal correcta.
5. Verificar que el campo "Sucursal de Origen" en la barra de filtros aparezca seleccionado correctamente.

### Riesgo
Bajo. Los cambios impactan de manera aislada en el ciclo de vida de inicio (`ngOnInit`) y en el template del componente `list-gastos`, asegurando únicamente el poblamiento temprano de los filtros. No existen modificaciones en los servicios base ni en operaciones críticas del backend.
