### PR TITLE
feat(compras): optimizar búsqueda exacta y apertura del diálogo de ítem en pedido

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/buscador-compras.service.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/buscador-compras.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Query } from 'apollo-angular';
 import { Observable, of } from 'rxjs';
-import { catchError, map, shareReplay, switchMap, take } from 'rxjs/operators';
+import { catchError, map, shareReplay, switchMap, take, tap } from 'rxjs/operators';
 import { GenericCrudService } from '../../../../generics/generic-crud.service';
 import { PageInfo } from '../../../../app.component';
 import { Producto } from '../../../productos/producto/producto.model';
@@ -55,6 +55,7 @@ const BUSQUEDA_CACHE_TTL_MS = 60_000;
 })
 export class BuscadorComprasService {
   private busquedaDialogCache = new Map<string, Observable<Producto[]>>();
+  private busquedaResultadosCache = new Map<string, Producto[]>();
 
   constructor(
     private genericCrudService: GenericCrudService,
@@ -91,14 +92,28 @@ export class BuscadorComprasService {
       size,
       silentLoad
     ).pipe(
+      tap((productos) => this.busquedaResultadosCache.set(cacheKey, productos)),
       shareReplay({ bufferSize: 1, refCount: false }),
       catchError(() => of([] as Producto[]))
     );
 
     this.busquedaDialogCache.set(cacheKey, request$);
-    setTimeout(() => this.busquedaDialogCache.delete(cacheKey), BUSQUEDA_CACHE_TTL_MS);
+    setTimeout(() => {
+      this.busquedaDialogCache.delete(cacheKey);
+      this.busquedaResultadosCache.delete(cacheKey);
+    }, BUSQUEDA_CACHE_TTL_MS);
 
     return request$;
+  }
+
+  /** Resultados ya resueltos en memoria (p. ej. tras prefetch al escribir). */
+  obtenerResultadosCacheados(
+    texto: string,
+    page = 0,
+    size = BUSQUEDA_DIALOG_PAGE_SIZE
+  ): Producto[] | null {
+    const cacheKey = `${(texto ?? '').trim()}|${page}|${size}`;
+    return this.busquedaResultadosCache.get(cacheKey) ?? null;
   }
 
   /** Precalienta la conexión GraphQL al entrar al tab de ítems. */
@@ -246,6 +261,44 @@ export class BuscadorComprasService {
       true,
       undefined,
       silentLoad
+    );
+  }
+
+  /**
+   * Devuelve el producto si hay una única coincidencia exacta por nombre o código.
+   */
+  encontrarCoincidenciaExacta(
+    productos: Producto[],
+    termino: string
+  ): Producto | null {
+    const terminoNormalizado = (termino ?? '').trim().toLowerCase();
+    if (!terminoNormalizado || !productos?.length) {
+      return null;
+    }
+
+    const coincidencias = productos.filter((producto) =>
+      this.esCoincidenciaExactaProducto(producto, terminoNormalizado)
+    );
+
+    return coincidencias.length === 1 ? coincidencias[0] : null;
+  }
+
+  private esCoincidenciaExactaProducto(
+    producto: Producto,
+    terminoNormalizado: string
+  ): boolean {
+    const descripcion = (producto.descripcion ?? '').trim().toLowerCase();
+    if (descripcion === terminoNormalizado) {
+      return true;
+    }
+
+    const codigoPrincipal = (producto.codigoPrincipal ?? '').trim().toLowerCase();
+    if (codigoPrincipal === terminoNormalizado) {
+      return true;
+    }
+
+    return (producto.codigos ?? []).some(
+      (codigo) => (codigo.codigo ?? '').trim().toLowerCase() === terminoNormalizado
     );
   }
 }

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
@@ -20,6 +20,8 @@ import {
   ComprasSearchProductoDialogComponent,
   ComprasSearchProductoResponse,
 } from "../compras-search-producto-dialog/compras-search-producto-dialog.component";
