### PR TITLE
fix(layout): recalcular ancho de pestañas al colapsar sidenav

### DIFF
--- a/src/app/layouts/default/default.component.html
+++ b/src/app/layouts/default/default.component.html
@@ -1,8 +1,13 @@
 <div style="height: 100vh">
   <app-header (toogleSideBarEvent)="toggleSideNav()" (openNotificationsEvent)="openNotifications()"></app-header>
 
-  <mat-drawer-container [hasBackdrop]="false">
-    <mat-drawer mode="side" [opened]="true" class="side-drawer">
+  <mat-drawer-container #drawerContainer [hasBackdrop]="false" autosize>
+    <mat-drawer
+      mode="side"
+      [opened]="true"
+      class="side-drawer"
+      [style.width.px]="sideBarOpen ? sidenavExpandedWidth : sidenavCollapsedWidth"
+    >
       <app-side-mini-variant [isExpanded]="sideBarOpen" (toggleSideNav)="setSideNav($event)"></app-side-mini-variant>
     </mat-drawer>
     <mat-drawer-content style="overflow: hidden;">

--- a/src/app/layouts/default/default.component.scss
+++ b/src/app/layouts/default/default.component.scss
@@ -315,8 +315,8 @@
 }
 
 .side-drawer {
-  width: auto !important;
-  min-width: auto !important;
+  transition: width 0.3s ease;
+  min-width: unset !important;
   max-width: none !important;
   overflow: visible !important;
 }

--- a/src/app/layouts/default/default.component.ts
+++ b/src/app/layouts/default/default.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, ViewEncapsulation, OnDestroy, ViewChild, ChangeDetectorRef } from "@angular/core";
+import { Component, OnInit, ViewEncapsulation, OnDestroy, ViewChild, ChangeDetectorRef, AfterViewInit } from "@angular/core";
+import { MatDrawerContainer } from "@angular/material/sidenav";
 import { Router } from "@angular/router";
 import { TabService } from "../tab/tab.service";
 import { Tab } from "../tab/tab.model";
@@ -23,9 +24,14 @@ import { FormControl, FormGroup } from "@angular/forms";
   styleUrls: ["./default.component.scss"],
   encapsulation: ViewEncapsulation.None,
 })
-export class DefaultComponent implements OnInit, OnDestroy {
+export class DefaultComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @ViewChild(MatTabGroup) matTabGroup: MatTabGroup;
+  @ViewChild("drawerContainer") drawerContainer: MatDrawerContainer;
+
+  readonly sidenavCollapsedWidth = 60;
+  readonly sidenavExpandedWidth = 250;
+  private readonly sidenavTransitionMs = 300;
 
   sideBarOpen = false;
   notificationsOpen = false;
@@ -97,6 +103,10 @@ export class DefaultComponent implements OnInit, OnDestroy {
 
 
 
+  ngAfterViewInit(): void {
+    this.updateDrawerLayout();
+  }
+
   ngOnInit(): void {
     this.mainService.authenticationSub
       .pipe(untilDestroyed(this))
@@ -136,9 +146,24 @@ export class DefaultComponent implements OnInit, OnDestroy {
 
   toggleSideNav(): void {
     this.sideBarOpen = !this.sideBarOpen;
+    this.onSideNavLayoutChange();
   }
+
   setSideNav(isExpanded: boolean): void {
     this.sideBarOpen = isExpanded;
+    this.onSideNavLayoutChange();
+  }
+
+  private onSideNavLayoutChange(): void {
+    this.updateDrawerLayout();
+    setTimeout(() => this.updateDrawerLayout(), this.sidenavTransitionMs);
+  }
+
+  private updateDrawerLayout(): void {
+    this.drawerContainer?.updateContentMargins();
+    this.cdr.detectChanges();
+    this.windowInfo.notifyLayoutChange();
+    window.dispatchEvent(new Event("resize"));
   }
 
 

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.scss
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.scss
@@ -1,17 +1,12 @@
 .side-nav-container {
   height: 100%;
-  width: 60px;
+  width: 100%;
   position: relative;
-  transition: width 0.3s ease;
   background-color: #424242;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
   overflow-x: hidden;
   overflow-y: auto;
   z-index: 1000;
-
-  &.expanded {
-    width: 250px;
-  }
 
   .side-nav-content {
     height: 100%;

--- a/src/app/shared/services/window-info.service.ts
+++ b/src/app/shared/services/window-info.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -9,11 +10,22 @@ export class WindowInfoService {
   innerHeight: any;
   innerTabHeight: number;
   wide?: boolean;
+  readonly layoutChanged$ = new Subject<void>();
 
-  constructor() { 
+  constructor() {
+    this.updateDimensions();
+    window.addEventListener('resize', () => this.updateDimensions());
+  }
+
+  updateDimensions(): void {
     this.innerHeight = window.innerHeight;
     this.innerWidth = window.innerWidth;
     this.innerTabHeight = this.innerHeight * 0.9;
     this.wide = (this.innerWidth / this.innerHeight) < 1.4;
+    this.notifyLayoutChange();
+  }
+
+  notifyLayoutChange(): void {
+    this.layoutChanged$.next();
   }
 }


### PR DESCRIPTION
## Summary
- Sincroniza el ancho del `mat-drawer` (60px / 250px) con el estado expandido/colapsado del sidenav.
- Fuerza el recálculo de márgenes del contenedor de pestañas al abrir o cerrar el menú lateral.
- Expone `layoutChanged$` en `WindowInfoService` y dispara `resize` para que pantallas y gráficos se redibujen correctamente.

## Test plan
- [ ] Abrir una pestaña (ej. Lista de productos) con el sidenav colapsado y verificar que ocupa todo el ancho disponible.
- [ ] Expandir el sidenav desde el botón del header y confirmar que el contenido se reduce sin solaparse.
- [ ] Colapsar el sidenav haciendo clic fuera o desde el header y verificar que la pestaña vuelve a ocupar el espacio liberado (sin zona gris vacía).
- [ ] Repetir con una pantalla de gráficos y confirmar que el chart se redimensiona al cambiar el sidenav.
- [ ] Cambiar entre pestañas abiertas y validar que el layout se mantiene consistente.


Made with [Cursor](https://cursor.com)