### PR TITLE
feat(compras): acelerar primera búsqueda de producto en pedido

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/buscador-compras.service.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/buscador-compras.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { Query } from 'apollo-angular';
 import { Observable, of } from 'rxjs';
-import { catchError, map, switchMap } from 'rxjs/operators';
+import { catchError, map, shareReplay, switchMap, take } from 'rxjs/operators';
 import { GenericCrudService } from '../../../../generics/generic-crud.service';
 import { PageInfo } from '../../../../app.component';
 import { Producto } from '../../../productos/producto/producto.model';
 import { ProductoProveedor } from '../../../productos/producto-proveedor/producto-proveedor.model';
+import { ProductoService } from '../../../productos/producto/producto.service';
 import { SearchProductoWithFiltersGQL } from '../../../productos/producto/graphql/searchWithFilters';
 import {
   buscarProductoInteligenteQuery,
@@ -46,16 +47,106 @@ export class ProductoProveedorBusquedaInteligenteGQL extends Query<ProductoProve
   document = productoProveedorBusquedaInteligenteQuery;
 }
 
+const BUSQUEDA_DIALOG_PAGE_SIZE = 20;
+const BUSQUEDA_CACHE_TTL_MS = 60_000;
+
 @Injectable({
   providedIn: 'root',
 })
 export class BuscadorComprasService {
+  private busquedaDialogCache = new Map<string, Observable<Producto[]>>();
+
   constructor(
     private genericCrudService: GenericCrudService,
     private buscarProductoInteligenteGQL: BuscarProductoInteligenteGQL,
     private productoProveedorBusquedaInteligenteGQL: ProductoProveedorBusquedaInteligenteGQL,
-    private searchProductoWithFiltersGQL: SearchProductoWithFiltersGQL
+    private searchProductoWithFiltersGQL: SearchProductoWithFiltersGQL,
+    private productoService: ProductoService
   ) {}
+
+  /**
+   * Búsqueda de productos para el diálogo de compras.
+   * Usa caché compartida (shareReplay) para que prefetch y diálogo reutilicen la misma petición.
+   */
+  buscarProductosParaDialog(
+    texto: string,
+    page = 0,
+    size = BUSQUEDA_DIALOG_PAGE_SIZE,
+    silentLoad = true
+  ): Observable<Producto[]> {
+    const termino = (texto ?? '').trim();
+    if (!termino) {
+      return of([]);
+    }
+
+    const cacheKey = `${termino}|${page}|${size}`;
+    const cached = this.busquedaDialogCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const request$ = this.ejecutarBusquedaProductosDialog(
+      termino,
+      page,
+      size,
+      silentLoad
+    ).pipe(
+      shareReplay({ bufferSize: 1, refCount: false }),
+      catchError(() => of([] as Producto[]))
+    );
+
+    this.busquedaDialogCache.set(cacheKey, request$);
+    setTimeout(() => this.busquedaDialogCache.delete(cacheKey), BUSQUEDA_CACHE_TTL_MS);
+
+    return request$;
+  }
+
+  /** Precalienta la conexión GraphQL al entrar al tab de ítems. */
+  warmupBusquedaProductos(): void {
+    this.buscarProductosParaDialog('a', 0, 1, true)
+      .pipe(take(1))
+      .subscribe({ error: () => undefined });
+  }
+
+  private ejecutarBusquedaProductosDialog(
+    termino: string,
+    page: number,
+    size: number,
+    silentLoad: boolean
+  ): Observable<Producto[]> {
+    if (this.pareceCodigoBarras(termino)) {
+      return this.buscarProducto(termino, page, size, undefined, silentLoad).pipe(
+        map((res) =>
+          (res.getContent ?? [])
+            .map((r) => r.producto)
+            .filter((p): p is Producto => p?.id != null)
+        )
+      );
+    }
+
+    return this.productoService.onSearch(
+      termino,
+      page * size,
+      null,
+      false,
+      true,
+      true,
+      silentLoad
+    );
+  }
+
+  private pareceCodigoBarras(termino: string): boolean {
+    if (!termino || termino.includes(' ')) {
+      return false;
+    }
+    if (/^\d{3,}$/.test(termino)) {
+      return true;
+    }
+    if (/^[A-Za-z]+$/.test(termino)) {
+      return false;
+    }
+    return /^[A-Za-z0-9\-._]{4,32}$/.test(termino);
+  }
 
   buscarProducto(
     texto: string,

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.html
@@ -293,7 +293,15 @@
             </div>
 
             <div
+              *ngIf="busquedaEnCurso"
+              class="estado-busqueda"
+            >
+              <mat-spinner diameter="32"></mat-spinner>
+            </div>
+
+            <div
               *ngIf="
+                !busquedaEnCurso &&
                 dataSource.data.length === 0 &&
                 formGroup.get('buscarControl')?.value?.trim()
               "

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.ts
@@ -25,9 +25,8 @@ import { MatTableDataSource } from '@angular/material/table';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Observable, of } from 'rxjs';
 import {
-  catchError,
   distinctUntilChanged,
-  map,
+  finalize,
   startWith,
   switchMap,
   tap,
@@ -83,6 +82,7 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
   selectedPresentacionRowIndex = -1;
   selectedPresentacion: Presentacion | null = null;
   mostrarStockColumna = false;
+  busquedaEnCurso = false;
   private paginaActual = 0;
   private terminoBusqueda = '';
 
@@ -119,11 +119,18 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
           this.paginaActual = 0;
 
           if (!termino) {
+            this.busquedaEnCurso = false;
             this.dataSource.data = [];
             return of([] as Producto[]);
           }
 
-          return this.crearBusqueda$(termino, 0);
+          this.busquedaEnCurso = true;
+          return this.crearBusqueda$(termino, 0).pipe(
+            finalize(() => {
+              this.busquedaEnCurso = false;
+              this.cdr.markForCheck();
+            })
+          );
         }),
         untilDestroyed(this)
       )
