### PR TITLE
feat(compras): mejorar buscador de productos en items del pedido

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.html
@@ -8,13 +8,7 @@
       <div fxLayout="column">
         <div fxLayout="row">
           <div fxFlex="100">
-            <mat-form-field
-              appearance="outline"
-              class="buscar-producto-field transferencia-input-field shrinking-mat-form-field"
-              floatLabel="always"
-              color="warn"
-              style="width: 95%"
-            >
+            <mat-form-field style="width: 95%">
               <mat-label>Ingresar texto</mat-label>
               <input
                 #buscarInput
@@ -22,7 +16,6 @@
                 placeholder="Buscar Producto"
                 autocomplete="off"
                 formControlName="buscarControl"
-                oninput="(this.value == ' ') ? this.value = null : null ;this.value = this.value.toUpperCase()"
                 (keydown)="keydownEvent($event.key)"
               />
               <button
@@ -299,14 +292,10 @@
               </button>
             </div>
 
-            <div *ngIf="isSearching" class="estado-busqueda">
-              <mat-spinner diameter="32"></mat-spinner>
-            </div>
             <div
               *ngIf="
-                !isSearching &&
                 dataSource.data.length === 0 &&
-                formGroup.get('buscarControl')?.value
+                formGroup.get('buscarControl')?.value?.trim()
               "
               class="estado-busqueda"
             >

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.scss
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.scss
@@ -143,8 +143,16 @@ input {
   text-transform: uppercase;
 }
 
