### PR TITLE
feat(usuarios): implementar paginador genérico en lista de usuarios

### DIFF
--- a/src/app/modules/personas/usuarios/graphql/graphql-query.ts
+++ b/src/app/modules/personas/usuarios/graphql/graphql-query.ts
@@ -246,9 +246,11 @@ export const usuariosSearchPaginated = gql`
         id
         nickname
         activo
+        creadoEn
         persona {
           id
           nombre
+          telefono
           documento
           imagenes
         }

--- a/src/app/modules/personas/usuarios/list-usuario/list-usuario.component.html
+++ b/src/app/modules/personas/usuarios/list-usuario/list-usuario.component.html
@@ -1,8 +1,7 @@
 <app-generic-list
   [data]="dataSource.data"
-  (cargarMasDatos)="cargarMasDatos()"
-  [isLastPage]="isLastPage || isSearching"
   (filtrar)="onFiltrar()"
+  (resetFiltro)="resetFiltro()"
 >
   <div filtros>
     <div fxLayout="row" fxLayoutAlign="start start" fxLayoutGap="10px" style="width: 100%;">
@@ -147,5 +146,14 @@
         class="example-detail-row"
       ></tr>
     </table>
+
+    <mat-paginator
+      itemsPerPageLabel="Itens por pagina"
+      [pageSizeOptions]="[15, 25, 50, 100]"
+      (page)="handlePageEvent($event)"
+      [length]="selectedPageInfo?.getTotalElements"
+      style="width: 100%"
+      showFirstLastButtons
+    ></mat-paginator>
   </div>
 </app-generic-list>

--- a/src/app/modules/personas/usuarios/list-usuario/list-usuario.component.ts
+++ b/src/app/modules/personas/usuarios/list-usuario/list-usuario.component.ts
@@ -1,16 +1,17 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
-import { FormControl, Validators } from '@angular/forms';
+import { FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { PageInfo } from '../../../../app.component';
 import { MainService } from '../../../../main.service';
-import { WindowInfoService } from '../../../../shared/services/window-info.service';
+import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
 import { ROLES } from '../../roles/roles.enum';
 import { AdicionarUsuarioDialogComponent } from '../adicionar-usuario-dialog/adicionar-usuario-dialog.component';
 import { Usuario } from '../usuario.model';
 import { UsuarioService } from '../usuario.service';
-import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
 
 @UntilDestroy()
 @Component({
@@ -33,17 +34,19 @@ export class ListUsuarioComponent implements OnInit {
   readonly ROLES = ROLES
 
   @ViewChild('buscar', { static: true }) buscar: ElementRef;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
 
   dataSource = new MatTableDataSource<Usuario>([]);
   selectedUsuario: Usuario;
   displayedColumns: string[] = ['id', 'nombre', 'nickname', 'telefono', 'activo', 'creadoEn', 'acciones'];
   expandedUsuario: Usuario;
 
-  page = -1;
-  isLastPage = false;
-  isSearching = false;
+  pageSize = 25;
+  pageIndex = 0;
+  selectedPageInfo: PageInfo<Usuario>;
+  timer: ReturnType<typeof setTimeout>;
 
-  buscarControl = new FormControl(null, Validators.required)
+  buscarControl = new FormControl(null);
 
   constructor(
     public service: UsuarioService,
@@ -53,28 +56,51 @@ export class ListUsuarioComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.cargarMasDatos()
+    setTimeout(() => {
+      this.paginator._changePageSize(this.paginator.pageSizeOptions[1]);
+      this.pageSize = this.paginator.pageSizeOptions[1];
+      this.onFiltrar();
+    }, 0);
+
+    this.buscarControl.valueChanges
+      .pipe(untilDestroyed(this))
+      .subscribe((valor) => {
+        this.pageIndex = 0;
+        if (this.timer != null) {
+          clearTimeout(this.timer);
+        }
+        this.timer = setTimeout(() => {
+          this.onFiltrar();
+        }, 500);
+      });
   }
 
   rowSelectedEvent(e) {
   }
 
-  onFiltrar() {
-    if (this.buscarControl.valid) {
-      this.isSearching = true;
-      this.service.onSeachUsuario(this.buscarControl.value)
-        .pipe(untilDestroyed(this))
-        .subscribe(res => {
-          this.isSearching = false;
-          this.isLastPage = true;
-          this.buscar.nativeElement.select()
-          this.dataSource.data = res;
-        })
-    } else {
-      this.page = -1;
-      this.isLastPage = false;
-      this.cargarMasDatos()
-    }
+  onFiltrar(): void {
+    const texto = this.buscarControl.value?.toString().trim() || null;
+    this.service.onSearchConFiltros(texto, this.pageIndex, this.pageSize)
+      .pipe(untilDestroyed(this))
+      .subscribe((res) => {
+        if (res != null) {
+          this.selectedPageInfo = res;
+          this.dataSource.data = this.selectedPageInfo?.getContent || [];
+        }
+      });
+  }
+
+  resetFiltro(): void {
+    this.pageIndex = 0;
+    this.dataSource.data = [];
+    this.selectedPageInfo = null;
+    this.buscarControl.setValue(null);
+  }
+
+  handlePageEvent(e: PageEvent): void {
+    this.pageIndex = e.pageIndex;
+    this.pageSize = e.pageSize;
+    this.onFiltrar();
   }
 
   onAddUsuario(usuario?: Usuario, index?) {
@@ -89,18 +115,6 @@ export class ListUsuarioComponent implements OnInit {
 
   onEditRoles(usuario, i) {
 
-  }
-
-  cargarMasDatos() {
-    this.isSearching = true;
-    this.page++;
-    this.service.onGetUsuarios(this.page)
-      .pipe(untilDestroyed(this))
-      .subscribe(res => {
-        if (res.length == 0) this.isLastPage = true;
-        this.isSearching = false;
-        this.dataSource.data = this.dataSource.data.concat(res)
-      })
   }
 
   onInitPassword(usuario: Usuario, i) {

--- a/src/app/modules/personas/usuarios/usuario.service.ts
+++ b/src/app/modules/personas/usuarios/usuario.service.ts
@@ -25,6 +25,7 @@ import { UsuarioPorEmbeddingGQL } from "./graphql/usuarioPorEmbedding";
 import { IncorporarEmbeddingMarcacionGQL } from "./graphql/incorporarEmbeddingMarcacion";
 import { IncorporarEmbeddingMarcacionResult } from '../../administrativo/marcacion/models/incorporar-embedding-result.model';
 import { UsuariosSearchPaginatedGQL } from "./graphql/usuarioSearchPaginated";
+import { PageInfo } from "../../../app.component";
 
 @UntilDestroy({ checkProperties: true })
 @Injectable({
@@ -128,7 +129,11 @@ export class UsuarioService {
     );
   }
 
-  onSearchUsuarioPaginated(texto: string, page: number, size: number, servidor: boolean = true): Observable<any> {
+  onSearchUsuarioPaginated(texto: string, page: number, size: number, servidor: boolean = true): Observable<PageInfo<Usuario>> {
     return this.genericService.onCustomQuery(this.usuariosSearchPaginatedGQL, { texto, page, size }, servidor);
+  }
+
+  onSearchConFiltros(texto: string, pageIndex: number, pageSize: number, servidor: boolean = true): Observable<PageInfo<Usuario>> {
+    return this.onSearchUsuarioPaginated(texto, pageIndex, pageSize, servidor);
   }
 }


### PR DESCRIPTION
## Summary
- Reemplaza el scroll infinito de la lista de usuarios por paginación servidor con `mat-paginator`.
- Integra `usuarioSearchPaginated` vía `onSearchConFiltros` en `UsuarioService`, siguiendo el patrón de clientes y sucursales.
- Agrega `creadoEn` y `telefono` a la query paginada para mantener las columnas existentes de la tabla.

## Test plan
- [ ] Abrir la pestaña Usuarios y verificar que carga la primera página con paginador visible.
- [ ] Cambiar de página y confirmar que se solicita una nueva página al backend.
- [ ] Buscar por nombre o nickname y validar resultados filtrados con paginación.
- [ ] Usar "Limpiar Filtro" y confirmar que vuelve a listar usuarios sin filtro.
- [ ] Verificar que edición e inicialización de contraseña siguen funcionando.


Made with [Cursor](https://cursor.com)