@@ -150,31 +157,12 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
       return of([]);
     }
 
-    const esCodigo = this.pareceCodigoBarras(termino);
-
-    if (esCodigo) {
-      return this.buscadorComprasService
-        .buscarProducto(termino, page, PAGE_SIZE, undefined, true)
-        .pipe(
-          map((res) =>
-            (res.getContent ?? [])
-              .map((r) => r.producto)
-              .filter((p): p is Producto => p?.id != null)
-          ),
-          catchError(() => of([] as Producto[]))
-        );
-    }
-
-    return this.productoService
-      .onSearch(termino, page * PAGE_SIZE, null, false, true, true, true)
-      .pipe(catchError(() => of([] as Producto[])));
-  }
-
-  private pareceCodigoBarras(termino: string): boolean {
-    if (!termino || termino.includes(' ')) {
-      return false;
-    }
-    return /^\d{3,}$/.test(termino) || /^[A-Za-z0-9\-._]{4,32}$/.test(termino);
+    return this.buscadorComprasService.buscarProductosParaDialog(
+      termino,
+      page,
+      PAGE_SIZE,
+      true
+    );
   }
 
   private reiniciarSeleccion(): void {
@@ -196,13 +184,21 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
     }
 
     if (!termino) {
+      this.busquedaEnCurso = false;
       this.dataSource.data = [];
       this.cdr.markForCheck();
       return;
     }
 
+    this.busquedaEnCurso = true;
     this.crearBusqueda$(termino, append ? page : 0)
