### PR TITLE
ci(release): evitar build y auto-update en releases byte-identicos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       pull-requests: write
     outputs:
       version: ${{ steps.version.outputs.version }}
+      skip_build: ${{ steps.redundant.outputs.skip_build }}
 
     steps:
       - uses: actions/checkout@v4
@@ -52,10 +53,43 @@ jobs:
             echo "No new release created"
           fi
 
+      # Skip the (expensive) build + auto-update publish when the released commit
+      # is byte-identical to the previous release on the same channel. This happens
+      # e.g. when a beta->master promotion PR triggers "Update branch" (merging
+      # master into release/beta adds only merge nodes, no code) yet semantic-release
+      # still bumps the version. Publishing it would push a redundant auto-update to
+      # every client on that channel for identical code.
+      - name: Detect redundant release
+        id: redundant
+        if: steps.version.outputs.version != ''
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          case "$VERSION" in
+            *-alpha*) PREV=$(git tag --sort=-creatordate | grep -- '-alpha\.' | grep -vx "v${VERSION}" | head -1) ;;
+            *-beta*)  PREV=$(git tag --sort=-creatordate | grep -- '-beta\.'  | grep -vx "v${VERSION}" | head -1) ;;
+            *)        PREV=$(git tag --sort=-creatordate | grep -vE 'alpha|beta' | grep -vx "v${VERSION}" | head -1) ;;
+          esac
+          if [ -z "$PREV" ]; then
+            echo "No previous release on this channel — building."
+            echo "skip_build=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          CUR_TREE=$(git rev-parse "v${VERSION}^{tree}")
+          PREV_TREE=$(git rev-parse "${PREV}^{tree}")
+          echo "current v${VERSION} tree=${CUR_TREE}"
+          echo "previous ${PREV} tree=${PREV_TREE}"
+          if [ "$CUR_TREE" = "$PREV_TREE" ]; then
+            echo "::warning::v${VERSION} is byte-identical to ${PREV} — skipping build & auto-update publish."
+            echo "skip_build=true" >> $GITHUB_OUTPUT
+          else
+            echo "Code differs from ${PREV} — building."
+            echo "skip_build=false" >> $GITHUB_OUTPUT
+          fi
+
   # Job 2: build platform artifacts and upload to the release
   build:
     needs: release
-    if: needs.release.outputs.version != ''
+    if: needs.release.outputs.version != '' && needs.release.outputs.skip_build != 'true'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write


### PR DESCRIPTION
## Qué resuelve

Cada promoción `release/beta → master` fuerza el botón **"Update branch"** del PR (porque `master` tenía `strict=true` y `release/beta` siempre queda atrás por los merge commits de promociones previas). Ese "Update branch" mergea `master` dentro de `release/beta` agregando **solo nodos de merge, sin código**, pero `semantic-release` igual sube la versión y corta un beta nuevo.

Resultado: se publica un manifest que dispara un **auto-update completo (~120MB exe / ~158MB AppImage + reinstall NSIS) a todos los clientes del canal beta, para código byte-a-byte idéntico**.

Caso real verificado: `v3.6.0-beta.1` tiene el mismo tree (`b1bcfe6e…`) que `v3.2.0-beta.9` — 0 archivos cambiados — pero igual se publicó y todos los clientes beta se actualizaron para nada.

## Qué hace este PR

Guard en el job `release`: compara el tree del tag recién liberado contra el del release anterior del **mismo canal** (alpha/beta/stable). Si son idénticos → setea `skip_build=true` y el job `build` no corre (sin artefactos, sin manifest, sin auto-update).

## Cómo testear

Lógica verificada contra la historia real:
- `v3.6.0-beta.1` vs `v3.2.0-beta.9` → IDÉNTICO → **SKIP** ✅ (habría evitado el incidente)
- `v3.6.0` vs `v3.5.0` → distinto → **BUILD** ✅ (stable legítimo no se ve afectado)

## Contexto / complemento

Este PR es el "cinturón de seguridad". La causa raíz ya se atacó aparte: se puso `strict=false` en la protección de `master`, así el "Update branch" deja de ser obligatorio en las promociones. Este guard cubre cualquier fantasma futuro por otra vía.

## Riesgo

Bajo. Solo agrega un step de comparación y un condicional en el `if` del job build. No toca el build en sí ni los nombres de artefactos. Prefijo `ci:` → no dispara release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
