### PR TITLE
feat(graficos): agregar filtro subfamilia en productos vendidos

### DIFF
--- a/src/app/modules/grafico/analisis-producto/analisis-producto.component.ts
+++ b/src/app/modules/grafico/analisis-producto/analisis-producto.component.ts
@@ -329,7 +329,7 @@ export class AnalisisProductoComponent implements OnInit {
     const ascendente = modo === 'menos';
 
     this.graficoService.obtenerProductosMasVendidos(
-      rango.inicio, rango.fin, sucId, famId, limit, ascendente, undefined,
+      rango.inicio, rango.fin, sucId, famId, undefined, limit, ascendente, undefined,
       productoIdsFiltro.length > 0 ? productoIdsFiltro : undefined
     ).pipe(
       catchError(() => of([])),

--- a/src/app/modules/grafico/grafico.service.ts
+++ b/src/app/modules/grafico/grafico.service.ts
@@ -83,6 +83,7 @@ export class GraficoService {
     fin: string,
     sucId?: number,
     familiaId?: number,
+    subfamiliaId?: number,
     limit: number = 10,
     ascendente: boolean = false,
     productoId?: number,
@@ -95,6 +96,7 @@ export class GraficoService {
         inicio, fin, limit, ascendente,
         sucursalId: sucId ? String(sucId) : null,
         familiaId: familiaId ? String(familiaId) : null,
+        subfamiliaId: subfamiliaId ? String(subfamiliaId) : null,
         productoId: productoId ? String(productoId) : null,
         productoIds: ids
       },
@@ -251,6 +253,7 @@ export class GraficoService {
     periodos: PeriodoGraficoInput[],
     sucIds?: number[],
     familiaId?: number,
+    subfamiliaId?: number,
     limit = 10,
     ascendente = false,
     productoIds?: number[]
@@ -263,6 +266,7 @@ export class GraficoService {
         limit,
         ascendente,
         familiaId: familiaId ? String(familiaId) : null,
+        subfamiliaId: subfamiliaId ? String(subfamiliaId) : null,
         productoIds: productoIds?.length ? productoIds.map(String) : null,
       },
       true,

--- a/src/app/modules/grafico/graphql/exportar-grafico-excel.gql.ts
+++ b/src/app/modules/grafico/graphql/exportar-grafico-excel.gql.ts
@@ -27,6 +27,7 @@ export class ExportarGraficoExcelGQL extends Query<{ data: string }> {
           ? input.usuarioIds.map(String)
           : null,
         familiaId: input.familiaId != null ? String(input.familiaId) : null,
+        subfamiliaId: input.subfamiliaId != null ? String(input.subfamiliaId) : null,
         productoIds: input.productoIds?.length
           ? input.productoIds.map(String)
           : null,

--- a/src/app/modules/grafico/graphql/productos-mas-vendidos-multi.gql.ts
+++ b/src/app/modules/grafico/graphql/productos-mas-vendidos-multi.gql.ts
@@ -11,6 +11,7 @@ export class ProductosMasVendidosMultiGQL extends Query<any> {
       $sucIds: [ID]
       $limit: Int
       $familiaId: ID
+      $subfamiliaId: ID
       $ascendente: Boolean
       $productoIds: [ID]
     ) {
@@ -19,6 +20,7 @@ export class ProductosMasVendidosMultiGQL extends Query<any> {
         sucIds: $sucIds
         limit: $limit
         familiaId: $familiaId
+        subfamiliaId: $subfamiliaId
         ascendente: $ascendente
         productoIds: $productoIds
       ) {

--- a/src/app/modules/grafico/graphql/productos-mas-vendidos.gql.ts
+++ b/src/app/modules/grafico/graphql/productos-mas-vendidos.gql.ts
@@ -8,8 +8,8 @@ export interface Response {
 }
 
 const productosMasVendidosQuery = gql`
-  query productosMasVendidos($inicio: String, $fin: String, $limit: Int, $sucursalId: ID, $familiaId: ID, $ascendente: Boolean, $productoId: ID, $productoIds: [ID]) {
-    data: productosMasVendidos(inicio: $inicio, fin: $fin, limit: $limit, sucursalId: $sucursalId, familiaId: $familiaId, ascendente: $ascendente, productoId: $productoId, productoIds: $productoIds) {
+  query productosMasVendidos($inicio: String, $fin: String, $limit: Int, $sucursalId: ID, $familiaId: ID, $subfamiliaId: ID, $ascendente: Boolean, $productoId: ID, $productoIds: [ID]) {
+    data: productosMasVendidos(inicio: $inicio, fin: $fin, limit: $limit, sucursalId: $sucursalId, familiaId: $familiaId, subfamiliaId: $subfamiliaId, ascendente: $ascendente, productoId: $productoId, productoIds: $productoIds) {
       productoId
       descripcion
       cantidad

--- a/src/app/modules/grafico/producto-vendido/producto-vendido.component.html
+++ b/src/app/modules/grafico/producto-vendido/producto-vendido.component.html
@@ -40,6 +40,22 @@
 
     <mat-form-field
       appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--subfamilia"
+    >
+      <mat-label>Subfamilia</mat-label>
+      <mat-select [formControl]="subfamiliaControl">
+        <mat-option [value]="null">Todas las subfamilias</mat-option>
+        <mat-option
+          *ngFor="let subfamilia of subfamiliasFiltradas$ | async"
+          [value]="subfamilia.id"
+        >
+          {{ subfamilia.nombre | titlecase }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field
+      appearance="outline"
       class="grafico-filtros__campo grafico-filtros__campo--anho"
     >
       <mat-label>Años</mat-label>

--- a/src/app/modules/grafico/producto-vendido/producto-vendido.component.ts
+++ b/src/app/modules/grafico/producto-vendido/producto-vendido.component.ts
@@ -14,17 +14,14 @@ import { EChartsOption } from "echarts";
 import {
   BehaviorSubject,
   Observable,
-  catchError,
   combineLatest,
   debounceTime,
   finalize,
   map,
-  of,
   Subject,
   startWith,
   switchMap,
   tap,
-  timeout,
 } from "rxjs";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { MatDialog } from "@angular/material/dialog";
@@ -32,6 +29,8 @@ import { ProductoForPdvGQL } from "../../productos/producto/graphql/productoSear
 import { ProductoVendidoEstadistica } from "./interfaces/producto-vendido-estadistica.model";
 import { Sucursal } from "../../empresarial/sucursal/sucursal.model";
 import { Familia } from "../../productos/familia/familia.model";
+import { Subfamilia } from "../../productos/sub-familia/sub-familia.model";
+import { SubFamiliaService } from "../../productos/sub-familia/sub-familia.service";
 import { GraficoService } from "../grafico.service";
 import {
   GRAFICO_COLORES,
@@ -65,12 +64,14 @@ import {
 })
 export class ProductoVendidoComponent implements OnInit {
   private graficoService = inject(GraficoService);
+  private subFamiliaService = inject(SubFamiliaService);
   private cdr = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private productoSearchGQL = inject(ProductoForPdvGQL);
 
   readonly filtroSucursales = new GraficoFiltroSucursalesMulti();
   familiaControl = new FormControl<number | null>(null);
+  subfamiliaControl = new FormControl<number | null>(null);
   limitControl = new FormControl<number>(10);
   readonly filtroPeriodo = new GraficoFiltrosPeriodo();
 
@@ -86,6 +87,7 @@ export class ProductoVendidoComponent implements OnInit {
   private readonly exportandoSubject = new BehaviorSubject<boolean>(false);
   private readonly sucursalesSubject = new BehaviorSubject<Sucursal[]>([]);
   private readonly familiasSubject = new BehaviorSubject<Familia[]>([]);
+  private readonly subfamiliasSubject = new BehaviorSubject<Subfamilia[]>([]);
   private readonly indicesOcultosSubject = new BehaviorSubject<Set<string>>(
     new Set()
   );
@@ -97,6 +99,12 @@ export class ProductoVendidoComponent implements OnInit {
 
   sucursales$: Observable<Sucursal[]> = this.sucursalesSubject.asObservable();
   familias$: Observable<Familia[]> = this.familiasSubject.asObservable();
+  subfamiliasFiltradas$: Observable<Subfamilia[]> = combineLatest([
+    this.subfamiliasSubject.asObservable(),
+    this.familiaControl.valueChanges.pipe(startWith(this.familiaControl.value)),
+  ]).pipe(
+    map(([subfamilias, familiaId]) => this.filtrarSubfamilias(subfamilias, familiaId))
+  );
 
   readonly pantalla$: Observable<ProductoVendidoPantalla> = combineLatest([
     this.datosSubject,
@@ -123,7 +131,23 @@ export class ProductoVendidoComponent implements OnInit {
       () => this.cdr.markForCheck()
     );
     this.cargarMetadata();
+    this.configurarFiltroSubfamilia();
     this.configurarDataStream();
+  }
+
+  onFamiliaChange(): void {
+    const familiaId = this.familiaControl.value;
+    const subfamiliaId = this.subfamiliaControl.value;
+    if (subfamiliaId == null) {
+      return;
+    }
+    const subfamilias = this.filtrarSubfamilias(
+      this.subfamiliasSubject.value,
+      familiaId
+    );
+    if (!subfamilias.some((s) => s.id === subfamiliaId)) {
+      this.subfamiliaControl.setValue(null);
+    }
   }
 
   alternarItem(id: string | number): void {
@@ -199,6 +223,7 @@ export class ProductoVendidoComponent implements OnInit {
   limpiarFiltros(): void {
     this.filtroSucursales.limpiar();
     this.familiaControl.setValue(null);
+    this.subfamiliaControl.setValue(null);
     this.limitControl.setValue(10);
     this.filtroPeriodo.limpiar();
     this.productosSeleccionadosIds = [];
@@ -221,14 +246,23 @@ export class ProductoVendidoComponent implements OnInit {
     const sucIds = this.filtroSucursales.normalizarIds();
     const filtros = etiquetasFiltroPeriodoGrafico(this.filtroPeriodo);
     const familiaId = this.familiaControl.value;
+    const subfamiliaId = this.subfamiliaControl.value;
     const familias = this.familiasSubject.value;
+    const subfamilias = this.subfamiliasSubject.value;
     const familiaNombre =
       familiaId != null
         ? familias.find((f) => f.id === familiaId)?.nombre ?? String(familiaId)
         : null;
+    const subfamiliaNombre =
+      subfamiliaId != null
+        ? subfamilias.find((s) => s.id === subfamiliaId)?.nombre ?? String(subfamiliaId)
+        : null;
     const partesExtra: string[] = [];
     if (familiaNombre) {
       partesExtra.push(`Familia: ${familiaNombre}`);
+    }
+    if (subfamiliaNombre) {
+      partesExtra.push(`Subfamilia: ${subfamiliaNombre}`);
     }
     if (this.productosSeleccionadosNombres.length) {
       partesExtra.push(
@@ -242,6 +276,7 @@ export class ProductoVendidoComponent implements OnInit {
         sucIds,
         limit: this.limitControl.value ?? 10,
         familiaId,
+        subfamiliaId,
         productoIds: this.productosSeleccionadosIds.length
           ? this.productosSeleccionadosIds
           : null,
@@ -282,6 +317,27 @@ export class ProductoVendidoComponent implements OnInit {
       .obtenerFamilias()
       .pipe(untilDestroyed(this))
       .subscribe((fams) => this.familiasSubject.next(fams));
+
+    this.subFamiliaService.subfamiliaBS
+      .pipe(untilDestroyed(this))
+      .subscribe((subs) => this.subfamiliasSubject.next(subs ?? []));
+  }
+
+  private configurarFiltroSubfamilia(): void {
+    this.familiaControl.valueChanges
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.onFamiliaChange());
+  }
+
+  private filtrarSubfamilias(
+    subfamilias: Subfamilia[] | null | undefined,
+    familiaId: number | null
+  ): Subfamilia[] {
+    const lista = subfamilias ?? [];
+    if (familiaId == null) {
+      return lista;
+    }
+    return lista.filter((s) => s.familia?.id === familiaId);
   }
 
   private configurarDataStream(): void {
@@ -297,6 +353,7 @@ export class ProductoVendidoComponent implements OnInit {
           this.consultarDatos(
             this.filtroSucursales.normalizarIds(),
             this.familiaControl.value,
+            this.subfamiliaControl.value,
             this.limitControl.value || 10,
             this.productosIdsBusquedaSubject.value
           )
@@ -328,6 +385,7 @@ export class ProductoVendidoComponent implements OnInit {
   private consultarDatos(
     sucIds: number[],
     famId: number | null,
+    subfamId: number | null,
     limit: number,
     productoIds: number[]
   ): Observable<ProductoVendidoEstadistica[]> {
@@ -336,18 +394,17 @@ export class ProductoVendidoComponent implements OnInit {
         periodosDesdeFiltro(this.filtroPeriodo),
         this.filtroSucursales.normalizarIds(sucIds),
         famId || undefined,
+        subfamId || undefined,
         limit || 10,
         false,
         productoIds?.length ? productoIds : undefined
       )
       .pipe(
-        timeout(20000),
         map((items) =>
           this.normalizarEstadisticas(items).sort(
             (a, b) => b.totalMonto - a.totalMonto
           )
         ),
-        catchError(() => of([])),
         finalize(() => this.cargandoSubject.next(false))
       );
   }

--- a/src/app/modules/grafico/styles/_grafico-filtros.scss
+++ b/src/app/modules/grafico/styles/_grafico-filtros.scss
@@ -48,6 +48,12 @@ $grafico-warn: #f44336;
       max-width: 240px;
     }
 
+    &--subfamilia {
+      min-width: 160px;
+      width: 200px;
+      max-width: 240px;
+    }
+
     &--anho {
       min-width: 120px;
       width: 140px;
@@ -197,6 +203,15 @@ $grafico-warn: #f44336;
     .mat-mdc-select-arrow,
     .mat-icon {
       color: $grafico-text-secondary;
+    }
+
+    .grafico-filtros__campo--familia,
+    .grafico-filtros__campo--subfamilia {
+      .mat-mdc-select-value-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 }

--- a/src/app/modules/grafico/utils/grafico-excel-export.model.ts
+++ b/src/app/modules/grafico/utils/grafico-excel-export.model.ts
@@ -22,6 +22,7 @@ export interface GraficoExcelExportInput {
   filtroExtra?: string;
   limit?: number;
   familiaId?: number | null;
+  subfamiliaId?: number | null;
   ascendente?: boolean;
   productoIds?: number[] | null;
 }

--- a/src/app/modules/productos/sub-familia/graphql/graphql-query.ts
+++ b/src/app/modules/productos/sub-familia/graphql/graphql-query.ts
@@ -8,6 +8,9 @@ export const subfamiliasQuery = gql`
       descripcion
       icono
       posicion
+      familia {
+        id
+      }
       subfamilia {
         id
       }


### PR DESCRIPTION
## Summary
- Agrega filtro Subfamilia en Productos Vendidos con cascada según familia seleccionada.
- Propaga `subfamiliaId` a GraphQL, servicio y exportación Excel.
- Elimina timeout/catchError silencioso que devolvía lista vacía ante errores.

## Test plan
- [ ] Abrir gráfico Productos Vendidos y filtrar por subfamilia
- [ ] Cambiar familia y verificar que subfamilia inválida se limpia
- [ ] Exportar Excel con subfamilia seleccionada
- [ ] Confirmar que errores de red/backend se muestran (no lista vacía silenciosa)


Made with [Cursor](https://cursor.com)