### PR TITLE
fix(productos): mostrar último costo en guaraníes en lista de productos

### DIFF
--- a/src/app/modules/operaciones/costo-por-producto/costo-por-producto.util.ts
+++ b/src/app/modules/operaciones/costo-por-producto/costo-por-producto.util.ts
@@ -1,0 +1,13 @@
+import { CostoPorProducto } from './costo-por-producto.model';
+
+/**
+ * Convierte ultimoPrecioCompra a guaraníes usando la cotización guardada en el registro de costo.
+ * costoMedio siempre está en Gs; ultimoPrecioCompra se guarda en la moneda de la última compra.
+ */
+export function ultimoPrecioCompraEnGs(costo: CostoPorProducto | null | undefined): number | null {
+  if (costo?.ultimoPrecioCompra == null) {
+    return null;
+  }
+  const cotizacion = costo.cotizacion ?? costo.moneda?.cambio ?? 1;
+  return costo.ultimoPrecioCompra * cotizacion;
+}

--- a/src/app/modules/productos/producto/graphql/graphql-query.ts
+++ b/src/app/modules/productos/producto/graphql/graphql-query.ts
@@ -223,6 +223,12 @@ export const searchProductoWithFilters = gql`
         costo {
           costoMedio
           ultimoPrecioCompra
+          cotizacion
+          moneda {
+            id
+            denominacion
+            cambio
+          }
         }
         precioPrincipal
         codigoPrincipal

--- a/src/app/modules/productos/producto/list-producto/list-producto.component.html
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.html
@@ -274,7 +274,7 @@
           Ult. costo
         </th>
         <td mat-cell *matCellDef="let producto" style="text-align: center">
-          {{ puedeVerCostos ? (producto?.costo?.ultimoPrecioCompra | number : "1.0-0") : "-" }}
+          {{ puedeVerCostos ? (ultimoPrecioCompraEnGs(producto?.costo) | number : "1.0-0") : "-" }}
         </td>
       </ng-container>
 

--- a/src/app/modules/productos/producto/list-producto/list-producto.component.ts
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.ts
@@ -66,6 +66,7 @@ import { GestionProveedoresProductoDialogComponent } from "../gestion-proveedore
 import { Familia } from "../../familia/familia.model";
 import { FamiliasSearchGQL } from "../../familia/graphql/familiasSearch";
 import { distinctUntilChanged, filter } from "rxjs/operators";
+import { ultimoPrecioCompraEnGs } from "../../../operaciones/costo-por-producto/costo-por-producto.util";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -85,6 +86,7 @@ import { distinctUntilChanged, filter } from "rxjs/operators";
 })
 export class ListProductoComponent implements OnInit, AfterViewInit {
   readonly ROLES = ROLES;
+  readonly ultimoPrecioCompraEnGs = ultimoPrecioCompraEnGs;
   titulo = 'Lista de productos';
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild("filtroProductoInput") filtroProductoInput: ElementRef;


### PR DESCRIPTION
## Summary
- Convierte `ultimoPrecioCompra` a guaraníes en la columna **Ult. costo** de la lista de productos usando la cotización guardada en el registro de costo.
- Amplía la consulta GraphQL de `searchProductoWithFilters` para traer `cotizacion` y `moneda`, necesarios para la conversión.
- Agrega utilidad reutilizable `ultimoPrecioCompraEnGs` para unificar la lógica de conversión.

## Test plan
- [ ] Buscar un producto cuya última compra fue en dólares y verificar que **Ult. costo** muestre el valor en Gs (ej. 1.57 USD × cotización ≈ 9.577).
- [ ] Verificar que **Costo medio** y **Ult. costo** sean comparables en la misma escala para compras en USD.
- [ ] Buscar un producto con última compra en guaraníes y confirmar que **Ult. costo** sigue mostrándose correctamente.
- [ ] Ejecutar `npm run check` sin errores AOT.


Made with [Cursor](https://cursor.com)