### PR TITLE
feat(financiero): agregar modulo terminal POS

### DIFF
--- a/src/app/modules/financiero/financiero.module.ts
+++ b/src/app/modules/financiero/financiero.module.ts
@@ -45,6 +45,10 @@ import { ListLoteDeComponent } from './documento-electronico/lote-de/list-lote-d
 import { GestionDeDialogComponent } from './factura-legal/gestion-de-dialog/gestion-de-dialog.component';
 import { InutilizacionNumerosTabComponent } from './factura-legal/inutilizacion-numeros-tab/inutilizacion-numeros-tab.component';
 import { TransferirCajaDialogComponent } from "./pdv/caja/transferir-caja-dialog/transferir-caja-dialog.component";
+import { ListTerminalPosComponent } from "./terminal-pos/list-terminal-pos/list-terminal-pos.component";
+import { AddTerminalPosDialogComponent } from "./terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component";
+import { PrintTerminalPosDialogComponent } from "./terminal-pos/print-terminal-pos-dialog/print-terminal-pos-dialog.component";
+import { ScanTerminalPosDialogComponent } from "./terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component";
 
 @NgModule({
   declarations: [
@@ -85,7 +89,11 @@ import { TransferirCajaDialogComponent } from "./pdv/caja/transferir-caja-dialog
     ListLoteDeComponent,
     GestionDeDialogComponent,
     InutilizacionNumerosTabComponent,
-    TransferirCajaDialogComponent
+    TransferirCajaDialogComponent,
+    ListTerminalPosComponent,
+    AddTerminalPosDialogComponent,
+    PrintTerminalPosDialogComponent,
+    ScanTerminalPosDialogComponent
 
   ],
   providers: [

--- a/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.html
+++ b/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.html
@@ -1,0 +1,68 @@
+<div class="dialog-container" fxLayout="column" fxLayoutGap="10px">
+  <h2 mat-dialog-title>Nueva Terminal POS</h2>
+  
+  <form [formGroup]="formGroup" fxLayout="column" fxLayoutGap="15px">
+    <!-- Nombre -->
+    <div fxLayout="row" fxLayoutGap="10px">
+      <div fxFlex="100%" style="margin-bottom: 10px;">
+        <mat-form-field appearance="outline" style="width: 100%">
+          <mat-label>Descripción</mat-label>
+          <input
+            matInput
+            [formControl]="descripcionControl"
+            required
+            #nombre
+          />
+          <mat-error *ngIf="descripcionControl.hasError('required')">
+            Descripción es obligatorio
+          </mat-error>
+        </mat-form-field>
+      </div>
+    </div>
+
+    <!-- Codigo -->
+    <div fxLayout="row" fxLayoutGap="10px">
+      <div fxFlex="100%">
+        <mat-form-field appearance="outline" style="width: 100%">
+          <mat-label>Código</mat-label>
+          <input
+            matInput
+            [formControl]="codigoControl"
+            required
+          />
+          <mat-error *ngIf="codigoControl.hasError('required')">
+            Código es obligatorio
+          </mat-error>
+        </mat-form-field>
+      </div>
+    </div>
+
+    <!-- Checkbox -->
+    <div fxLayout="column" fxLayoutGap="10px">
+      <div fxLayout="row" fxLayoutGap="20px">
+        <div fxFlex="50%">
+          <mat-checkbox 
+            [formControl]="activoControl"
+            [checked]="activoControl.value">
+            Activo
+          </mat-checkbox>
+        </div>
+      </div>
+    </div>
+  </form>
+
+  <!-- Action Buttons -->
+  <div fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px" style="margin-top: 20px;">
+    <button mat-raised-button color="primary" (click)="onCancel()">
+      Cancelar
+    </button>
+    <button 
+      mat-raised-button 
+      color="accent" 
+      [disabled]="isEditting && formGroup.invalid"
+      (click)="isEditting ? onSave() : onHabilitarEdicion()"
+    >
+      {{ isEditting ? 'Guardar' : 'Editar' }}
+    </button>
+  </div>
+</div> 

--- a/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.scss
+++ b/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.scss
@@ -1,0 +1,13 @@
+.dialog-container {
+  padding: 16px;
+  max-width: 500px;
+}
+
+input {
+  text-transform: uppercase;
+}
+
+h2 {
+  margin-bottom: 10px;
+  color: white;
+} 

--- a/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.ts
+++ b/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.ts
@@ -1,0 +1,96 @@
+import { Component, Inject, OnInit } from "@angular/core";
+import { FormControl, FormGroup, Validators } from "@angular/forms";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { TerminalPos } from "../terminal-pos.model";
+import { TerminalPosService } from "../terminal-pos.service";
+
+export class AddTerminalPosData {
+  terminalPos?: TerminalPos;
+}
+
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: "app-add-terminal-pos-dialog",
+  templateUrl: "./add-terminal-pos-dialog.component.html",
+  styleUrls: ["./add-terminal-pos-dialog.component.scss"],
+})
+export class AddTerminalPosDialogComponent implements OnInit {
+
+  formGroup: FormGroup;
+  isEditting = false;
+
+  //Form Controls
+  descripcionControl = new FormControl(null, Validators.required);
+  codigoControl = new FormControl(null, Validators.required);
+  activoControl = new FormControl(true);
+  selectedTerminalPos: TerminalPos;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: AddTerminalPosData,
+    private matDialogRef: MatDialogRef<AddTerminalPosDialogComponent>,
+    private terminalPosService: TerminalPosService
+  ) {
+    if (data?.terminalPos != null) {
+      this.selectedTerminalPos = data.terminalPos;
+    }
+  }
+
+  ngOnInit(): void {
+    this.formGroup = new FormGroup({
+      descripcion: this.descripcionControl,
+      codigo: this.codigoControl,
+      activo: this.activoControl,
+    });
+
+    if (this.selectedTerminalPos != null) {
+      this.cargarDatos();
+      // Editar: arranca en modo lectura hasta que el usuario habilite la edicion
+      this.isEditting = false;
+      this.formGroup.disable();
+    } else {
+      // Nuevo: edicion habilitada de entrada
+      this.isEditting = true;
+      this.formGroup.enable();
+    }
+  }
+
+  cargarDatos() {
+    this.descripcionControl.setValue(this.selectedTerminalPos.descripcion);
+    this.codigoControl.setValue(this.selectedTerminalPos.codigo);
+    this.activoControl.setValue(this.selectedTerminalPos.activo);
+  }
+
+  onSave() {
+    if (this.formGroup.invalid) {
+      this.formGroup.markAllAsTouched();
+      return;
+    }
+
+    let terminalPos = new TerminalPos();
+    if (this.selectedTerminalPos != null) {
+      Object.assign(terminalPos, this.selectedTerminalPos);
+    }
+    terminalPos.descripcion = this.descripcionControl.value?.toUpperCase();
+    terminalPos.codigo = this.codigoControl.value?.toUpperCase();
+    terminalPos.activo = this.activoControl.value;
+
+    this.terminalPosService
+      .onSave(terminalPos.toInput())
+      .pipe(untilDestroyed(this))
+      .subscribe((res) => {
+        if (res != null) {
+          this.matDialogRef.close(res);
+        }
+      });
+  }
+
+  onCancel() {
+    this.matDialogRef.close();
+  }
+
+  onHabilitarEdicion() {
+    this.isEditting = true;
+    this.formGroup.enable();
+  }
+}

