### PR TITLE
feat(personas): avisar documento duplicado al registrar persona o funcionario

### DIFF
--- a/src/app/modules/personas/funcionarios/funcionario-wizard/funcionario-wizard.component.ts
+++ b/src/app/modules/personas/funcionarios/funcionario-wizard/funcionario-wizard.component.ts
@@ -134,6 +134,33 @@ export class FuncionarioWizardComponent implements OnInit {
                   duracion: 2
                 })
               } else {
+                const documento = this.documentoPersona.value?.toString().trim();
+                this.personaService.onGetPorDocumento(documento)
+                  .pipe(untilDestroyed(this))
+                  .subscribe(personaExistente => {
+                    if (personaExistente?.id != null) {
+                      if (personaExistente.isFuncionario && personaExistente.isCliente) {
+                        this.notificacionService.openWarn('La persona ya existe y ha sido registrada como cliente y funcionario');
+                      } else if (personaExistente.isFuncionario) {
+                        this.notificacionService.openWarn('La persona ya existe y ha sido registrada como funcionario');
+                      } else if (personaExistente.isCliente) {
+                        this.notificacionService.openWarn('La persona ya existe y ha sido registrada como cliente');
+                      } else {
+                        this.notificacionService.openWarn('La persona ya existe en el sistema');
+                      }
+                      return;
+                    }
+                    this.guardarFuncionario();
+                  });
+              }
+            })
+
+        }
+      })
+
+  }
+
+  private guardarFuncionario(): void {
                 let persona = new Persona;
                 persona.nombre = this.nombrePersona.value;
                 persona.apodo = this.apodoPersona.value;
@@ -200,12 +227,6 @@ export class FuncionarioWizardComponent implements OnInit {
                         })
                     }
                   })
-              }
-            })
-
-        }
-      })
-
   }
 
 }

--- a/src/app/modules/personas/persona/adicionar-persona-dialog/adicionar-persona-dialog.component.ts
+++ b/src/app/modules/personas/persona/adicionar-persona-dialog/adicionar-persona-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
+import { NotificacionSnackbarService } from '../../../../notificacion-snackbar.service';
 import { Ciudad } from '../../../general/ciudad/ciudad.model';
 import { Persona } from '../persona.model';
 import { PersonaService } from '../persona.service';
@@ -43,7 +44,8 @@ export class AdicionarPersonaDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: AdicionarPersonaData,
     private matDialogRef: MatDialogRef<AdicionarPersonaDialogComponent>,
     private dialogoService: DialogosService,
-    private personaService: PersonaService
+    private personaService: PersonaService,
+    private notificacionService: NotificacionSnackbarService
   ) {
     if (data?.persona != null) {
       this.selectedPersona = data.persona;
@@ -99,6 +101,33 @@ export class AdicionarPersonaDialogComponent implements OnInit {
   }
 
   onSave() {
+    const documento = this.documentoControl.value?.toString().trim();
+    const personaId = this.selectedPersona?.id;
+
+    this.personaService.onGetPorDocumento(documento)
+      .pipe(untilDestroyed(this))
+      .subscribe(personaExistente => {
+        if (personaExistente?.id != null && personaExistente.id !== personaId) {
+          this.mostrarAvisoPersonaExistente(personaExistente);
+          return;
+        }
+        this.ejecutarGuardado();
+      });
+  }
+
+  private mostrarAvisoPersonaExistente(persona: Persona): void {
+    if (persona.isFuncionario && persona.isCliente) {
+      this.notificacionService.openWarn('La persona ya existe y ha sido registrada como cliente y funcionario');
+    } else if (persona.isFuncionario) {
+      this.notificacionService.openWarn('La persona ya existe y ha sido registrada como funcionario');
+    } else if (persona.isCliente) {
+      this.notificacionService.openWarn('La persona ya existe y ha sido registrada como cliente');
+    } else {
+      this.notificacionService.openWarn('La persona ya existe en el sistema');
+    }
+  }
+
+  private ejecutarGuardado(): void {
     let persona = new Persona();
     Object.assign(persona, this.selectedPersona)
     persona.nombre = this.nombreControl.value;


### PR DESCRIPTION
## Summary
- Valida el C.I./RUC antes de guardar en el diálogo Nueva Persona y en el wizard de funcionarios.
- Muestra avisos según el tipo de registro existente: cliente, funcionario, ambos o persona genérica.
- Evita el error de restricción única `persona_un_documento` sin alterar la lógica de negocio del backend.

## Test plan
- [ ] Desde Lista de funcionarios → Agregar → Nueva Persona, ingresar un documento ya registrado como cliente y verificar el aviso.
- [ ] Repetir con un documento registrado solo como funcionario.
- [ ] Repetir con un documento registrado como cliente y funcionario.
- [ ] Repetir con un documento registrado como persona sin rol de cliente ni funcionario.
- [ ] Confirmar que al editar una persona existente con el mismo documento el guardado sigue funcionando.
- [ ] Verificar el mismo comportamiento en el wizard de pre-registro de funcionarios.

Made with [Cursor](https://cursor.com)