### PR TITLE
fix(replicacion): eliminacion del atributo creado_en en replication.m…

### DIFF
--- a/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.html
+++ b/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.html
@@ -11,7 +11,7 @@
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>Nombre de Tabla</mat-label>
         <input matInput formControlName="tableName" placeholder="Ej: personas.usuario" style="text-transform: lowercase !important;"/>
-        <mat-hint>Nombre de la tabla en la base de datos (Se guardará en mayúsculas)</mat-hint>
+        <mat-hint>Nombre de la tabla en la base de datos, formato esquema.tabla</mat-hint>
         <mat-error *ngIf="tableForm.get('tableName').invalid">
           <ng-container *ngIf="tableForm.get('tableName').hasError('required')">Este campo es obligatorio</ng-container>
           <ng-container *ngIf="tableForm.get('tableName').hasError('pattern')">Solo se permiten letras, números, guiones bajos y un punto (esquema.tabla)</ng-container>

--- a/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.scss
+++ b/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.scss
@@ -20,12 +20,11 @@
 .enabled-toggle {
   display: flex;
   align-items: center;
-  margin-bottom: 24px;
   
   .toggle-hint {
     margin-left: 12px;
     font-size: 12px;
-    color: rgba(0, 0, 0, 0.6);
+    color: rgba(255, 255, 255, 0.8);
   }
 }
 

--- a/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.ts
+++ b/src/app/modules/configuracion/logical-replication/edit-replication-table-dialog/edit-replication-table-dialog.component.ts
@@ -89,10 +89,7 @@ export class EditReplicationTableDialogComponent implements OnInit {
     
     // Convert form value to ReplicationTable
     const replicationTable: ReplicationTable = this.tableForm.value;
-    
-    // Convert tableName to UPPERCASE as per requirements
-    replicationTable.tableName = replicationTable.tableName.toUpperCase();
-    
+
     this.replicationTableService.saveReplicationTable(replicationTable)
       .pipe(untilDestroyed(this))
       .subscribe({

--- a/src/app/modules/configuracion/logical-replication/list-replication-tables/list-replication-tables.component.html
+++ b/src/app/modules/configuracion/logical-replication/list-replication-tables/list-replication-tables.component.html
@@ -81,8 +81,8 @@
 
       <!-- Actions Column -->
       <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef>Acciones</th>
-        <td mat-cell *matCellDef="let element">
+        <th mat-header-cell *matHeaderCellDef style="text-align: center;">Acciones</th>
+        <td mat-cell *matCellDef="let element" style="text-align: center;">
           <button mat-icon-button color="primary" matTooltip="Editar" (click)="openEditDialog(element)">
             <mat-icon>edit</mat-icon>
           </button>

--- a/src/app/modules/configuracion/logical-replication/list-replication-tables/list-replication-tables.component.scss
+++ b/src/app/modules/configuracion/logical-replication/list-replication-tables/list-replication-tables.component.scss
@@ -7,6 +7,8 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 16px;
+  margin-right: 10px;
+  margin-left: 10px;
 
   h2 {
     margin: 0;
@@ -24,6 +26,7 @@
   flex-wrap: wrap;
   gap: 16px;
   margin-bottom: 16px;
+  margin-left: 10px;
   align-items: center;
 
   .search-field {

--- a/src/app/modules/configuracion/logical-replication/replication-table.model.ts
+++ b/src/app/modules/configuracion/logical-replication/replication-table.model.ts
@@ -1,5 +1,4 @@
 import { Usuario } from '../../personas/usuarios/usuario.model';
-import { dateToString } from '../../../commons/core/utils/dateUtils';
 
 /**
  * Enum para las direcciones de replicación
@@ -65,12 +64,11 @@ export class ReplicationTableModel {
   toInput(): any {
     return {
       id: this.id,
-      tableName: this.tableName?.toUpperCase(),
+      tableName: this.tableName,
       direction: this.direction,
       enabled: this.enabled,
-      description: this.description?.toUpperCase(),
+      description: this.description,
       usuarioId: this.usuario?.id,
-      creadoEn: dateToString(this.creadoEn),
       branchIds: this.branchIds ?? [],
       replicateCentralToBranchWithFilter: this.replicateCentralToBranchWithFilter ?? false
     };


### PR DESCRIPTION
### Que resuelve

Continuacion de la correccion del dialogo de tablas de replicacion (`edit-replication-table-dialog`):

- Guardado en mayusculas de `tableName` y `description`: el formulario forzaba ambos campos a mayusculas antes de guardarlos (`toUpperCase()`), pero las tablas reales de la base de datos usan minusculas (comportamiento por defecto de Postgres para identificadores sin comillas) y las tablas de replicacion ya existentes fueron cargadas directamente en la base en minusculas. Esto generaba inconsistencia entre lo guardado en `configuracion.replication_table` y el nombre real de la tabla/esquema en Postgres. Se saca el `toUpperCase()` para que ambos campos se guarden tal cual los ingresa el usuario.
- Campo `creadoEn` en el payload de guardado: `ReplicationTableModel.toInput()` enviaba creadoEn en la mutacion de guardado, pero ese campo no existe en `ReplicationTableInput` del backend (el backend lo setea automaticamente en el servidor al crear el registro, y lo preserva en updates). Enviarlo rompia la mutacion con el error `The variables input contains a field name 'creadoEn' that is not defined for input object type 'ReplicationTableInput'`, impidiendo guardar cualquier tabla nueva. Se elimina el campo del payload (y el import de `dateToString` que quedaba sin uso).
- Ajustes menores de UI: hint del campo "Nombre de Tabla" actualizado para reflejar el formato `esquema.tabla` en lugar de mencionar guardado en mayusculas; color del hint del toggle "Activa/Inactiva" corregido para modo oscuro (antes usaba `rgba(0, 0, 0, 0.6)`, ilegible sobre fondo oscuro); columna "Acciones" del listado de tablas centrada, en linea con la convencion de texto centrado en tablas; ajustes de margenes en el listado.

### Como probarlo

1. Ir a Configuracion > Replicacion Logica > Tablas.
2. Crear una tabla nueva con nombre en minusculas y esquema, por ejemplo `personas.usuario`, y guardar.
3. Verificar que se guarda sin errores (antes fallaba con el error de `creadoEn` no definido en `ReplicationTableInput`).
4. Verificar en el listado que el nombre y la descripcion quedan guardados tal cual se ingresaron (sin forzar mayusculas).
5. Editar una tabla existente, cambiar la descripcion y guardar; confirmar que tampoco se fuerza a mayusculas.
6. Revisar visualmente el dialogo en modo oscuro: el hint del toggle "Activa/Inactiva" debe verse legible, y la columna "Acciones" del listado debe estar centrada.

### Impacto DB

Ninguno directo (no hay migraciones ni cambios de schema). Si existen filas previas en `configuracion.replication_table` guardadas en mayusculas por versiones anteriores de este dialogo, quedaran inconsistentes con los nuevos registros en minusculas; puede ser necesario normalizarlas manualmente si el servicio de replicacion hace matching case-sensitive contra el catalogo de Postgres.

### Riesgo

Bajo. Cambios acotados al dialogo y modelo de tablas de replicacion (frontend), sin tocar logica de negocio del backend ni otros modulos. El fix de `creadoEn`  es el que desbloquea la funcionalidad de creacion, que actualmente estaba completamente rota.