+import { BuscadorComprasService } from "../../buscador-compras.service";
+import { take } from "rxjs/operators";
 import {
   PedidoItem,
   PedidoItemInput,
@@ -48,6 +50,7 @@ export interface AddEditItemDialogData {
   pedido: Pedido;
   item?: PedidoItem;
   lastSearchText?: string;
+  coincidenciaExacta?: boolean;
   producto?: Producto;
   presentacion?: Presentacion;
   productoIdsEnPedido?: number[];
@@ -232,6 +235,7 @@ export class AddEditItemDialogComponent implements OnInit {
     private dialogosService: DialogosService,
     private productoService: ProductoService,
     private movimientoStockService: MovimientoStockService,
+    private buscadorComprasService: BuscadorComprasService,
     @Inject(MAT_DIALOG_DATA) public data: AddEditItemDialogData
   ) {
     this.initializeForm();
@@ -250,7 +254,11 @@ export class AddEditItemDialogComponent implements OnInit {
     this.setupFormSubscriptions();
 
     if (!this.data.isEdit && this.data.producto) {
-      this.onProductoSelected(this.data.producto, this.data.presentacion);
+      this.onProductoSelected(
+        this.data.producto,
+        this.data.presentacion,
+        this.data.coincidenciaExacta === true
+      );
     }
 
     this.setInitialFocus();
@@ -298,7 +306,10 @@ export class AddEditItemDialogComponent implements OnInit {
   }
 
   private initializeForm(): void {
-    const initialSearch = (!this.data.isEdit && this.data.lastSearchText) ? this.data.lastSearchText : "";
+    const initialSearch =
+      !this.data.isEdit && this.data.lastSearchText && !this.data.coincidenciaExacta
+        ? this.data.lastSearchText
+        : "";
     this.originalSearchText = initialSearch;
     this.itemForm = this.formBuilder.group({
       productoSearch: [initialSearch],
@@ -684,9 +695,40 @@ export class AddEditItemDialogComponent implements OnInit {
 
   // Product search functionality similar to edit-transferencia.component.ts
   onSearchProducto(): void {
-    const searchText = this.itemForm.get("productoSearch")?.value || "";
+    const searchText = (this.itemForm.get("productoSearch")?.value || "").trim();
     this.originalSearchText = searchText;
 
+    if (!searchText) {
+      this.abrirDialogoBusquedaProducto(searchText);
+      return;
+    }
+
+    this.buscadorComprasService
+      .buscarProductosParaDialog(searchText, 0, 20, true)
+      .pipe(take(1))
+      .subscribe({
+        next: (productos) => {
+          const productoExacto = this.buscadorComprasService.encontrarCoincidenciaExacta(
+            productos,
+            searchText
+          );
+
+          if (productoExacto) {
+            this.onProductoSelected(productoExacto, undefined, true);
+            this.enfocarTrasSeleccionProducto({
+              producto: productoExacto,
+              coincidenciaExacta: true,
+            });
+            return;
+          }
+
+          this.abrirDialogoBusquedaProducto(searchText);
+        },
+        error: () => this.abrirDialogoBusquedaProducto(searchText),
+      });
+  }
+
+  private abrirDialogoBusquedaProducto(searchText: string): void {
     const dialogData: ComprasSearchProductoData = {
       texto: searchText,
       mostrarStock: false,
@@ -701,27 +743,35 @@ export class AddEditItemDialogComponent implements OnInit {
       .afterClosed()
       .subscribe((result: ComprasSearchProductoResponse) => {
         if (result?.producto) {
-          this.onProductoSelected(result.producto, result.presentacion);
+          this.onProductoSelected(
+            result.producto,
+            result.presentacion,
+            result.coincidenciaExacta === true
+          );
         }
 
-        // based on some condition, move focus
-        setTimeout(() => {
-          if (!result.producto) {
-            this.productoInput?.nativeElement.select();
-          } else if (!result.presentacion) {
-            this.presentacionSelect?.focus();
-            setTimeout(() => {
-              this.presentacionSelect?.open();
-            }, 100);
-          } else {
-            // Si hay producto y presentación, ir a precio
-            if (!this.isBonificacionComputed) {
-              this.precioPorPresentacionInput?.nativeElement.focus();
-              this.precioPorPresentacionInput?.nativeElement.select();
-            }
-          }
-        }, 500);
+        this.enfocarTrasSeleccionProducto(result);
       });
+  }
+
+  private enfocarTrasSeleccionProducto(result?: ComprasSearchProductoResponse): void {
+    if (result?.coincidenciaExacta) {
+      return;
+    }
+
+    setTimeout(() => {
+      if (!result?.producto) {
+        this.productoInput?.nativeElement.select();
+      } else if (!result.presentacion) {
+        this.presentacionSelect?.focus();
+        setTimeout(() => {
+          this.presentacionSelect?.open();
+        }, 100);
+      } else if (!this.isBonificacionComputed) {
+        this.precioPorPresentacionInput?.nativeElement.focus();
+        this.precioPorPresentacionInput?.nativeElement.select();
+      }
+    }, 500);
   }
 
   private loadProductoIdsEnPedido(): void {
@@ -788,7 +838,11 @@ export class AddEditItemDialogComponent implements OnInit {
       });
   }
 
-  onProductoSelected(producto: Producto, presentacion?: Presentacion): void {
+  onProductoSelected(
+    producto: Producto,
+    presentacion?: Presentacion,
+    coincidenciaExacta = false
+  ): void {
     this.avisoProductoYaEnPedido(producto?.id);
 
     this.isLoadingInitialData = true; // Marcar que estamos cargando datos iniciales
@@ -838,7 +892,7 @@ export class AddEditItemDialogComponent implements OnInit {
     
     this.itemForm.patchValue(
       {
-        productoSearch: producto.descripcion,
+        productoSearch: coincidenciaExacta ? "" : producto.descripcion,
         producto: producto,
         presentacion: presentacionSeleccionada,
         precioUnitarioSolicitado: precioInicial,

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.ts
@@ -48,6 +48,7 @@ export interface ComprasSearchProductoResponse {
   producto?: Producto;
   presentacion?: Presentacion;
   searchText?: string;
+  coincidenciaExacta?: boolean;
 }
 
 const PAGE_SIZE = 20;
@@ -137,6 +138,7 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
       .subscribe({
         next: (productos) => {
           this.dataSource.data = productos;
+          this.intentarSeleccionPorCoincidenciaExacta(productos);
           this.cdr.markForCheck();
         },
         error: () => {
@@ -170,6 +172,28 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
     this.selectedRowIndex = -1;
     this.selectedPresentacionRowIndex = -1;
     this.selectedPresentacion = null;
+  }
+
+  private intentarSeleccionPorCoincidenciaExacta(productos: Producto[]): void {
+    const termino = (this.formGroup.get('buscarControl')?.value ?? '').trim();
+    if (!termino) {
+      return;
+    }
+
+    const productoExacto = this.buscadorComprasService.encontrarCoincidenciaExacta(
+      productos,
+      termino
+    );
+
+    if (!productoExacto) {
+      return;
+    }
+
+    this.dialogRef.close({
+      producto: productoExacto,
+      searchText: termino,
+      coincidenciaExacta: true,
+    } as ComprasSearchProductoResponse);
   }
 
   ejecutarBusqueda(texto: string, page: number, append: boolean): void {
@@ -207,6 +231,7 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
             this.dataSource.data = [...this.dataSource.data, ...nuevos];
           } else {
             this.dataSource.data = productos;
+            this.intentarSeleccionPorCoincidenciaExacta(productos);
           }
 
           this.cdr.markForCheck();

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -516,7 +516,7 @@ export class GestionComprasComponent
   private setupCodigoPrefetch(): void {
     this.codigoControl.valueChanges
       .pipe(
-        debounceTime(250),
+        debounceTime(100),
         map((value) => (value ?? "").trim()),
         distinctUntilChanged(),
         filter((texto) => texto.length >= 2),
@@ -2341,19 +2341,65 @@ export class GestionComprasComponent
   }
 
   onCodigoFocus(): void {
+    const text = this.codigoControl.value?.trim();
+    if (text && text.length >= 2) {
+      this.buscadorComprasService
+        .buscarProductosParaDialog(text, 0, 20, true)
+        .pipe(take(1), takeUntil(this.destroy$))
+        .subscribe({ error: () => undefined });
+    }
     this.addItemInput?.nativeElement?.select();
   }
 
   onAddItem(texto?: string): void {
     const searchText = (texto || this.lastItemSearchText || "").trim();
 
-    if (searchText) {
-      this.buscadorComprasService
-        .buscarProductosParaDialog(searchText, 0, 20, true)
-        .pipe(take(1), takeUntil(this.destroy$))
-        .subscribe({ error: () => undefined });
+    if (!searchText) {
+      this.abrirDialogoBusquedaProducto(searchText);
+      return;
     }
 
+    const abrirProductoExacto = (producto: Producto) => {
+      this.lastItemSearchText = "";
+      this.openAddEditItemDialog(producto, undefined, undefined, true);
+      this.codigoControl.setValue(null);
+      setTimeout(() => this.addItemInput?.nativeElement?.select(), 100);
+    };
+
+    const procesarResultados = (productos: Producto[]) => {
+      const productoExacto = this.buscadorComprasService.encontrarCoincidenciaExacta(
+        productos,
+        searchText
+      );
+
+      if (productoExacto) {
+        abrirProductoExacto(productoExacto);
+        return;
+      }
+
+      this.abrirDialogoBusquedaProducto(searchText);
+    };
+
+    const resultadosCacheados = this.buscadorComprasService.obtenerResultadosCacheados(
+      searchText,
+      0,
+      20
+    );
+    if (resultadosCacheados !== null) {
+      procesarResultados(resultadosCacheados);
+      return;
+    }
+
+    this.buscadorComprasService
+      .buscarProductosParaDialog(searchText, 0, 20, true)
+      .pipe(take(1), takeUntil(this.destroy$))
+      .subscribe({
+        next: procesarResultados,
+        error: () => this.abrirDialogoBusquedaProducto(searchText),
+      });
+  }
+
+  private abrirDialogoBusquedaProducto(searchText: string): void {
     const searchData: ComprasSearchProductoData = {
       texto: searchText,
       mostrarStock: true,
@@ -2375,7 +2421,8 @@ export class GestionComprasComponent
         this.openAddEditItemDialog(
           searchResult.producto,
           searchResult.presentacion,
-          this.lastItemSearchText
+          searchResult.coincidenciaExacta ? undefined : this.lastItemSearchText,
+          searchResult.coincidenciaExacta === true
         );
       }
 
@@ -2387,18 +2434,33 @@ export class GestionComprasComponent
   private openAddEditItemDialog(
     producto: Producto,
     presentacion?: Presentacion,
-    searchText?: string
+    searchText?: string,
+    coincidenciaExacta = false
   ): void {
-    this.fetchProductoIdsEnPedido()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((productoIdsEnPedido) => {
-        this.openAddEditItemDialogInternal(
-          producto,
-          presentacion,
-          searchText,
-          productoIdsEnPedido
-        );
-      });
+    this.openAddEditItemDialogInternal(
+      producto,
+      presentacion,
+      searchText,
+      this.obtenerProductoIdsEnPedidoDisponibles(),
+      coincidenciaExacta
+    );
+  }
+
+  private obtenerProductoIdsEnPedidoDisponibles(): number[] {
+    const itemsCargados = this.itemsDataSource.data;
+    if (itemsCargados.length === 0) {
+      return [];
+    }
+
+    const totalConocido = this.itemsTotalElements;
+    if (totalConocido > 0 && totalConocido > itemsCargados.length) {
+      return [];
+    }
+
+    return itemsCargados
+      .map((item) => item.producto?.id)
+      .filter((id): id is number => id != null)
+      .map((id) => Number(id));
   }
 
   private fetchProductoIdsEnPedido(): Observable<number[]> {
@@ -2421,13 +2483,15 @@ export class GestionComprasComponent
     producto: Producto,
     presentacion?: Presentacion,
     searchText?: string,
-    productoIdsEnPedido: number[] = []
+    productoIdsEnPedido: number[] = [],
+    coincidenciaExacta = false
   ): void {
     const dialogData: AddEditItemDialogData = {
       pedido: this.currentPedido as Pedido,
       isEdit: false,
       title: "Añadir Nuevo Ítem al Pedido",
-      lastSearchText: searchText || this.lastItemSearchText,
+      lastSearchText: coincidenciaExacta ? undefined : (searchText || this.lastItemSearchText),
+      coincidenciaExacta,
       producto,
       presentacion,
       productoIdsEnPedido,
@@ -4355,32 +4419,29 @@ export class GestionComprasComponent
       return;
     }
 
-    this.fetchProductoIdsEnPedido()
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((productoIdsEnPedido) => {
-        const dialogData: AddEditItemDialogData = {
-          pedido: this.currentPedido as Pedido,
-          isEdit: false,
-          title: "Añadir Nuevo Ítem al Pedido",
-          productoIdsEnPedido,
-        };
+    const dialogData: AddEditItemDialogData = {
+      pedido: this.currentPedido as Pedido,
+      isEdit: false,
+      title: "Añadir Nuevo Ítem al Pedido",
+      productoIdsEnPedido: this.obtenerProductoIdsEnPedidoDisponibles(),
+    };
 
-        const dialogRef = this.dialog.open(AddEditItemDialogComponent, {
-          width: "65%",
-          height: "70%",
-          data: dialogData,
-          disableClose: true,
-        });
+    const dialogRef = this.dialog.open(AddEditItemDialogComponent, {
+      width: "65%",
+      height: "70%",
+      data: dialogData,
+      disableClose: true,
+    });
 
-        // Después de abrir el diálogo, precargar el producto
-        dialogRef.afterOpened().subscribe(() => {
-          const dialogComponent = dialogRef.componentInstance;
-          if (dialogComponent && producto) {
-            dialogComponent.onProductoSelected(producto);
-          }
-        });
+    // Después de abrir el diálogo, precargar el producto
+    dialogRef.afterOpened().subscribe(() => {
+      const dialogComponent = dialogRef.componentInstance;
+      if (dialogComponent && producto) {
+        dialogComponent.onProductoSelected(producto);
+      }
+    });
 
-        dialogRef.afterClosed().subscribe((result: AddEditItemDialogResult) => {
+    dialogRef.afterClosed().subscribe((result: AddEditItemDialogResult) => {
           if (result && result.action === "save") {
             if (result.item?.producto?.id) {
               this.actualizarProductoProveedorLocalmente(result.item.producto.id, true);
@@ -4404,7 +4465,6 @@ export class GestionComprasComponent
             }, 300);
           }
         });
-      });
   }
 
   /**


### PR DESCRIPTION
## Summary
- Abre directamente el formulario de ítem cuando el nombre o código del producto coincide exactamente, sin pasar por el diálogo intermedio de búsqueda.
- Limpia el input de búsqueda solo en coincidencia exacta y evita reutilizar texto anterior que ralentizaba búsquedas sucesivas.
- Reduce la latencia al presionar Enter usando caché de prefetch, IDs locales del pedido y apertura inmediata del diálogo.

## Test plan
- [ ] En Gestión de Compras > Ítems del Pedido, buscar un producto por código exacto en "Código de barra" y verificar apertura directa del diálogo de ítem.
- [ ] Buscar un producto por nombre exacto y confirmar que el campo "Buscar Producto" queda vacío tras la selección.
- [ ] Buscar un segundo producto consecutivo y verificar que la apertura es rápida.
- [ ] Buscar por texto parcial y confirmar que sigue mostrando el diálogo intermedio con lista de resultados.

Made with [Cursor](https://cursor.com)