-.buscar-producto-field {
-  width: 100%;
+::ng-deep .mat-mdc-form-field .mat-mdc-form-field-outline {
+  color: rgba(255, 255, 255, 0.3) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-form-field-label {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+::ng-deep .mat-mdc-form-field input {
+  color: white !important;
 }
 
 .estado-busqueda {

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.ts
@@ -23,7 +23,15 @@ import {
 } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import {
+  catchError,
+  distinctUntilChanged,
+  map,
+  startWith,
+  switchMap,
+  tap,
+} from 'rxjs/operators';
 import { Producto } from '../../../../../productos/producto/producto.model';
 import { Presentacion } from '../../../../../productos/presentacion/presentacion.model';
 import { ProductoComponent } from '../../../../../productos/producto/edit-producto/producto.component';
@@ -43,7 +51,6 @@ export interface ComprasSearchProductoResponse {
   searchText?: string;
 }
 
-const DEBOUNCE_MS = 300;
 const PAGE_SIZE = 20;
 
 @UntilDestroy({ checkProperties: true })
@@ -75,7 +82,6 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
   selectedRowIndex = -1;
   selectedPresentacionRowIndex = -1;
   selectedPresentacion: Presentacion | null = null;
-  isSearching = false;
   mostrarStockColumna = false;
   private paginaActual = 0;
   private terminoBusqueda = '';
@@ -104,55 +110,101 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
     this.formGroup
       .get('buscarControl')
       ?.valueChanges.pipe(
-        debounceTime(DEBOUNCE_MS),
+        startWith(this.data?.texto ?? ''),
         distinctUntilChanged(),
+        tap(() => this.reiniciarSeleccion()),
+        switchMap((value: string) => {
+          const termino = (value ?? '').trim();
+          this.terminoBusqueda = termino;
+          this.paginaActual = 0;
+
+          if (!termino) {
+            this.dataSource.data = [];
+            return of([] as Producto[]);
+          }
+
+          return this.crearBusqueda$(termino, 0);
+        }),
         untilDestroyed(this)
       )
-      .subscribe((value: string) => {
-        this.ejecutarBusqueda(value, 0, false);
+      .subscribe({
+        next: (productos) => {
+          this.dataSource.data = productos;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.dataSource.data = [];
+          this.notificacionService.openWarn('Error al buscar productos');
+          this.cdr.markForCheck();
+        },
       });
-
-    const textoInicial = this.data?.texto?.trim();
-    if (textoInicial) {
-      this.ejecutarBusqueda(textoInicial, 0, false);
-    }
   }
 
   ngAfterViewInit(): void {
     setTimeout(() => this.buscarInput?.nativeElement?.focus(), 200);
   }
 
+  private crearBusqueda$(texto: string, page: number): Observable<Producto[]> {
+    const termino = (texto ?? '').trim();
+    if (!termino) {
+      return of([]);
+    }
+
+    const esCodigo = this.pareceCodigoBarras(termino);
+
+    if (esCodigo) {
+      return this.buscadorComprasService
+        .buscarProducto(termino, page, PAGE_SIZE, undefined, true)
+        .pipe(
+          map((res) =>
+            (res.getContent ?? [])
+              .map((r) => r.producto)
+              .filter((p): p is Producto => p?.id != null)
+          ),
+          catchError(() => of([] as Producto[]))
+        );
+    }
+
+    return this.productoService
+      .onSearch(termino, page * PAGE_SIZE, null, false, true, true, true)
+      .pipe(catchError(() => of([] as Producto[])));
+  }
+
+  private pareceCodigoBarras(termino: string): boolean {
+    if (!termino || termino.includes(' ')) {
+      return false;
+    }
+    return /^\d{3,}$/.test(termino) || /^[A-Za-z0-9\-._]{4,32}$/.test(termino);
+  }
+
+  private reiniciarSeleccion(): void {
+    this.expandedProducto = null;
+    this.selectedRowIndex = -1;
+    this.selectedPresentacionRowIndex = -1;
+    this.selectedPresentacion = null;
+  }
+
   ejecutarBusqueda(texto: string, page: number, append: boolean): void {
     const termino = (texto ?? '').trim();
     this.terminoBusqueda = termino;
-    this.paginaActual = page;
 
     if (!append) {
-      this.expandedProducto = null;
-      this.selectedRowIndex = -1;
-      this.selectedPresentacionRowIndex = -1;
-      this.selectedPresentacion = null;
+      this.paginaActual = 0;
+      this.reiniciarSeleccion();
+    } else {
+      this.paginaActual = page;
     }
 
     if (!termino) {
       this.dataSource.data = [];
-      this.isSearching = false;
       this.cdr.markForCheck();
       return;
     }
 
-    this.isSearching = true;
-    this.cdr.markForCheck();
-
-    this.buscadorComprasService
-      .buscarProducto(termino, page, PAGE_SIZE, undefined, true)
+    this.crearBusqueda$(termino, append ? page : 0)
       .pipe(untilDestroyed(this))
       .subscribe({
-        next: (res) => {
-          const productos = (res.getContent ?? [])
-            .map((r) => r.producto)
-            .filter((p): p is Producto => p?.id != null);
-
+        next: (productos) => {
           if (append) {
             const idsExistentes = new Set(this.dataSource.data.map((p) => p.id));
             const nuevos = productos.filter((p) => !idsExistentes.has(p.id));
@@ -161,14 +213,12 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
             this.dataSource.data = productos;
           }
 
-          this.isSearching = false;
           this.cdr.markForCheck();
         },
         error: () => {
           if (!append) {
             this.dataSource.data = [];
           }
-          this.isSearching = false;
           this.notificacionService.openWarn('Error al buscar productos');
           this.cdr.markForCheck();
         },

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -2277,45 +2277,7 @@ export class GestionComprasComponent
     }
 
     const text = this.codigoControl.value?.trim();
-    if (!text) {
-      this.onAddItem();
-      return;
-    }
-
-    this.buscadorComprasService
-      .buscarProducto(text, 0, 10, undefined, true)
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (page) => {
-          const resultados = page.getContent ?? [];
-
-          if (resultados.length === 0) {
-            this.notificacionService.openWarn("Producto no encontrado");
-            setTimeout(() => this.addItemInput?.nativeElement?.select(), 100);
-            return;
-          }
-
-          const unicoResultado = resultados.length === 1 ? resultados[0] : null;
-          const coincidenciaExacta = resultados.find(
-            (r) => r.tipoCoincidencia === "CODIGO_EXACTO"
-          );
-
-          const seleccion = coincidenciaExacta ?? unicoResultado;
-          if (seleccion?.producto) {
-            const presentacion = this.resolverPresentacionPrincipal(seleccion.producto);
-            this.lastItemSearchText = text;
-            this.openAddEditItemDialog(seleccion.producto, presentacion, text);
-            this.codigoControl.setValue(null);
-            setTimeout(() => this.addItemInput?.nativeElement?.select(), 100);
-            return;
-          }
-
-          this.onAddItem(text);
-        },
-        error: () => {
-          this.onAddItem(text);
-        },
-      });
+    this.onAddItem(text || undefined);
   }
 
   onCodigoFocus(): void {
@@ -2351,13 +2313,6 @@ export class GestionComprasComponent
       this.codigoControl.setValue(null);
       setTimeout(() => this.addItemInput?.nativeElement?.select(), 100);
     });
-  }
-
-  private resolverPresentacionPrincipal(producto: Producto): Presentacion | undefined {
-    const presentaciones = (producto?.presentaciones ?? []).filter(
-      (p) => p?.activo !== false
-    );
-    return presentaciones.find((p) => p.principal) ?? presentaciones[0];
   }
 
   private openAddEditItemDialog(

--- a/src/app/modules/productos/producto/producto.service.ts
+++ b/src/app/modules/productos/producto/producto.service.ts
@@ -138,12 +138,12 @@ export class ProductoService {
     return this.genericService.onCustomQuery(this.productoDescripcionExistsGql, { descripcion }, servidor);
   }
 
-  onGetProductoPorCodigo(texto, servidor: boolean = true): Observable<Producto> {
-    return this.genericService.onCustomQuery(this.productoPorCodigo, { texto }, servidor);
+  onGetProductoPorCodigo(texto, servidor: boolean = true, silentLoad: boolean = false): Observable<Producto> {
+    return this.genericService.onCustomQuery(this.productoPorCodigo, { texto }, servidor, undefined, silentLoad);
   }
 
-  onSearch(texto, offset?, sucursalId?, conStock?, activo?, servidor = true): Observable<Producto[]> {
-    return this.genericService.onCustomQuery(this.productoSearch, {texto, offset, sucursalId, conStock, isEnvase: false, activo}, servidor);
+  onSearch(texto, offset?, sucursalId?, conStock?, activo?, servidor = true, silentLoad: boolean = false): Observable<Producto[]> {
+    return this.genericService.onCustomQuery(this.productoSearch, {texto, offset, sucursalId, conStock, isEnvase: false, activo}, servidor, undefined, silentLoad);
   }
 
   onEnvaseSearch(texto, offset?, isEnvase?: boolean, servidor = true): Observable<Producto[]> {


### PR DESCRIPTION
## Summary
- Alinea el estilo del diálogo de búsqueda con transferencias y abre el buscador al presionar Enter en código de barra.
- Habilita búsqueda en tiempo real sin spinner ni debounce que interfiera al escribir.
- Soporta prefijo de código de barras mientras se escribe, usando el buscador inteligente de compras.

## Test plan
- [ ] En gestión de compras, pestaña Items del pedido, escribir en Código de barra y presionar Enter.
- [ ] Verificar que el diálogo abre con el texto ingresado y sin spinner al tipear.
- [ ] Buscar por nombre (ej. COCA) y confirmar resultados en tiempo real.
- [ ] Buscar por prefijo de código de barras (ej. 784005) y confirmar productos relevantes.
- [ ] Seleccionar un producto y verificar que el flujo de agregar ítem sigue funcionando.

Made with [Cursor](https://cursor.com)