--- a/src/app/modules/financiero/terminal-pos/graphql/allTerminalPos.ts
+++ b/src/app/modules/financiero/terminal-pos/graphql/allTerminalPos.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { TerminalPos } from '../terminal-pos.model';
+import { terminalesPosQuery } from './graphql-query';
+
+export interface Response {
+  data: TerminalPos[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AllTerminalPosGQL extends Query<Response> {
+  document = terminalesPosQuery;
+}

--- a/src/app/modules/financiero/terminal-pos/graphql/countTerminalPos.ts
+++ b/src/app/modules/financiero/terminal-pos/graphql/countTerminalPos.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { countTerminalPosQuery } from './graphql-query';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CountTerminalPosGQL extends Query<number> {
+  document = countTerminalPosQuery;
+}

--- a/src/app/modules/financiero/terminal-pos/graphql/deleteTerminalPos.ts
+++ b/src/app/modules/financiero/terminal-pos/graphql/deleteTerminalPos.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { deleteTerminalPosQuery } from './graphql-query';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DeleteTerminalPosGQL extends Mutation {
+  document = deleteTerminalPosQuery;
+}

--- a/src/app/modules/financiero/terminal-pos/graphql/filterTerminalPos.ts
+++ b/src/app/modules/financiero/terminal-pos/graphql/filterTerminalPos.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { PageInfo } from '../../../../app.component';
+import { TerminalPos } from '../terminal-pos.model';
+import { filterTerminalPosQuery } from './graphql-query';
+
+export interface Response {
+  data: PageInfo<TerminalPos>;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FilterTerminalPosGQL extends Query<Response> {
+  document = filterTerminalPosQuery;
+}

--- a/src/app/modules/financiero/terminal-pos/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/terminal-pos/graphql/graphql-query.ts
@@ -1,0 +1,117 @@
+import gql from "graphql-tag";
+
+export const terminalesPosQuery = gql`
+  query ($page: Int, $size: Int) {
+    data: terminalesPos(page: $page, size: $size) {
+      id
+      descripcion
+      codigo
+      activo
+      creadoEn
+      usuario {
+        id
+        nickname
+        persona {
+          nombre
+        }
+      }
+    }
+  }
+`;
+
+export const terminalPosQuery = gql`
+  query ($id: ID!) {
+    data: terminalPos(id: $id) {
+      id
+      descripcion
+      codigo
+      activo
+      creadoEn
+      usuario {
+        id
+        nickname
+        persona {
+          nombre
+        }
+      }
+    }
+  }
+`;
+
+export const searchTerminalPosQuery = gql`
+  query ($texto: String) {
+    data: searchTerminalPos(texto: $texto) {
+      id
+      descripcion
+      codigo
+      activo
+      creadoEn
+      usuario {
+        id
+        nickname
+        persona {
+          nombre
+        }
+      }
+    }
+  }
+`;
+
+export const filterTerminalPosQuery = gql`
+  query ($descripcion: String, $codigo: String, $activo: Boolean, $page: Int, $size: Int) {
+    data: filterTerminalPos(descripcion: $descripcion, codigo: $codigo, activo: $activo, page: $page, size: $size) {
+      getTotalPages
+      getTotalElements
+      getNumberOfElements
+      isFirst
+      isLast
+      hasNext
+      hasPrevious
+      getContent {
+        id
+        descripcion
+        codigo
+        activo
+        creadoEn
+        usuario {
+          id
+          nickname
+          persona {
+            nombre
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const saveTerminalPos = gql`
+  mutation saveTerminalPos($entity: TerminalPosInput!) {
+    data: saveTerminalPos(terminalPos: $entity) {
+      id
+      descripcion
+      codigo
+      activo
+      creadoEn
+      usuario {
+        id
+        nickname
+        persona {
+          nombre
+        }
+      }
+    }
+  }
+`;
+
+export const deleteTerminalPosQuery = gql`
+  mutation deleteTerminalPos($id: ID!) {
+    deleteTerminalPos(id: $id)
+  }
+`;
+
+export const countTerminalPosQuery = gql`
+  {
+    data: countTerminalPos
+  }
+`;

--- a/src/app/modules/financiero/terminal-pos/graphql/saveTerminalPos.ts
+++ b/src/app/modules/financiero/terminal-pos/graphql/saveTerminalPos.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { TerminalPos } from '../terminal-pos.model';
+import { saveTerminalPos } from './graphql-query';
+
+export interface Response {
+  data: TerminalPos;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SaveTerminalPosGQL extends Mutation<Response> {
+  document = saveTerminalPos;
+}

--- a/src/app/modules/financiero/terminal-pos/graphql/searchTerminalPos.ts
+++ b/src/app/modules/financiero/terminal-pos/graphql/searchTerminalPos.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { TerminalPos } from '../terminal-pos.model';
+import { searchTerminalPosQuery } from './graphql-query';
+
+export interface Response {
+  data: TerminalPos[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SearchTerminalPosGQL extends Query<Response> {
+  document = searchTerminalPosQuery;
+}

--- a/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.html
+++ b/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.html
@@ -1,0 +1,138 @@
+<app-generic-list
+  titulo="Lista de terminales POS"
+  class="terminal-list"
+  (adicionar)="onAddOrEdit()"
+  (filtrar)="onFilter()"
+  [isAdicionar]="true"
+  (resetFiltro)="onLimpiarFiltros()"
+  [data]="dataSource.data"
+  style="height: 100%"
+>
+  <div filtros>
+    <div
+      fxLayout="row"
+      fxLayoutGap="15px"
+      fxLayoutAlign="start center"
+      style="height: 64px; min-height: 64px;"
+    >
+      <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
+        <div fxFlex="80%">
+          <mat-form-field style="width: 100%" appearance="outline">
+            <mat-label>Descripción</mat-label>
+            <input 
+              type="text" 
+              matInput 
+              [formControl]="descripcionControl" 
+              (keyup.enter)="onFilter()"
+            >
+          </mat-form-field>
+        </div>
+        <div fxFlex="80%">
+          <mat-form-field style="width: 100%" appearance="outline">
+            <mat-label>Código</mat-label>
+            <input 
+              type="text" 
+              matInput 
+              [formControl]="codigoControl" 
+              (keyup.enter)="onFilter()"
+            >
+          </mat-form-field>
+        </div>
+        <div fxFlex="30%">
+        <mat-label>Estado</mat-label>
+        <mat-checkbox 
+          [checked]="activoControl.value == true" 
+          [indeterminate]="activoControl.value == null"
+          (click)="
+            activoControl.setValue(
+              activoControl.value === null
+              ? true
+              : activoControl.value === true
+              ? false
+              : null
+            )">
+          {{
+            activoControl.value == null ? "Todos":
+            activoControl.value ==true ? "Activos": "Inactivos"
+          }}  
+        </mat-checkbox>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div table fxFlex fxLayout="column" style="min-height: 0; height: 100%;">
+    <div fxFlex style="overflow: auto; min-height: 0;">
+    <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+      <ng-container matColumnDef="id" style="width: 10%">
+        <th mat-header-cell *matHeaderCellDef style="width: 10%;">Id</th>
+        <td mat-cell *matCellDef="let terminalPos" style="width: 10%;"> 
+          {{terminalPos.id}} 
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="descripcion" style="width: 20%">
+        <th mat-header-cell *matHeaderCellDef style="width: 20%;">Descripción</th>
+        <td mat-cell *matCellDef="let terminalPos" style="width: 20%;"> 
+          {{terminalPos.descripcion}} 
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="codigo" style="width: 20%">
+        <th mat-header-cell *matHeaderCellDef style="width: 20%">Código</th>
+        <td mat-cell *matCellDef="let terminalPos" style="width: 20%"> 
+          {{terminalPos.codigo}} 
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="creadoEn" style="width: 10%">
+        <th mat-header-cell *matHeaderCellDef style="width: 10%;">Creado En</th>
+        <td mat-cell *matCellDef="let terminalPos" style="width: 10%;"> 
+          {{terminalPos.creadoEn | date:'dd/MM/yyyy HH:mm'}} 
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="creadoPor" style="width: 10%">
+        <th mat-header-cell *matHeaderCellDef style="width: 10%;">Creado Por</th>
+        <td mat-cell *matCellDef="let terminalPos" style="width: 10%;"> 
+          {{terminalPos.usuario.nickname}} 
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="activo" style="width: 10%">
+        <th mat-header-cell *matHeaderCellDef style="width: 10%;">Activo</th>
+        <td mat-cell *matCellDef="let terminalPos" style="width: 10%;"> 
+          {{terminalPos.activo ? 'Si' : 'No'}} 
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="acciones" style="width: 10%">
+        <th mat-header-cell *matHeaderCellDef style="width: 10%;">...</th>
+        <td mat-cell *matCellDef="let terminalPos; let i = index" style="width: 10%;">
+          <button mat-icon-button [matMenuTriggerFor]="menu" (click)="$event.stopPropagation()">
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #menu="matMenu">
+            <button mat-menu-item (click)="onAddOrEdit(terminalPos, i)">
+              <mat-icon>edit</mat-icon>
+              Editar
+            </button>
+            <button mat-menu-item (click)="onPrintCode(terminalPos)">
+              <mat-icon>print</mat-icon>
+              Imprimir código
+            </button>
+            <button mat-menu-item (click)="onDelete(terminalPos, i)">
+              <mat-icon>delete</mat-icon>
+              Eliminar
+            </button>
+          </mat-menu>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let element; columns: displayedColumns"></tr>
+    </table>
+    </div>
+    <mat-paginator
+      itemsPerPageLabel="Items por pagina"
+      [pageSizeOptions]="[15, 25, 50, 100]"
+      [pageIndex]="pageIndex"
+      (page)="handlePageEvent($event)"
+      [length]="selectedPageInfo?.getTotalElements"
+      style="width: 100%"
+      showFirstLastButtons
+    ></mat-paginator>
+  </div>
+</app-generic-list>

--- a/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.scss
+++ b/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.scss
@@ -1,0 +1,43 @@
+:host ::ng-deep .terminal-list .mat-mdc-card {
+  min-height: 64px !important;
+  display: flex !important;
+  align-items: center !important;
+}
+
+table {
+  width: 100%;
+}
+
+tr.example-detail-row {
+  height: 0;
+}
+
+.example-element-row:hover {
+  background-color: rgb(34, 34, 34);
+}
+
+.example-element-detail {
+    overflow: hidden;
+    display: flex;
+}
+
+.example-element-detail:hover {
+  background-color: rgb(32, 32, 32);
+}
+
+td, th {
+  text-align: center !important;
+}
+th {
+  text-align: center !important;
+}
+
+mat-column-expandedDetail {
+  padding: 0px !important;
+}
+
+.heightLight {
+  background-color: rgb(0, 143, 64);
+  box-shadow: 0 4px 8px rgb(43, 155, 93);
+}
+

--- a/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.ts
+++ b/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.ts
@@ -1,0 +1,143 @@
+import { Component, OnInit, ViewChild } from "@angular/core";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { GenericList } from "../../../../generics/generic-list-model";
+import { TerminalPos } from "../terminal-pos.model";
+import { MatTableDataSource } from "@angular/material/table";
+import { MatPaginator, PageEvent } from "@angular/material/paginator";
+import { FormControl } from "@angular/forms";
+import { MatDialog } from "@angular/material/dialog";
+import { AddTerminalPosDialogComponent } from "../add-terminal-pos-dialog/add-terminal-pos-dialog.component";
+import { PrintTerminalPosDialogComponent } from "../print-terminal-pos-dialog/print-terminal-pos-dialog.component";
+import { PageInfo } from "../../../../app.component";
+import { TerminalPosService } from "../terminal-pos.service";
+import { ScanTerminalPosDialogComponent } from "../scan-terminal-pos-dialog/scan-terminal-pos-dialog.component";
+
+@UntilDestroy()
+@Component({
+  selector: 'app-list-terminal-pos',
+  templateUrl: './list-terminal-pos.component.html',
+  styleUrls: ['./list-terminal-pos.component.scss']
+})
+export class ListTerminalPosComponent implements OnInit, GenericList<TerminalPos> {
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  dataSource: MatTableDataSource<TerminalPos>;
+  selectedEntity: TerminalPos;
+  expandedElement: TerminalPos;
+  displayedColumns: string[];
+  isLastPage: boolean = false;
+  page = 0;
+  pageIndex = 0;
+  pageSize = 15;
+  selectedPageInfo: PageInfo<TerminalPos>;
+  descripcionControl = new FormControl(null);
+  codigoControl = new FormControl(null);
+  activoControl = new FormControl(null);
+
+  constructor(
+    private matDialog: MatDialog,
+    private terminalPosService: TerminalPosService
+  ) {
+    this.dataSource = new MatTableDataSource<TerminalPos>([]);
+    this.displayedColumns = [
+      'id',
+      'descripcion',
+      'codigo',
+      'creadoEn',
+      'creadoPor',
+      'activo',
+      'acciones',
+    ];
+  }
+
+
+  cargarMasDatos(): void {
+    this.onGetData();
+   }
+
+  ngOnInit(): void {
+    this.onGetData();
+  }
+
+  onGetData(): void {
+    setTimeout(() => {
+      this.terminalPosService
+        .onFilter(
+          this.descripcionControl.value,
+          this.codigoControl.value,
+          this.activoControl.value,
+          this.pageIndex,
+          this.pageSize
+        )
+        .pipe(untilDestroyed(this))
+        .subscribe(res => {
+          if (res != null) {
+            this.selectedPageInfo = res;
+            this.dataSource.data = res.getContent;
+          }
+        })
+    }, 0);
+  }
+
+  handlePageEvent(e: PageEvent): void {
+    this.pageIndex = e.pageIndex;
+    this.pageSize = e.pageSize;
+    this.onGetData();
+  }
+  onRowClick(entity: TerminalPos, index: any): void {
+    throw new Error('Method not implemented.');
+  }
+
+  onDelete(entity: TerminalPos, index: any): void {
+    this.terminalPosService
+      .onDelete(entity.id)
+      .pipe(untilDestroyed(this))
+      .subscribe((res) => {
+        if (res != null) {
+          this.onGetData();
+        }
+      });
+  }
+
+  onAddOrEdit(entity?: TerminalPos, index?: any): void {
+    this.matDialog.open(ScanTerminalPosDialogComponent, {
+      data: {
+        terminalPos: entity,
+      },
+      disableClose: true,
+      width: '400px',
+      autoFocus: true,
+      restoreFocus: true,
+    }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => {
+      if (res != null) {
+        this.onGetData();
+      }
+    })
+  }
+  onFilter(): void {
+    this.pageIndex = 0;
+    if (this.paginator) {
+      this.paginator.pageIndex = 0;
+    }
+    this.onGetData();
+  }
+
+  onLimpiarFiltros(): void {
+    this.descripcionControl.setValue("");
+    this.codigoControl.setValue("");
+    this.activoControl.setValue(null);
+    this.onFilter();
+  } 
+
+  onPrintCode(entity: TerminalPos): void {
+    this.matDialog.open(PrintTerminalPosDialogComponent, {
+      data: {
+        terminalPos: entity,
+      },
+      width: '400px',
+      autoFocus: false,
+      restoreFocus: true,
+    });
+  }
+}

--- a/src/app/modules/financiero/terminal-pos/print-terminal-pos-dialog/print-terminal-pos-dialog.component.html
+++ b/src/app/modules/financiero/terminal-pos/print-terminal-pos-dialog/print-terminal-pos-dialog.component.html
@@ -1,0 +1,63 @@
+<h2 mat-dialog-title>Imprimir Código de Barras</h2>
+
+<mat-dialog-content class="mat-typography">
+  <form [formGroup]="printForm">
+    <div class="printer-selection">
+      <mat-form-field appearance="outline" class="full-width"  style="margin-bottom: 10px; margin-top: 4px;">
+        <mat-label>Impresora Térmica</mat-label>
+        <mat-select formControlName="selectedPrinter">
+          <mat-option *ngFor="let printer of printers" [value]="printer.name">
+            {{ printer.displayName || printer.name }}
+          </mat-option>
+        </mat-select>
+        <mat-error *ngIf="printForm.get('selectedPrinter').hasError('required')">
+          Seleccione una impresora
+        </mat-error>
+      </mat-form-field>
+    </div>
+
+    <div class="quantity-selection">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Cantidad</mat-label>
+        <input matInput type="number" min="1" formControlName="quantity" />
+        <mat-error *ngIf="printForm.get('quantity').hasError('required')">
+          Ingrese la cantidad
+        </mat-error>
+        <mat-error *ngIf="printForm.get('quantity').hasError('min')">
+          La cantidad debe ser al menos 1
+        </mat-error>
+      </mat-form-field>
+    </div>
+
+    <div class="label-preview">
+      <h3>Vista Previa (CODE128)</h3>
+      <div class="label-shape box">
+        <div style="text-align: center">
+          <div class="terminal-descripcion">{{ data.terminalPos?.descripcion }}</div>
+          <img
+            *ngIf="previewBarcodeDataUrl"
+            [src]="previewBarcodeDataUrl"
+            alt="barcode"
+            style="height: 70px; max-width: 100%"
+          />
+          <div *ngIf="!previewBarcodeDataUrl" class="sin-codigo">
+            El terminal POS no tiene un código válido
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" style="padding-right: 24px">
+  <button mat-button (click)="onCancel()" [disabled]="loading">Cancelar</button>
+  <button
+    mat-raised-button
+    color="primary"
+    (click)="onPrint()"
+    [disabled]="loading || printForm.invalid || !previewBarcodeDataUrl"
+  >
+    <mat-spinner *ngIf="loading" diameter="20" class="button-spinner"></mat-spinner>
+    <span *ngIf="!loading">Imprimir</span>
+  </button>
+</mat-dialog-actions>

--- a/src/app/modules/financiero/terminal-pos/print-terminal-pos-dialog/print-terminal-pos-dialog.component.scss
+++ b/src/app/modules/financiero/terminal-pos/print-terminal-pos-dialog/print-terminal-pos-dialog.component.scss
@@ -1,0 +1,36 @@
+.full-width {
+  width: 100%;
+}
+
+.label-preview {
+  margin-top: 10px;
+
+  h3 {
+    margin-bottom: 8px;
+  }
+}
+
+.label-shape.box {
+  border: 1px dashed rgba(255, 255, 255, 0.4);
+  border-radius: 4px;
+  padding: 12px;
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.terminal-descripcion {
+  color: #000000;
+  font-weight: bold;
+  margin-bottom: 6px;
+}
+
+.sin-codigo {
+  color: #b00020;
+  font-size: 12px;
+}
+
+.button-spinner {
+  display: inline-block;
+}

--- a/src/app/modules/financiero/terminal-pos/print-terminal-pos-dialog/print-terminal-pos-dialog.component.ts
+++ b/src/app/modules/financiero/terminal-pos/print-terminal-pos-dialog/print-terminal-pos-dialog.component.ts
@@ -1,0 +1,147 @@
+import { Component, Inject, OnInit } from "@angular/core";
+import { FormBuilder, FormGroup, Validators } from "@angular/forms";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { PrinterInfo } from "../../../../commons/core/electron/electron.service";
+import { ThermalPrinterService } from "../../../configuracion/thermal-printer/thermal-printer.service";
+import { BarcodeQrGeneratorService } from "../../../productos/producto/list-producto/print-label-dialog/barcode-qr-generator.service";
+import { TerminalPos } from "../terminal-pos.model";
+
+export class PrintTerminalPosData {
+  terminalPos: TerminalPos;
+}
+
+@Component({
+  selector: "app-print-terminal-pos-dialog",
+  templateUrl: "./print-terminal-pos-dialog.component.html",
+  styleUrls: ["./print-terminal-pos-dialog.component.scss"],
+})
+export class PrintTerminalPosDialogComponent implements OnInit {
+  printers: PrinterInfo[] = [];
+  printForm: FormGroup;
+  loading = false;
+  previewBarcodeDataUrl: string | null = null;
+
+  constructor(
+    public dialogRef: MatDialogRef<PrintTerminalPosDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: PrintTerminalPosData,
+    private fb: FormBuilder,
+    private snackBar: MatSnackBar,
+    private thermalPrinterService: ThermalPrinterService,
+    private barcodeQrService: BarcodeQrGeneratorService
+  ) {}
+
+  ngOnInit(): void {
+    this.printForm = this.fb.group({
+      selectedPrinter: ["", Validators.required],
+      quantity: [1, [Validators.required, Validators.min(1)]],
+    });
+    this.loadPrinters();
+    this.generatePreview();
+  }
+
+  get codigo(): string {
+    return (this.data.terminalPos?.codigo || "").toString().trim();
+  }
+
+  loadPrinters(): void {
+    this.loading = true;
+    this.thermalPrinterService.getPrinters().subscribe({
+      next: (printers) => {
+        this.printers = printers;
+        if (printers.length > 0) {
+          this.printForm.get("selectedPrinter").setValue(printers[0].name);
+        } else {
+          this.snackBar.open("No hay impresoras disponibles", "Cerrar", { duration: 5000 });
+        }
+        this.loading = false;
+      },
+      error: () => {
+        this.snackBar.open("Error al cargar impresoras térmicas", "Cerrar", { duration: 5000 });
+        this.loading = false;
+      },
+    });
+  }
+
+  generatePreview(): void {
+    if (!this.codigo) {
+      this.previewBarcodeDataUrl = null;
+      return;
+    }
+    this.barcodeQrService
+      .generateBarcode(this.codigo, "CODE128", { height: 80, margin: 0, displayValue: true })
+      .then((dataUrl) => (this.previewBarcodeDataUrl = dataUrl))
+      .catch(() => (this.previewBarcodeDataUrl = null));
+  }
+
+  onPrint(): void {
+    if (this.printForm.invalid) {
+      this.snackBar.open("Por favor complete todos los campos requeridos", "Cerrar", { duration: 3000 });
+      return;
+    }
+    if (!this.codigo) {
+      this.snackBar.open("El terminal POS no tiene un código válido", "Cerrar", { duration: 5000 });
+      return;
+    }
+
+    this.loading = true;
+    const printerName = this.printForm.get("selectedPrinter").value;
+    const quantity = this.printForm.get("quantity").value;
+    const descripcion = (this.data.terminalPos?.descripcion || "").toString();
+
+    const printData: any[] = [];
+    // Salto inicial para que el cabezal térmico no corte el contenido superior
+    printData.push({ type: "text", value: "\n", style: { fontSize: "10px" } });
+
+    if (descripcion) {
+      printData.push({
+        type: "text",
+        value: descripcion,
+        style: { textAlign: "center", fontSize: "14px", fontWeight: "bold", color: "#000000" },
+      });
+    }
+
+    // Mismo formato de código de barras que print-label-dialog (CODE128 nativo ESC/POS)
+    printData.push({
+      type: "barCode",
+      value: this.codigo,
+      barcodeType: "CODE128",
+      format: "CODE128",
+      position: "BELOW",
+      includeParity: true,
+    } as any);
+
+    printData.push({
+      type: "text",
+      value: "------------------------",
+      style: { textAlign: "center", fontSize: "12px", color: "#000000" },
+    });
+    printData.push({ type: "cut", position: "full" } as any);
+
+    const options = {
+      preview: false,
+      width: "58mm",
+      margin: "0 0 0 0",
+      copies: quantity,
+      printerName,
+      timeOutPerLine: 400,
+      silent: true,
+    } as any;
+
+    this.thermalPrinterService.electronService
+      .printWithPosPrinter(printData, options)
+      .subscribe((result) => {
+        this.loading = false;
+        if (result.success) {
+          this.snackBar.open("Código enviado a la impresora", "Cerrar", { duration: 3000 });
+          this.dialogRef.close(true);
+        } else {
+          this.snackBar.open("Error al imprimir: " + (result.error || "Error desconocido"), "Cerrar", { duration: 5000 });
+        }
+      });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+}

--- a/src/app/modules/financiero/terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component.html
+++ b/src/app/modules/financiero/terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component.html
@@ -1,0 +1,36 @@
+<div class="dialog-container" fxLayout="column" fxLayoutGap="10px">
+  <h2 mat-dialog-title style="padding-left: 0;">Escanear Código del POS</h2>
+  
+  <form [formGroup]="formGroup" fxLayout="column" fxLayoutGap="15px">
+    <!-- Codigo -->
+    <div fxLayout="row" fxLayoutGap="10px">
+      <div fxFlex="100%">
+        <mat-form-field appearance="outline" style="width: 100%">
+          <mat-label>Código</mat-label>
+          <input
+            matInput
+            [formControl]="codigoControl"
+            required
+          />
+          <mat-error *ngIf="codigoControl.hasError('required')">
+            Código es obligatorio
+          </mat-error>
+        </mat-form-field>
+      </div>
+    </div>
+  </form>
+
+  <!-- Action Buttons -->
+  <div fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px" style="margin-top: 20px;">
+    <button mat-raised-button color="primary" (click)="onCancel()">
+      Cancelar
+    </button>
+    <button 
+      mat-raised-button 
+      color="accent" 
+      [disabled]="formGroup.invalid"
+    >
+      Confirmar
+    </button>
+  </div>
+</div> 

--- a/src/app/modules/financiero/terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component.scss
+++ b/src/app/modules/financiero/terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component.scss
@@ -1,0 +1,8 @@
+.dialog-container {
+  padding: 16px;
+  max-width: 500px;
+}
+
+input {
+  text-transform: uppercase;
+}

--- a/src/app/modules/financiero/terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component.ts
+++ b/src/app/modules/financiero/terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component.ts
@@ -1,0 +1,45 @@
+import { Component, Inject, OnInit } from "@angular/core";
+import { FormControl, FormGroup, Validators } from "@angular/forms";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { TerminalPos } from "../terminal-pos.model";
+import { TerminalPosService } from "../terminal-pos.service";
+
+export class AddTerminalPosData {
+  terminalPos?: TerminalPos;
+}
+
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: "app-scan-terminal-pos-dialog",
+  templateUrl: "./scan-terminal-pos-dialog.component.html",
+  styleUrls: ["./scan-terminal-pos-dialog.component.scss"],
+})
+export class ScanTerminalPosDialogComponent implements OnInit {
+
+  formGroup: FormGroup;
+
+  //Form Controls
+  codigoControl = new FormControl(null, Validators.required);
+  selectedTerminalPos: TerminalPos;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: AddTerminalPosData,
+    private matDialogRef: MatDialogRef<ScanTerminalPosDialogComponent>,
+    private terminalPosService: TerminalPosService
+  ) {
+    if (data?.terminalPos != null) {
+      this.selectedTerminalPos = data.terminalPos;
+    }
+  }
+
+  ngOnInit(): void {
+    this.formGroup = new FormGroup({
+      codigo: this.codigoControl
+    });
+  }
+
+  onCancel() {
+    this.matDialogRef.close();
+  }
+}

--- a/src/app/modules/financiero/terminal-pos/terminal-pos.model.ts
+++ b/src/app/modules/financiero/terminal-pos/terminal-pos.model.ts
@@ -1,0 +1,34 @@
+import { dateToString } from "../../../commons/core/utils/dateUtils";
+import { Usuario } from "../../personas/usuarios/usuario.model";
+
+export class TerminalPos {
+  id: number;
+  descripcion: string;
+  codigo: string;
+  cuentaBancariaId: number;
+  activo: boolean;
+  creadoEn: Date;
+  usuario: Usuario;
+
+  toInput(): TerminalPosInput {
+    let input = new TerminalPosInput();
+    input.id = this?.id;
+    input.descripcion = this?.descripcion;
+    input.codigo = this?.codigo;
+    input.cuentaBancariaId = this?.cuentaBancariaId;
+    input.activo = this?.activo;
+    input.creadoEn = dateToString(this?.creadoEn);
+    input.usuarioId = this?.usuario?.id;
+    return input;
+  }
+}
+
+export class TerminalPosInput {
+  id?: number;
+  descripcion?: string;
+  codigo?: string;
+  cuentaBancariaId?: number;
+  activo?: boolean;
+  creadoEn?: string;
+  usuarioId?: number;
+}

--- a/src/app/modules/financiero/terminal-pos/terminal-pos.service.ts
+++ b/src/app/modules/financiero/terminal-pos/terminal-pos.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { PageInfo } from '../../../app.component';
+import { GenericCrudService } from '../../../generics/generic-crud.service';
+import { AllTerminalPosGQL } from './graphql/allTerminalPos';
+import { CountTerminalPosGQL } from './graphql/countTerminalPos';
+import { DeleteTerminalPosGQL } from './graphql/deleteTerminalPos';
+import { FilterTerminalPosGQL } from './graphql/filterTerminalPos';
+import { SaveTerminalPosGQL } from './graphql/saveTerminalPos';
+import { SearchTerminalPosGQL } from './graphql/searchTerminalPos';
+import { TerminalPos, TerminalPosInput } from './terminal-pos.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TerminalPosService {
+
+  constructor(
+    private genericCrud: GenericCrudService,
+    private getAllTerminalPos: AllTerminalPosGQL,
+    private saveTerminalPosGQL: SaveTerminalPosGQL,
+    private deleteTerminalPosGQL: DeleteTerminalPosGQL,
+    private searchTerminalPosGQL: SearchTerminalPosGQL,
+    private filterTerminalPosGQL: FilterTerminalPosGQL,
+    private countTerminalPosGQL: CountTerminalPosGQL
+  ) { }
+
+  onCount(servidor: boolean = true): Observable<number> {
+    return this.genericCrud.onCustomQuery(this.countTerminalPosGQL, null, servidor);
+  }
+
+  onGetAll(page?, size?, servidor: boolean = true): Observable<any> {
+    return this.genericCrud.onGetAll(this.getAllTerminalPos, page, size, servidor);
+  }
+
+  onSearch(texto, servidor: boolean = true): Observable<any> {
+    return this.genericCrud.onGetByTexto(this.searchTerminalPosGQL, texto, servidor);
+  }
+
+  onFilter(descripcion, codigo, activo, page = 0, size = 10, servidor: boolean = true): Observable<PageInfo<TerminalPos>> {
+    return this.genericCrud.onCustomQuery(this.filterTerminalPosGQL, { descripcion, codigo, activo, page, size }, servidor);
+  }
+
+  onSave(input: TerminalPosInput, servidor: boolean = true): Observable<any> {
+    return this.genericCrud.onSave(this.saveTerminalPosGQL, input, null, null, servidor);
+  }
+
+  onDelete(id, servidor: boolean = true): Observable<any> {
+    return this.genericCrud.onDelete(this.deleteTerminalPosGQL, id, '¿Eliminar terminal POS?', null, true, servidor, '¿Está seguro que desea eliminar esta terminal POS?');
+  }
+
+}

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -53,6 +53,7 @@ import { ListMarcacionComponent } from '../../../modules/administrativo/marcacio
 import { MarcarHorarioComponent } from '../../../modules/administrativo/marcacion/pages/marcar-horario/marcar-horario.component';
 import { VehiculosDashboardComponent } from '../../../modules/activos/dashboard/vehiculos-dashboard/vehiculos-dashboard.component';
 import { BienesDashboardComponent } from '../../../modules/activos/dashboard/bienes-dashboard/bienes-dashboard.component';
+import { ListTerminalPosComponent } from '../../../modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component';
 
 
 interface BaseNavigationItem {
@@ -291,7 +292,13 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
           icon: 'qr_code_2',
           action: 'list-lote-de',
           visibilityRoles: [ROLES.ADMIN]
-        }
+        },
+        // {
+        //   name: 'Terminales POS',
+        //   icon: 'contactless',
+        //   action: 'list-terminal-pos',
+        //   visibilityRoles: [ROLES.ADMIN]
+        // }
       ]
     },
     {
@@ -691,6 +698,9 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
         break;
       case "list-maletin":
         this.openTabIfAuthorized(ROLES.ADMIN, ListMaletinComponent, "Maletines");
+        break;
+      case "list-terminal-pos":
+        this.openTabIfAuthorized(ROLES.ADMIN, ListTerminalPosComponent, "Terminales POS");
         break;
       case "delivery-dashboard":
         this.tabService.addTab(new Tab(DeliveryDashboardComponent, "Delivery Dash", null, null));


### PR DESCRIPTION
### Que resuelve
Agrega el módulo frontend de terminales POS al dominio financiero. Permite registrar, consultar, filtrar y eliminar terminales de punto de venta asociadas a una cuenta bancaria y a un usuario.

**Componentes incluidos:**

1. `ListTerminalPosComponent` — lista paginada con filtros por descripción, código y estado activo
2. `AddTerminalPosDialogComponent` — formulario de alta/edición
3. `PrintTerminalPosDialogComponent` — diálogo de impresión
4. `ScanTerminalPosDialogComponent` — diálogo de escaneo
Operaciones GraphQL implementadas: `terminalPos`, `terminalesPos`, `searchTerminalPos`, `filterTerminalPos`, `countTerminalPos`, `saveTerminalPos`, `deleteTerminalPos`.

El ítem de menú lateral (`Terminales POS` bajo Financiero) está comentado intencionalmente hasta que la integración con el backend esté validada en develop.

### Como probarlo

1. Descomentar temporalmente el ítem de menú en `side-mini-variant.component.ts` (líneas 297–301).
2. Compilar y levantar la aplicación.
3. Navegar a Financiero > Terminales POS.
4. Crear una terminal con descripción, código.
5. Verificar que aparece en la lista.
6. Probar el filtro por descripción, código y estado activo.
7. Editar y eliminar un registro.
8. Volver a comentar el ítem de menú antes de mergear.

### Impacto en DB
**No aplica**. El módulo consume los endpoints GraphQL del backend. El cambio de DB correspondiente está en el PR del backend (`feat/financiero-add-pos-module` en `franco-system-backend-servidor`, PR #113).

### Riesgo
**Bajo**. Cambio exclusivamente aditivo: nuevos componentes y operaciones GraphQL, sin modificación de lógica existente. El ítem de menú está comentado, por lo que no hay impacto en usuarios finales hasta que se habilite explícitamente.