### PR TITLE
chore(ci): actualizar actions a node 24 en workflows de CI y release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18'
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
       skip_build: ${{ steps.redundant.outputs.skip_build }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18'
 
@@ -104,12 +104,12 @@ jobs:
             args: --win
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: v${{ needs.release.outputs.version }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18'
           cache: npm


### PR DESCRIPTION
## Summary
- Actualiza `actions/checkout` y `actions/setup-node` de v4 a v5 en los workflows CI y Release.
- Elimina los warnings de deprecación de Node.js 20 en los jobs `release`, `build (ubuntu-latest)` y `build (windows-latest)`.

## Test plan
- [ ] Verificar que el workflow **CI** corre sin warnings de Node.js 20 en un PR.
- [ ] Verificar que el workflow **Release** (jobs `release` y `build`) corre sin warnings en el próximo push a develop.


Made with [Cursor](https://cursor.com)