### PR TITLE
fix(config): mantener sucursal en modo cloud sin servidor local

### DIFF
--- a/src/app/main.service.ts
+++ b/src/app/main.service.ts
@@ -16,7 +16,6 @@ import { IpcRenderer } from "electron";
 import { ActualizacionService } from "./modules/configuracion/actualizacion/actualizacion.service";
 import { SucursalService } from "./modules/empresarial/sucursal/sucursal.service";
 import { MonedaService } from "./modules/financiero/moneda/moneda.service";
-import { PuntoDeVentaService } from "./modules/financiero/punto-de-venta/punto-de-venta.service";
 import { ConfiguracionService } from "./shared/services/configuracion.service";
 import { LoginService } from "./modules/login/login.service";
 
@@ -54,7 +53,6 @@ export class MainService implements OnDestroy {
     public sucursalService: SucursalService,
     private usuarioService: UsuarioService,
     private configService: ConfiguracionService,
-    private puntoDeVentaService: PuntoDeVentaService,
     private injector: Injector
   ) {
     // Get server IP from ConfiguracionService instead of environment
@@ -172,11 +170,6 @@ export class MainService implements OnDestroy {
               if (this.sucursalActual?.id == 0) {
                 this.isServidor = true;
               }
-              // Si no es local (solo servidor central) y hay pdvId configurado,
-              // resolver la sucursal real usando el pdvId
-              if (!isLocal && config.pdvId) {
-                this.resolverSucursalPorPdvId(config.pdvId);
-              }
               resolve(true);
             } else {
               resolve(false);
@@ -189,31 +182,6 @@ export class MainService implements OnDestroy {
           }
         });
     });
-  }
-
-  /**
-   * Resuelve la sucursal actual usando el pdvId cuando se usa solo el servidor central.
-   * Consulta el punto de venta por ID en el servidor central y extrae la sucursal asociada.
-   * Esto permite que el frontend sepa a qué sucursal pertenece sin necesidad de un servidor local.
-   * @param pdvId ID del punto de venta configurado
-   */
-  private resolverSucursalPorPdvId(pdvId: number): void {
-    this.puntoDeVentaService.onGetPuntoDeVentaPorId(pdvId, true)
-      .pipe(untilDestroyed(this))
-      .subscribe({
-        next: (puntoDeVenta) => {
-          if (puntoDeVenta?.sucursal) {
-            console.log(`Sucursal resuelta por pdvId ${pdvId}: ${puntoDeVenta.sucursal.nombre} (ID: ${puntoDeVenta.sucursal.id})`);
-            this.sucursalActual = puntoDeVenta.sucursal;
-            this.isServidor = false;
-          } else {
-            console.warn(`No se encontró sucursal para pdvId ${pdvId}`);
-          }
-        },
-        error: (err) => {
-          console.error(`Error al resolver sucursal por pdvId ${pdvId}:`, err);
-        }
-      });
   }
 
   /**


### PR DESCRIPTION
## Summary
- Elimina la resolución de sucursal por `pdvId` en `main.service.ts` cuando `isLocal` está desactivado.
- Con solo servidor central, la app mantiene la sucursal SERVIDOR (id 0) y el header muestra **BODEGA FRANCO CLOUD**.

## Test plan
- [ ] Configurar la app con "Usar Servidor Local" desmarcado y un `pdvId` definido (ej. 25).
- [ ] Reiniciar la aplicación e iniciar sesión contra el servidor central.
- [ ] Verificar que el header muestre **BODEGA FRANCO CLOUD** y no la sucursal del PDV.
- [ ] Activar "Usar Servidor Local" y confirmar que el comportamiento de filial sigue funcionando con `pdvId`.


Made with [Cursor](https://cursor.com)