### PR TITLE
fix(pdv): bloquear descuento por ítem desde carrito en venta touch

### DIFF
--- a/src/app/modules/pdv/comercial/venta-touch/venta-touch.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/venta-touch.component.ts
@@ -100,10 +100,6 @@ import {
   ListDeliveryComponent,
   ListDeliveryData,
 } from "./list-delivery/list-delivery.component";
-import {
-  DescuentoDialogComponent,
-  DescuentoDialogData,
-} from "./pago-touch/descuento-dialog/descuento-dialog.component";
 import { FormControl } from "@angular/forms";
 import { catchError, map, startWith, switchMap } from "rxjs/operators";
 import { TipoPrecioService } from "../../../productos/tipo-precio/tipo-precio.service";
@@ -791,29 +787,10 @@ export class VentaTouchComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   editItem(event: any) {
-    let item = new VentaItem();
     this.mostrarPrecios = false;
-    Object.assign(item, event["item"]);
-    let index = event["i"];
-
-    let data: DescuentoDialogData = {
-      valorTotal: item.precioVenta.precio,
-      saldo: 0,
-      cambioDs: this.cambioDs,
-      cambioRs: this.cambioRs,
-    };
-    this.matDialog
-      .open(DescuentoDialogComponent, {
-        data: data,
-      })
-      .afterClosed()
-      .subscribe((res) => {
-        if (res > 0) {
-          item.valorDescuento = res;
-          this.selectedItemList[index] = item;
-          this.calcularTotales();
-        }
-      });
+    this.notificacionSnackbar.openWarn(
+      "El descuento debe aplicarse desde la pantalla de pago (F12)."
+    );
   }
 
   crearItem(eventData: any, index?) {


### PR DESCRIPTION
## Summary
- Bloquea la apertura del diálogo de descuento al hacer clic en un ítem del carrito en la pantalla de venta touch.
- Muestra un aviso indicando que el descuento debe aplicarse desde la pantalla de pago (F12).
- Mantiene intacto el flujo de descuento en la pantalla de pago (F9).

## Test plan
- [ ] Abrir venta touch y agregar productos al carrito.
- [ ] Hacer clic en la descripción de un ítem del carrito y verificar que no se abre el diálogo de descuento.
- [ ] Verificar que aparece el mensaje: "El descuento debe aplicarse desde la pantalla de pago (F12)."
- [ ] Ir a la pantalla de pago (F12) y confirmar que el descuento sigue funcionando con F9.


Made with [Cursor](https://cursor.com)