### PR TITLE
fix(login): compat de login con servidores release/beta (embeddingFacial)

### DIFF
--- a/src/app/modules/login/login.service.ts
+++ b/src/app/modules/login/login.service.ts
@@ -147,7 +147,7 @@ export class LoginService {
               setTimeout(() => {
                 if (res["usuarioId"] != null) {
                   this.usuarioService
-                    .onGetUsuario(res["usuarioId"], !config.isLocal)
+                    .onGetUsuarioParaLogin(res["usuarioId"], !config.isLocal)
                     .pipe(untilDestroyed(this))
                     .subscribe((res) => {
                       if (res?.id != null) {

--- a/src/app/modules/personas/usuarios/graphql/graphql-query.ts
+++ b/src/app/modules/personas/usuarios/graphql/graphql-query.ts
@@ -77,6 +77,50 @@ export const usuarioQuery = gql`
   }
 `;
 
+// Version de la query de usuario usada EXCLUSIVAMENTE en el login.
+// Es identica a `usuarioQuery` pero SIN `persona.embeddingFacial`.
+// Motivo: el login corre contra cualquier servidor (central o filial), y los
+// servidores en `release/beta` todavia no tienen el campo `embeddingFacial` en
+// el type Persona -> GraphQL rechaza la query y el login falla.
+// El login no consume `embeddingFacial`; la busqueda/galeria facial de marcacion
+// sigue usando `usuarioQuery` (con el campo) contra el servidor que lo soporta.
+export const usuarioLoginQuery = gql`
+  query ($id: ID!) {
+    data: usuario(id: $id) {
+      id
+      nickname
+      activo
+      persona {
+        id
+        nombre
+        imagenes
+      }
+      creadoEn
+      usuario {
+        persona {
+          nombre
+        }
+      }
+      roles
+      inicioSesion {
+        id
+        usuario {
+          id
+        }
+        sucursal {
+          id
+        }
+        tipoDespositivo
+        idDispositivo
+        token
+        horaInicio
+        horaFin
+        creadoEn
+      }
+    }
+  }
+`;
+
 export const usuarioPorPersonaIdQuery = gql`
   query ($id: ID!) {
     data: usuarioPorPersonaId(id: $id) {

--- a/src/app/modules/personas/usuarios/graphql/usuarioLogin.ts
+++ b/src/app/modules/personas/usuarios/graphql/usuarioLogin.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { Usuario } from '../usuario.model';
+import { usuarioLoginQuery } from './graphql-query';
+
+export interface Response {
+  data: Usuario;
+}
+
+// Query de usuario para el login. Duplica UsuarioPorIdGQL pero sin
+// `persona.embeddingFacial`, para mantener compatibilidad con servidores en
+// `release/beta` que aun no tienen ese campo en el schema.
+@Injectable({
+  providedIn: 'root',
+})
+export class UsuarioLoginGQL extends Query<Response> {
+  document = usuarioLoginQuery;
+}

--- a/src/app/modules/personas/usuarios/usuario.service.ts
+++ b/src/app/modules/personas/usuarios/usuario.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Injector } from "@angular/core";
 import { UsuarioPorIdGQL } from "./graphql/usuarioPorId";
+import { UsuarioLoginGQL } from "./graphql/usuarioLogin";
 import { Usuario } from "./usuario.model";
 import { UsuarioSearchGQL } from "./graphql/usuarioSearch";
 import {
@@ -37,6 +38,7 @@ export class UsuarioService {
 
   constructor(
     private getUsuario: UsuarioPorIdGQL,
+    private getUsuarioLogin: UsuarioLoginGQL,
     private getUsuarioPorPersonaId: UsuarioPorPersonaIdGQL,
     private saveUsuario: SaveUsuarioGQL,
     private searchUsuario: UsuarioSearchGQL,
@@ -62,6 +64,12 @@ export class UsuarioService {
 
   onGetUsuario(id: number, servidor: boolean = true): Observable<any> {
     return this.genericService.onCustomQuery(this.getUsuario, { id }, servidor);
+  }
+
+  // Usa la query de login (sin `persona.embeddingFacial`) para ser compatible
+  // con servidores en `release/beta` que aun no tienen ese campo en el schema.
+  onGetUsuarioParaLogin(id: number, servidor: boolean = true): Observable<any> {
+    return this.genericService.onCustomQuery(this.getUsuarioLogin, { id }, servidor);
   }
 
   onGetUsuarioPorPersonaId(id: number, servidor: boolean = true, errorConf?: any): Observable<any> {


### PR DESCRIPTION
## Qué resuelve

El login usaba `usuarioQuery`, que pide `persona.embeddingFacial`. Ese campo existe en `develop` pero **no** en `release/beta` (servidor y filial). Al iniciar sesión contra un servidor que corre `release/beta`, GraphQL rechaza la query por campo desconocido y **el login falla**.

## Cambios

- Nueva `usuarioLoginQuery` en `graphql-query.ts`: copia de `usuarioQuery` **sin** `persona.embeddingFacial` (conserva `roles`, `inicioSesion`, etc.).
- Nueva clase Apollo `UsuarioLoginGQL` (`usuarioLogin.ts`).
- Nuevo método `onGetUsuarioParaLogin()` en `usuario.service.ts`.
- `login.service.ts` usa `onGetUsuarioParaLogin` en vez de `onGetUsuario`.

La galería/búsqueda facial de marcación sigue usando `usuarioQuery` completa (con el campo) contra el servidor que lo soporta, **sin perder funcionalidad**. El `usuarioActual` del login nunca lee `.persona.embeddingFacial`.

## Cómo probarlo

1. Apuntar la app a un servidor corriendo `release/beta` e iniciar sesión → antes fallaba, ahora funciona.
2. Contra un servidor `develop`: login OK y el módulo de marcación (reconocimiento facial) sigue operando normal.

## Riesgo

Bajo. Cambio aditivo (query nueva), no toca la query compartida de marcación ni el flujo de embeddings.

## Impacto en auto-update

Ninguno. No toca `installer.nsh`, `electron-builder.json` ni manifests.