### PR TITLE
fix(usuarios): corregir buscador al agregar rol a usuario

### DIFF
--- a/src/app/modules/personas/usuarios/adicionar-usuario-dialog/adicionar-usuario-dialog.component.ts
+++ b/src/app/modules/personas/usuarios/adicionar-usuario-dialog/adicionar-usuario-dialog.component.ts
@@ -115,22 +115,33 @@ export class AdicionarUsuarioDialogComponent implements OnInit {
   }
 
   onAddUsuarioRole() {
-    this.onSearchRole().pipe(untilDestroyed(this)).subscribe((res) => {
-      if (res != null) {
-        let selectedRole: Role = res;
-        let input = new UsuarioRoleInput;
-        input.roleId = selectedRole.id;
-        input.userId = this.selectedUsuario.id;
-        this.roleService.onSaveUsuarioRole(input).pipe(untilDestroyed(this)).subscribe(saveRes => {
-          this.usuarioRoleList.data = updateDataSource(this.usuarioRoleList.data, saveRes)
-        })
-      }
-    })
+    const openSearch = () => {
+      this.onSearchRole().pipe(untilDestroyed(this)).subscribe((res) => {
+        if (res != null) {
+          const selectedRole: Role = res;
+          const input = new UsuarioRoleInput;
+          input.roleId = selectedRole.id;
+          input.userId = this.selectedUsuario.id;
+          this.roleService.onSaveUsuarioRole(input).pipe(untilDestroyed(this)).subscribe(saveRes => {
+            this.usuarioRoleList.data = updateDataSource(this.usuarioRoleList.data, saveRes)
+          })
+        }
+      })
+    };
+
+    if (this.roleList != null) {
+      openSearch();
+    } else {
+      this.roleService.onGetRoles().pipe(untilDestroyed(this)).subscribe(res => {
+        this.roleList = res ?? [];
+        openSearch();
+      });
+    }
   }
 
   onSearchRole(): Observable<Role> {
-    let data: SearchListtDialogData = {
-      titulo: "Seleccionar sucursal",
+    const data: SearchListtDialogData = {
+      titulo: "Seleccionar rol",
       query: null,
       tableData: [
         { id: "id", nombre: "Id", width: "20%" },
@@ -138,7 +149,7 @@ export class AdicionarUsuarioDialogComponent implements OnInit {
       ],
       inicialData: this.roleList?.filter(r => {
         return this.usuarioRoleList.data.find(ur => ur.role.id == r.id) == null;
-      }),
+      }) ?? [],
     };
     return new Observable(obs => {
       this.matDialog
@@ -150,11 +161,8 @@ export class AdicionarUsuarioDialogComponent implements OnInit {
         .afterClosed()
         .pipe(untilDestroyed(this))
         .subscribe((res) => {
-          if (res != null) {
-            return obs.next(res);
-          } else {
-            return obs.next(null);
-          }
+          obs.next(res ?? null);
+          obs.complete();
         });
     })
   }

--- a/src/app/shared/components/search-list-dialog/search-list-dialog.component.ts
+++ b/src/app/shared/components/search-list-dialog/search-list-dialog.component.ts
@@ -203,6 +203,11 @@ export class SearchListDialogComponent implements OnInit, AfterViewInit {
       return;
     }
 
+    if (this.data?.query == null) {
+      this.filterLocalData();
+      return;
+    }
+
     this.isSearching = true;
     this.isLoadingComputed = true;
     this.updateComputedProperties();
@@ -268,6 +273,29 @@ export class SearchListDialogComponent implements OnInit, AfterViewInit {
           }
         });
     }
+  }
+
+  private filterLocalData(): void {
+    const baseData = Array.isArray(this.data?.inicialData) ? this.data.inicialData : [];
+    let text = this.buscarControl.value;
+
+    if (text == null || String(text).trim() === '' || String(text).trim() === '%') {
+      this.dataSource.data = [...baseData];
+    } else {
+      text = String(text).toUpperCase();
+      this.dataSource.data = baseData.filter(item => this.matchesLocalSearch(item, text));
+    }
+
+    this.selectedItem = null;
+    this.procesarResultados(this.dataSource.data);
+  }
+
+  private matchesLocalSearch(item: any, text: string): boolean {
+    const fields = this.data?.tableData?.map(c => c.id) || ['id', 'nombre'];
+    return fields.some(field => {
+      const value = field.split('.').reduce((obj, key) => obj?.[key], item);
+      return value != null && String(value).toUpperCase().includes(text);
+    });
   }
 
   private procesarResultados(res: any): void {


### PR DESCRIPTION
## Summary
- Corrige el buscador del diálogo al agregar un rol a un usuario, que quedaba en "Cargando..." al presionar Buscar.
- Agrega filtrado local en `SearchListDialogComponent` cuando no hay query GraphQL y se usa `inicialData`.
- Corrige el título del diálogo de "Seleccionar sucursal" a "Seleccionar rol" y asegura que la lista de roles esté cargada antes de abrirlo.

## Test plan
- [ ] Abrir Usuarios y editar un usuario existente
- [ ] Hacer clic en el botón (+) para agregar un rol
- [ ] Verificar que el diálogo muestra "Seleccionar rol"
- [ ] Buscar un rol por nombre (ej. "EDITAR") y confirmar que filtra resultados sin quedar en carga infinita
- [ ] Seleccionar un rol y verificar que se agrega correctamente a la tabla
- [ ] Confirmar que roles ya asignados no aparecen en la lista


Made with [Cursor](https://cursor.com)