### PR TITLE
fix(replicacion): permitir punto en nombre de tabla al crear replicacion

### DIFF
--- a/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.html
+++ b/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.html
@@ -14,7 +14,7 @@
         <mat-hint>Nombre de la tabla en la base de datos (Se guardará en mayúsculas)</mat-hint>
         <mat-error *ngIf="tableForm.get('tableName').invalid">
           <ng-container *ngIf="tableForm.get('tableName').hasError('required')">Este campo es obligatorio</ng-container>
-          <ng-container *ngIf="tableForm.get('tableName').hasError('pattern')">Solo se permiten letras, números y guiones bajos</ng-container>
+          <ng-container *ngIf="tableForm.get('tableName').hasError('pattern')">Solo se permiten letras, números, guiones bajos y un punto (esquema.tabla)</ng-container>
         </mat-error>
       </mat-form-field>
       

--- a/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.ts
+++ b/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.ts
@@ -44,7 +44,7 @@ export class EditReplicationTableDialogComponent implements OnInit {
     // Initialize form
     this.tableForm = this.fb.group({
       id: [this.data.table?.id || null],
-      tableName: [this.data.table?.tableName || '', [Validators.required, Validators.pattern(/^[a-zA-Z0-9_]+$/)]],
+      tableName: [this.data.table?.tableName || '', [Validators.required, Validators.pattern(/^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?$/)]],
       description: [this.data.table?.description || ''],
       direction: [this.data.table?.direction || ReplicationDirection.MAIN_TO_ALL, Validators.required],
       enabled: [this.data.table?.enabled !== undefined ? this.data.table.enabled : true],
@@ -141,7 +141,7 @@ export class EditReplicationTableDialogComponent implements OnInit {
     }
     
     if (control.hasError('pattern')) {
-      return 'Solo se permiten letras, números y guiones bajos';
+      return 'Solo se permiten letras, números, guiones bajos y un punto (esquema.tabla)';
     }
     
     return '';


### PR DESCRIPTION
## Que resuelve

El dialogo para crear/editar tablas de replicacion (`edit-replication-table-dialog`) validaba el campo `tableName` con la expresion regular `/^[a-zA-Z0-9_]+$/`, que no permite el caracter `.`. Sin embargo, el formato esperado y sugerido por el propio formulario (placeholder `Ej: personas.usuario`) requiere el formato `esquema.tabla`. Esto impedia guardar cualquier tabla de replicacion nueva, ya que el usuario siempre necesita incluir el punto para especificar el esquema.

## Como probarlo

1. Ir a Configuracion > Replicacion Logica > Tablas.
2. Abrir el dialogo de "Nueva Tabla de Replicacion".
3. Ingresar un nombre de tabla con esquema, por ejemplo `personas.usuario`.
4. Completar el resto de los campos obligatorios (direccion) y guardar.
5. Verificar que el formulario ya no marca error de patron y que la tabla se guarda correctamente (mensaje "Tabla de replicacion creada correctamente").
6. Verificar tambien que nombres sin punto (ej: `usuario`) y nombres invalidos (ej: `personas..usuario`, `personas.usuario.extra`, caracteres especiales) siguen comportandose como se espera (validos/invalidos segun corresponda).

## Impacto DB

Ninguno. Es un cambio unicamente de validacion en el frontend (Angular Reactive Forms), no afecta queries, mutaciones ni el schema de base de datos.

## Riesgo

Bajo. El cambio amplia una expresion regular de validacion de un campo de texto en un dialogo especifico, sin tocar logica de negocio, servicios GraphQL ni otros modulos. `npm run check` (build AOT) se corrio sin errores.