-      .pipe(untilDestroyed(this))
+      .pipe(
+        finalize(() => {
+          this.busquedaEnCurso = false;
+          this.cdr.markForCheck();
+        }),
+        untilDestroyed(this)
+      )
       .subscribe({
         next: (productos) => {
           if (append) {

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
@@ -153,14 +153,11 @@
                     >
                       <mat-icon>search</mat-icon>
                     </button>
-                    <mat-error
-                      *ngIf="
-                        datosGeneralesForm
-                          .get('proveedor')
-                          ?.hasError('required')
-                      "
-                    >
+                    <mat-error *ngIf="proveedorRequiredErrorComputed">
                       El proveedor es requerido
+                    </mat-error>
+                    <mat-error *ngIf="proveedorNoSeleccionadoErrorComputed">
+                      Debe seleccionar un proveedor válido de la lista
                     </mat-error>
                   </mat-form-field>
                 </div>

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -6,11 +6,18 @@ import {
   Input,
   ElementRef,
 } from "@angular/core";
-import { FormBuilder, FormControl, FormGroup, Validators } from "@angular/forms";
+import {
+  AbstractControl,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  ValidationErrors,
+  Validators,
+} from "@angular/forms";
 import { MatTableDataSource } from "@angular/material/table";
 import { MatDialog } from "@angular/material/dialog";
 import { Subject, forkJoin, Observable, of } from "rxjs";
-import { takeUntil, tap, map, catchError } from "rxjs/operators";
+import { takeUntil, tap, map, catchError, debounceTime, distinctUntilChanged, filter, switchMap, take } from "rxjs/operators";
 
 import {
   AddEditItemDialogComponent,
@@ -207,6 +214,19 @@ type TabState = "disabled" | "readonly" | "editable";
  * - Los otros tabs están deshabilitados hasta que se guarde el pedido
  * - Al guardar el pedido, se cambia automáticamente a modo edición
  */
+function proveedorSeleccionadoValidator(
+  control: AbstractControl
+): ValidationErrors | null {
+  const value = control.value;
+  if (value != null && typeof value === "object" && value.id != null) {
+    return null;
+  }
+  if (value == null || value === "") {
+    return null;
+  }
+  return { proveedorNoSeleccionado: true };
+}
+
 @Component({
   selector: "app-gestion-compras",
   templateUrl: "./gestion-compras.component.html",
@@ -279,6 +299,8 @@ export class GestionComprasComponent
   isFormaPagoCreditoComputed = false;
   step1ButtonDisabledComputed = true;
   step1ButtonTextComputed = "Guardar y Continuar";
+  proveedorRequiredErrorComputed = false;
+  proveedorNoSeleccionadoErrorComputed = false;
   canFinalizarPlanificacionComputed = false; // Para el botón Finalizar Planificación
   canReabrirPlanificacionComputed = false; // Para el botón Reabrir Planificación
 
@@ -484,6 +506,26 @@ export class GestionComprasComponent
 
     // Configurar navegación con teclado para productos del proveedor
     this.setupKeyboardNavigation();
+    this.setupCodigoPrefetch();
+  }
+
+  /**
+   * Precarga búsquedas mientras el usuario escribe en el campo de código,
+   * para que al presionar Enter los resultados ya estén en caché.
+   */
+  private setupCodigoPrefetch(): void {
+    this.codigoControl.valueChanges
+      .pipe(
+        debounceTime(250),
+        map((value) => (value ?? "").trim()),
+        distinctUntilChanged(),
+        filter((texto) => texto.length >= 2),
+        switchMap((texto) =>
+          this.buscadorComprasService.buscarProductosParaDialog(texto, 0, 20, true)
+        ),
+        takeUntil(this.destroy$)
+      )
+      .subscribe({ error: () => undefined });
   }
 
   ngOnDestroy(): void {
@@ -498,7 +540,7 @@ export class GestionComprasComponent
 
   private initializeForms(): void {
     this.datosGeneralesForm = this.fb.group({
-      proveedor: [null, Validators.required],
+      proveedor: [null, [Validators.required, proveedorSeleccionadoValidator]],
       vendedor: [null],
       moneda: [null, Validators.required],
       cotizacion: [null],
@@ -559,6 +601,8 @@ export class GestionComprasComponent
             this.loadProductosProveedor();
           }
         } else {
+          this.selectedProveedorComputed = null;
+          this.showProveedorCard = false;
           // Si se remueve el proveedor, limpiar la lista de productos
           this.productosProveedorDataSource.data = [];
           this.ultimasComprasDataSource.data = [];
@@ -568,6 +612,11 @@ export class GestionComprasComponent
           this.selectedProductoProveedor = null;
         }
       });
+
+    this.datosGeneralesForm
+      .get("proveedor")
+      ?.statusChanges.pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.updateComputedProperties());
 
     this.datosGeneralesForm
       .get("moneda")
@@ -961,9 +1010,9 @@ export class GestionComprasComponent
     }
     cotizacionCtrl?.updateValueAndValidity({ emitEvent: false });
 
-    // Establecer proveedor seleccionado para mostrar la tarjeta
+    // Mostrar tarjeta solo si hay proveedor; si no, dejar visible el buscador
     this.selectedProveedorComputed = pedido.proveedor;
-    this.showProveedorCard = true;
+    this.showProveedorCard = !!pedido.proveedor;
   }
 
   private loadItemsIntoTable(items: PedidoItem[]): void {
@@ -1051,6 +1100,7 @@ export class GestionComprasComponent
       Object.keys(this.datosGeneralesForm.controls).forEach((key) => {
         this.datosGeneralesForm.get(key)?.markAsTouched();
       });
+      this.updateComputedProperties();
     }
   }
 
@@ -1273,6 +1323,15 @@ export class GestionComprasComponent
     this.isFormaPagoCreditoComputed = this.isFormaPagoCredito();
     this.step1ButtonDisabledComputed = this.shouldDisableStep1Button();
     this.step1ButtonTextComputed = this.getStep1ButtonText();
+
+    const proveedorCtrl = this.datosGeneralesForm.get("proveedor");
+    const proveedorInteracted = proveedorCtrl?.touched || proveedorCtrl?.dirty;
+    this.proveedorRequiredErrorComputed = !!(
+      proveedorCtrl?.hasError("required") && proveedorInteracted
+    );
+    this.proveedorNoSeleccionadoErrorComputed = !!(
+      proveedorCtrl?.hasError("proveedorNoSeleccionado") && proveedorInteracted
+    );
     
     // Moneda display
     const moneda = this.headerDataComputed?.moneda;
@@ -1714,6 +1773,7 @@ export class GestionComprasComponent
         // Solo marcar como cargado para el sistema de lazy loading
         break;
       case 1: // Tab 2: Ítems del Pedido
+        this.buscadorComprasService.warmupBusquedaProductos();
         if (this.currentPedido?.id) {
           // Pedido existente: cargar ítems del backend
           this.loadItemsData();
@@ -2285,8 +2345,17 @@ export class GestionComprasComponent
   }
 
   onAddItem(texto?: string): void {
+    const searchText = (texto || this.lastItemSearchText || "").trim();
+
+    if (searchText) {
+      this.buscadorComprasService
+        .buscarProductosParaDialog(searchText, 0, 20, true)
+        .pipe(take(1), takeUntil(this.destroy$))
+        .subscribe({ error: () => undefined });
+    }
+
     const searchData: ComprasSearchProductoData = {
-      texto: texto || this.lastItemSearchText || "",
+      texto: searchText,
       mostrarStock: true,
     };
 


### PR DESCRIPTION
## Summary
- Precarga la búsqueda de productos antes de abrir el diálogo y reutiliza la misma petición con caché compartida (`shareReplay`).
- Precalienta GraphQL al entrar al tab **Items del Pedido** y mientras el usuario escribe en el campo de código de barra.
- Muestra spinner de carga en el diálogo de búsqueda y valida que el proveedor sea seleccionado de la lista.

## Test plan
- [ ] Crear un pedido nuevo, ir al tab **Items del Pedido** y buscar un producto por nombre (ej. `COCA`) con Enter: el diálogo debe mostrar resultados más rápido que antes.
- [ ] Escribir en **Código de barra**, esperar ~250 ms y presionar Enter: los resultados deben aparecer casi al instante.
- [ ] Verificar que búsquedas posteriores siguen siendo rápidas.
- [ ] En **Datos Generales**, escribir texto libre en proveedor sin seleccionar de la lista: debe mostrar error de validación.
- [ ] Confirmar que el spinner aparece mientras carga y desaparece al recibir resultados.


Made with [Cursor](https://cursor.com)