### PR TITLE
feat(financiero): configuracion global para habilitar venta con tarjeta

### DIFF
--- a/src/app/modules/financiero/financiero.module.ts
+++ b/src/app/modules/financiero/financiero.module.ts
@@ -51,6 +51,7 @@ import { PrintTerminalPosDialogComponent } from "./terminal-pos/print-terminal-p
 import { ScanTerminalPosDialogComponent } from "./terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component";
 import { TerminalPosDashboard } from "./terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component";
 import { ListVentaTarjetaComponent } from "./venta-tarjeta/list-venta-tarjeta/list-venta-tarjeta.component";
+import { ConfiguracionVentaTarjetaDialogComponent } from "./venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component";
 
 @NgModule({
   declarations: [
@@ -97,7 +98,8 @@ import { ListVentaTarjetaComponent } from "./venta-tarjeta/list-venta-tarjeta/li
     PrintTerminalPosDialogComponent,
     ScanTerminalPosDialogComponent,
     TerminalPosDashboard,
-    ListVentaTarjetaComponent
+    ListVentaTarjetaComponent,
+    ConfiguracionVentaTarjetaDialogComponent
 
   ],
   providers: [

--- a/src/app/modules/financiero/terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component.html
+++ b/src/app/modules/financiero/terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component.html
@@ -7,6 +7,13 @@
       <div fxFlex="30%" style="height: 250px">
         <app-boton nombre="Ventas con tarjeta" icon="tune" [iconSize]="4" (clickEvent)="onListVentaTarjeta()"></app-boton>
       </div>
+      <div fxFlex="30%" style="height: 250px" *ngIf="
+                mainService.usuarioActual?.roles.includes(
+                  ROLES.ADMIN
+                )
+              ">
+        <app-boton nombre="Configurar ventas con tarjeta" icon="tune" [iconSize]="4" (clickEvent)="onAbrirConfiguracion()"></app-boton>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/modules/financiero/terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component.ts
+++ b/src/app/modules/financiero/terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component.ts
@@ -4,6 +4,9 @@ import { Tab } from "../../../../layouts/tab/tab.model";
 import { ListTerminalPosComponent } from "../list-terminal-pos/list-terminal-pos.component";
 import { MainService } from "../../../../main.service";
 import { ListVentaTarjetaComponent } from "../../venta-tarjeta/list-venta-tarjeta/list-venta-tarjeta.component";
+import { ROLES } from "../../../personas/roles/roles.enum";
+import { ConfiguracionVentaTarjetaDialogComponent } from "../../venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component";
+import { MatDialog } from "@angular/material/dialog";
 
 @Component({
   selector: 'app-terminal-pos-dashboard',
@@ -11,13 +14,16 @@ import { ListVentaTarjetaComponent } from "../../venta-tarjeta/list-venta-tarjet
   styleUrls: ['./terminal-pos-dashboard.component.scss']
 })
 export class TerminalPosDashboard  implements OnInit{
+
+  readonly ROLES = ROLES;
   ngOnInit(): void {
     
   }
 
   constructor(
     private tabService: TabService,
-    private mainService: MainService
+    public mainService: MainService,
+    private matDialog: MatDialog
   ) {}
 
   onNuevaTerminalPos() {
@@ -26,5 +32,13 @@ export class TerminalPosDashboard  implements OnInit{
 
   onListVentaTarjeta() {
     this.tabService.addTab(new Tab(ListVentaTarjetaComponent, 'Lista de ventas con tarjeta', null, TerminalPosDashboard));
+  }
+
+  onAbrirConfiguracion() {
+    this.matDialog.open(ConfiguracionVentaTarjetaDialogComponent, {
+      width: '560px',
+      disableClose: false,
+      panelClass: 'custom-dialog-container'
+    });
   }
 }

--- a/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component.html
+++ b/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component.html
@@ -1,0 +1,34 @@
+<h2 mat-dialog-title>Configuración de Venta con Tarjeta</h2>
+
+<mat-dialog-content>
+    <div fxLayout="column" fxLayoutGap="15px" style="margin-top: 10px;">
+        <div class="config-item">
+            <div class="config-item-info">
+                <div class="config-item-title">Habilitar venta con tarjeta</div>
+                <div class="config-item-desc">
+                    Cuando está activado, las sucursales podrán registrar ventas con tarjeta escaneando la
+                    terminal POS desde el desktop y confirmando el registro desde la aplicación móvil.
+                    Si está desactivado, el cobro con tarjeta funciona como un medio de pago normal, sin el
+                    escaneo de terminal ni el registro adicional.
+                </div>
+            </div>
+            <div class="config-item-toggle">
+                <mat-slide-toggle
+                    [checked]="config.habilitado"
+                    (change)="onToggleHabilitado()"
+                    color="accent">
+                </mat-slide-toggle>
+                <span class="toggle-label" [class.active]="config.habilitado" [class.desactive]="!config.habilitado">
+                    {{ config.habilitado ? 'ACTIVADO' : 'DESACTIVADO' }}
+                </span>
+            </div>
+        </div>
+    </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+    <button mat-button (click)="onCancelar()">Cancelar</button>
+    <button mat-raised-button color="primary" (click)="onGuardar()">
+        <mat-icon>save</mat-icon> Guardar
+    </button>
+</mat-dialog-actions>

--- a/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component.scss
+++ b/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component.scss
@@ -1,0 +1,58 @@
+.config-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: border-color 0.2s ease;
+
+  &:hover {
+    border-color: #90caf9;
+  }
+}
+
+.config-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.config-item-title {
+  font-size: 18px;
+  font-weight: 500;
+  color: #e0e0e0;
+}
+
+.config-item-desc {
+  font-size: 15px;
+  color: #9e9e9e;
+  line-height: 1.4;
+}
+
+.config-item-toggle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 90px;
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #757575;
+  letter-spacing: 0.5px;
+  transition: color 0.2s ease;
+
+  &.active {
+    color: #81c784;
+  }
+
+  &.desactive {
+    color: #f44336;
+  }
+}

--- a/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component.ts
+++ b/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component.ts
@@ -1,0 +1,65 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MainService } from '../../../../main.service';
+import { NotificacionSnackbarService } from '../../../../notificacion-snackbar.service';
+import { ConfiguracionVentaTarjetaService } from './configuracion-venta-tarjeta.service';
+import { ConfiguracionVentaTarjeta } from './configuracion-venta-tarjeta.model';
+
+@Component({
+  selector: 'app-configuracion-venta-tarjeta-dialog',
+  templateUrl: './configuracion-venta-tarjeta-dialog.component.html',
+  styleUrls: ['./configuracion-venta-tarjeta-dialog.component.scss']
+})
+export class ConfiguracionVentaTarjetaDialogComponent implements OnInit {
+
+  config: ConfiguracionVentaTarjeta = new ConfiguracionVentaTarjeta();
+  isLoading = true;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: MatDialogRef<ConfiguracionVentaTarjetaDialogComponent>,
+    private configuracionService: ConfiguracionVentaTarjetaService,
+    private notificacionService: NotificacionSnackbarService,
+    public mainService: MainService
+  ) { }
+
+  ngOnInit(): void {
+    this.configuracionService.onGetConfiguracion().subscribe({
+      next: (res) => {
+        if (res != null) {
+          Object.assign(this.config, res);
+        }
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+        this.notificacionService.openAlgoSalioMal('Error al cargar la configuración');
+      }
+    });
+  }
+
+  onToggleHabilitado(): void {
+    this.config.habilitado = !this.config.habilitado;
+  }
+
+  onGuardar(): void {
+    const input = this.config.toInput();
+    input.usuarioId = this.mainService.usuarioActual?.id;
+    this.configuracionService.onSaveConfiguracion(input).subscribe({
+      next: (res) => {
+        if (res != null) {
+          this.config = res;
+          this.notificacionService.openSucess('Configuración guardada correctamente');
+          this.dialogRef.close(this.config);
+        }
+      },
+      error: () => {
+        this.notificacionService.openAlgoSalioMal('Error al guardar la configuración');
+      }
+    });
+  }
+
+  onCancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta.model.ts
+++ b/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta.model.ts
@@ -1,0 +1,23 @@
+import { Usuario } from "../../../personas/usuarios/usuario.model";
+
+export class ConfiguracionVentaTarjeta {
+  id: number;
+  habilitado: boolean;
+  usuario: Usuario;
+  creadoEn: Date;
+  modificadoEn: Date;
+
+  toInput(): ConfiguracionVentaTarjetaInput {
+    let input = new ConfiguracionVentaTarjetaInput();
+    input.id = this?.id;
+    input.habilitado = this?.habilitado;
+    input.usuarioId = this?.usuario?.id;
+    return input;
+  }
+}
+
+export class ConfiguracionVentaTarjetaInput {
+  id?: number;
+  habilitado?: boolean;
+  usuarioId?: number;
+}

--- a/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta.service.ts
+++ b/src/app/modules/financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { GenericCrudService } from '../../../../generics/generic-crud.service';
+import { ConfiguracionVentaTarjeta, ConfiguracionVentaTarjetaInput } from './configuracion-venta-tarjeta.model';
+import { GetConfiguracionVentaTarjetaGQL } from '../graphql/getConfiguracionVentaTarjeta';
+import { SaveConfiguracionVentaTarjetaGQL } from '../graphql/saveConfiguracionVentaTarjeta';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfiguracionVentaTarjetaService {
+
+  constructor(
+    private genericCrudService: GenericCrudService,
+    private getConfiguracionGQL: GetConfiguracionVentaTarjetaGQL,
+    private saveConfiguracionGQL: SaveConfiguracionVentaTarjetaGQL
+  ) { }
+
+  onGetConfiguracion(servidor = true): Observable<ConfiguracionVentaTarjeta> {
+    return this.genericCrudService.onCustomQuery(this.getConfiguracionGQL, {}, servidor);
+  }
+
+  onSaveConfiguracion(input: ConfiguracionVentaTarjetaInput, servidor = true): Observable<ConfiguracionVentaTarjeta> {
+    return this.genericCrudService.onSave(this.saveConfiguracionGQL, input, null, null, servidor);
+  }
+}

--- a/src/app/modules/financiero/venta-tarjeta/graphql/getConfiguracionVentaTarjeta.ts
+++ b/src/app/modules/financiero/venta-tarjeta/graphql/getConfiguracionVentaTarjeta.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { configuracionVentaTarjetaQuery } from './graphql-query';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class GetConfiguracionVentaTarjetaGQL extends Query<any> {
+    document = configuracionVentaTarjetaQuery;
+}

--- a/src/app/modules/financiero/venta-tarjeta/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/venta-tarjeta/graphql/graphql-query.ts
@@ -65,3 +65,33 @@ export const imprimirReporteVentaTarjetaQuery = gql`
     )
   }
 `;
+
+export const configuracionVentaTarjetaQuery = gql`
+  {
+    data: configuracionVentaTarjeta {
+      id
+      habilitado
+      usuario {
+        id
+        nickname
+      }
+      creadoEn
+      modificadoEn
+    }
+  }
+`;
+
+export const saveConfiguracionVentaTarjeta = gql`
+  mutation saveConfiguracionVentaTarjeta($entity: ConfiguracionVentaTarjetaInput!) {
+    data: saveConfiguracionVentaTarjeta(input: $entity) {
+      id
+      habilitado
+      usuario {
+        id
+        nickname
+      }
+      creadoEn
+      modificadoEn
+    }
+  }
+`;

--- a/src/app/modules/financiero/venta-tarjeta/graphql/saveConfiguracionVentaTarjeta.ts
+++ b/src/app/modules/financiero/venta-tarjeta/graphql/saveConfiguracionVentaTarjeta.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { saveConfiguracionVentaTarjeta } from './graphql-query';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class SaveConfiguracionVentaTarjetaGQL extends Mutation<any> {
+    document = saveConfiguracionVentaTarjeta;
+}

--- a/src/app/modules/financiero/venta-tarjeta/list-venta-tarjeta/list-venta-tarjeta.component.ts
+++ b/src/app/modules/financiero/venta-tarjeta/list-venta-tarjeta/list-venta-tarjeta.component.ts
@@ -9,6 +9,10 @@ import { VentaTarjetaService } from '../venta-tarjeta.service';
 import { SucursalService } from '../../../empresarial/sucursal/sucursal.service';
 import { Sucursal } from '../../../empresarial/sucursal/sucursal.model';
 import { TerminalPosService } from '../../terminal-pos/terminal-pos.service';
+import { MainService } from '../../../../main.service';
+import { ROLES } from '../../../personas/roles/roles.enum';
+import { MatDialog } from '@angular/material/dialog';
+import { ConfiguracionVentaTarjetaDialogComponent } from '../configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component';
 
 @UntilDestroy()
 @Component({
@@ -17,6 +21,8 @@ import { TerminalPosService } from '../../terminal-pos/terminal-pos.service';
   styleUrls: ['./list-venta-tarjeta.component.scss']
 })
 export class ListVentaTarjetaComponent implements OnInit {
+
+  ROLES = ROLES;
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
 
@@ -50,7 +56,9 @@ export class ListVentaTarjetaComponent implements OnInit {
   constructor(
     private ventaTarjetaService: VentaTarjetaService,
     private sucursalService: SucursalService,
-    private terminalPosService: TerminalPosService
+    private terminalPosService: TerminalPosService,
+    public mainService: MainService,
+    private matDialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -154,5 +162,13 @@ export class ListVentaTarjetaComponent implements OnInit {
     }
 
     this.ventaTarjetaService.onImprimirReporteVentaTarjeta(params);
+  }
+
+  onAbrirConfiguracion(): void {
+    this.matDialog.open(ConfiguracionVentaTarjetaDialogComponent, {
+      width: '560px',
+      disableClose: false,
+      panelClass: 'custom-dialog-container'
+    });
   }
 }

--- a/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.ts
@@ -76,6 +76,7 @@ import { Cliente } from "../../../../personas/clientes/cliente.model";
 import { BotonComponent } from "../../../../../shared/components/boton/boton.component";
 import { MonedaService } from "../../../../financiero/moneda/moneda.service";
 import { ScanTerminalPosDialogComponent, ScanTerminalPosResult } from "../../../../financiero/terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component";
+import { ConfiguracionVentaTarjetaService } from "../../../../financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta.service";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -166,7 +167,8 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
     private notificacionSnackbar: NotificacionSnackbarService,
     private formaPagoService: FormaPagoService,
     private cargandoDialog: CargandoDialogService,
-    private ventaService: VentaService
+    private ventaService: VentaService,
+    private configuracionVentaTarjetaService: ConfiguracionVentaTarjetaService
   ) {
     this.formaPagoList = [];
     if (data.delivery != null) {
@@ -611,6 +613,31 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
       return;
     }
 
+    this.configuracionVentaTarjetaService.onGetConfiguracion().subscribe({
+      next: (config) => {
+        if (!config?.habilitado) {
+          // Flujo de registro de venta con tarjeta deshabilitado: el cobro con
+          // TARJETA sigue funcionando como un medio de pago normal, sin escaneo
+          // de terminal ni generación de QR.
+          this.cerrarConRespuesta(ventaCredito, itens, ticket, []);
+          return;
+        }
+        this.iniciarEscaneoTarjetaCobros(tarjetaCobros, ventaCredito, itens, ticket);
+      },
+      error: () => {
+        // Ante un error de configuración, no bloqueamos el cobro: se comporta
+        // como si el flujo estuviera deshabilitado.
+        this.cerrarConRespuesta(ventaCredito, itens, ticket, []);
+      }
+    });
+  }
+
+  private iniciarEscaneoTarjetaCobros(
+    tarjetaCobros: CobroDetalle[],
+    ventaCredito?: VentaCredito,
+    itens?: VentaCreditoCuotaInput[],
+    ticket?: boolean
+  ) {
     const tarjetaPagos: TarjetaPago[] = [];
 
     const abrirDialogPara = (index: number) => {


### PR DESCRIPTION
## Que resuelve

El flujo de venta con tarjeta (escaneo de terminal POS + generacion de QR para el mobile) es una feature nueva en pruebas en alpha. Se agrega un flag de configuracion global (`configuracionVentaTarjeta.habilitado`, backend en `franco-system-backend-servidor`) para poder activarlo/desactivarlo sin release, y este PR agrega la administracion y el enforcement en el desktop.

## Cambio

- **Dialog de administracion** (`ConfiguracionVentaTarjetaDialogComponent`), mismo patron que "Configuracion de Transferencias" (permitir stock negativo). Accesible desde el dashboard de Terminal POS, boton "Configurar ventas con tarjeta", visible solo para `ROLES.ADMIN`.
- **Enforcement en vivo**: en `pago-touch.component.ts`, antes de disparar el escaneo de terminal POS + generacion de QR para un cobro con `TARJETA`, se consulta el flag (sin cache). Si esta deshabilitado, el cobro con TARJETA sigue funcionando como medio de pago normal — sin el sub-flujo nuevo, sin bloquear la venta.
- El listado existente de `VentaTarjeta` en el desktop no se oculta (es solo consulta, no genera nuevos registros).

## Como probarlo

1. Con el flag deshabilitado (default): cobrar con TARJETA no debe disparar el dialogo de escaneo de terminal ni generar QR — el cobro se registra normal.
2. Activar el flag desde "Configurar ventas con tarjeta" (dashboard de Terminal POS, requiere rol ADMIN).
3. Con el flag habilitado: cobrar con TARJETA debe disparar el escaneo de terminal y generar el QR normalmente.

## Requiere

PR de backend: `feat/configuracion-venta-tarjeta` en `franco-system-backend-servidor` (agrega el query/mutation `configuracionVentaTarjeta`).

## Riesgo

Bajo. Fallback seguro: si la consulta de configuracion falla, se comporta como deshabilitado (no bloquea el cobro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)