### PR TITLE
fix(notificaciones): cerrar sesión activa al logout y registrar tipo de dispositivo

### DIFF
--- a/src/app/main.service.ts
+++ b/src/app/main.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from "@angular/common/http";
-import { Injectable, OnDestroy } from "@angular/core";
+import { Injectable, Injector, OnDestroy } from "@angular/core";
 import { MatDialog } from "@angular/material/dialog";
 import { BehaviorSubject, Observable, Subscription } from "rxjs";
 import { ConfigFile } from "../environments/conectionConfig";
@@ -18,6 +18,7 @@ import { SucursalService } from "./modules/empresarial/sucursal/sucursal.service
 import { MonedaService } from "./modules/financiero/moneda/moneda.service";
 import { PuntoDeVentaService } from "./modules/financiero/punto-de-venta/punto-de-venta.service";
 import { ConfiguracionService } from "./shared/services/configuracion.service";
+import { LoginService } from "./modules/login/login.service";
 
 @UntilDestroy()
 @Injectable({
@@ -53,7 +54,8 @@ export class MainService implements OnDestroy {
     public sucursalService: SucursalService,
     private usuarioService: UsuarioService,
     private configService: ConfiguracionService,
-    private puntoDeVentaService: PuntoDeVentaService
+    private puntoDeVentaService: PuntoDeVentaService,
+    private injector: Injector
   ) {
     // Get server IP from ConfiguracionService instead of environment
     const config = this.configService.getConfig();
@@ -242,7 +244,12 @@ export class MainService implements OnDestroy {
    * This will force a re-authentication on next app start
    */
   logout(): void {
-    // Clear authentication tokens
+    try {
+      this.injector.get(LoginService).cerrarSesionActiva();
+    } catch (error) {
+      console.warn("No se pudo cerrar la sesión activa en el servidor", error);
+    }
+
     localStorage.removeItem("token");
     localStorage.removeItem("token_central");
     localStorage.removeItem("usuarioId");

--- a/src/app/modules/configuracion/inicio-sesion/tipo-dispositivo.model.ts
+++ b/src/app/modules/configuracion/inicio-sesion/tipo-dispositivo.model.ts
@@ -1,9 +1,9 @@
 export enum TipoDispositivo {
-    ANDROID,
-    IOS,
-    DESKTOP_WIN,
-    DESKTOP_LIN,
-    DESKTOP_MAC,
-    WEB,
-    WEB_MOBILE
+    ANDROID = 'ANDROID',
+    IOS = 'IOS',
+    DESKTOP_WIN = 'DESKTOP_WIN',
+    DESKTOP_LIN = 'DESKTOP_LIN',
+    DESKTOP_MAC = 'DESKTOP_MAC',
+    WEB = 'WEB',
+    WEB_MOBILE = 'WEB_MOBILE'
 }

--- a/src/app/modules/login/login.service.ts
+++ b/src/app/modules/login/login.service.ts
@@ -21,6 +21,7 @@ import { DeviceDetectorService } from "ngx-device-detector";
 import { generateUUID } from "../../commons/core/utils/string-utils";
 import { ElectronService } from "../../commons/core/electron/electron.service";
 import { InicioSesion } from "../configuracion/models/inicio-sesion.model";
+import { TipoDispositivo } from "../configuracion/inicio-sesion/tipo-dispositivo.model";
 import { NotificarInicioSesionGQL } from "../configuracion/inicio-sesion/graphql/notificarInicioSesion.gql";
 
 @UntilDestroy({ checkProperties: true })
@@ -46,6 +47,70 @@ export class LoginService {
     private configService: ConfiguracionService,
     private notificarInicioSesionGQL: NotificarInicioSesionGQL
   ) { }
+
+  private resolveTipoDispositivo(): TipoDispositivo {
+    if (this.electronService.isElectron) {
+      const platform = window.navigator.platform.toLowerCase();
+      if (platform.includes("win")) {
+        return TipoDispositivo.DESKTOP_WIN;
+      }
+      if (platform.includes("mac")) {
+        return TipoDispositivo.DESKTOP_MAC;
+      }
+      return TipoDispositivo.DESKTOP_LIN;
+    }
+    if (this.deviceDetector.isMobile()) {
+      return TipoDispositivo.WEB_MOBILE;
+    }
+    return TipoDispositivo.WEB;
+  }
+
+  private registrarSesionActiva(usuario: Usuario, servidor: boolean): void {
+    const inicioSesion = new InicioSesion();
+    inicioSesion.usuario = usuario;
+    inicioSesion.sucursal = this.mainService?.sucursalActual;
+    inicioSesion.creadoEn = new Date();
+    inicioSesion.tipoDespositivo = this.resolveTipoDispositivo();
+
+    let deviceId = localStorage.getItem("deviceId");
+    if (deviceId == null) {
+      deviceId = generateUUID();
+      localStorage.setItem("deviceId", deviceId);
+    }
+    inicioSesion.idDispositivo = deviceId;
+    inicioSesion.token = localStorage.getItem("pushToken");
+
+    const sesionExistente = usuario?.inicioSesion;
+    if (sesionExistente?.idDispositivo === deviceId && sesionExistente?.id) {
+      inicioSesion.id = sesionExistente.id;
+      inicioSesion.horaInicio = sesionExistente.horaInicio
+        ? new Date(sesionExistente.horaInicio)
+        : new Date();
+    } else {
+      inicioSesion.horaInicio = new Date();
+    }
+
+    this.usuarioService
+      .onSaveInicioSesion(inicioSesion.toInput(), servidor)
+      .subscribe((res) => {
+        this.mainService.usuarioActual.inicioSesion = res;
+      });
+  }
+
+  cerrarSesionActiva(servidor: boolean = true): void {
+    const sesionActual = this.mainService.usuarioActual?.inicioSesion;
+    if (!sesionActual?.id || !sesionActual?.sucursal) {
+      return;
+    }
+
+    const inicioSesion = new InicioSesion();
+    Object.assign(inicioSesion, sesionActual);
+    inicioSesion.horaFin = new Date();
+    inicioSesion.token = null;
+    this.usuarioService
+      .onSaveInicioSesion(inicioSesion.toInput(), servidor)
+      .subscribe();
+  }
 
   login(nickname: string, password: string, keepLogged: boolean = false): Observable<LoginResponse> {
     return new Observable((obs) => {
@@ -87,38 +152,8 @@ export class LoginService {
                     .subscribe((res) => {
                       if (res?.id != null) {
                         this.mainService.usuarioActual = res;
-                        let inicioSesion = new InicioSesion();
-                        inicioSesion.usuario = res;
-                        inicioSesion.sucursal =
-                          this.mainService?.sucursalActual;
-                        inicioSesion.horaInicio = new Date();
-                        inicioSesion.creadoEn = new Date();
-
-                        let deviceId = localStorage.getItem("deviceId");
-                        if (deviceId == null) {
-                          let uuid = generateUUID();
-                          localStorage.setItem("deviceId", uuid);
-                          deviceId = uuid;
-                        }
-                        inicioSesion.idDispositivo = deviceId;
-                        inicioSesion.token = localStorage.getItem("pushToken");
-
-                        if (
-                          res?.inicioSesion != null &&
-                          res?.inicioSesion?.idDispositivo == deviceId &&
-                          res?.inicioSesion?.sucursal != null
-                        ) {
-                          this.notificarInicioSesion(res.id);
-                          this.enviarNotificacionLogin(serverIp, serverPort, this.mainService.usuarioActual);
-                        } else {
-                          this.usuarioService
-                            .onSaveInicioSesion(inicioSesion.toInput())
-                            .subscribe((res) => {
-                              this.notificarInicioSesion(res.usuario.id);
-                              this.mainService.usuarioActual.inicioSesion = res;
-                              this.enviarNotificacionLogin(serverIp, serverPort, this.mainService.usuarioActual);
-                            });
-                        }
+                        this.registrarSesionActiva(res, !config.isLocal);
+                        this.notificarInicioSesion(res.id);
 
                         let response: LoginResponse = {
                           usuario: res,
@@ -153,9 +188,6 @@ export class LoginService {
         })
       )
       .subscribe();
-  }
-
-  private enviarNotificacionLogin(serverIp: string, serverPort: string, usuario: any): void {
   }
 
   autenticarEnCentral(nickname: string, password: string): Observable<any> {


### PR DESCRIPTION
## Summary
- Cierra la sesión activa en el backend al hacer logout para evitar tokens FCM huérfanos.
- Registra el tipo de dispositivo (desktop Linux/Windows) al crear o actualizar `inicio_sesion`.
- Refactoriza el flujo de login para consolidar la sesión por dispositivo y alinear el sync de push con el backend.

## Test plan
- [ ] Iniciar sesión en Electron y verificar que `tipoDispositivo` e `idDispositivo` se envían al backend
- [ ] Confirmar que `actualizarTokenFcm` actualiza la sesión del dispositivo actual
- [ ] Cerrar sesión y validar en BD que la sesión queda con `hora_fin` y sin token activo
- [ ] Volver a iniciar sesión y comprobar que las notificaciones push siguen llegando correctamente


Made with [Cursor](https://cursor.com)