### PR TITLE
feat(impresoras/facturas): imprimir en sucursal remota

### DIFF
--- a/src/app/modules/configuracion/configuracion.module.ts
+++ b/src/app/modules/configuracion/configuracion.module.ts
@@ -27,12 +27,14 @@ import { EmpresarialModule } from '../empresarial/empresarial.module';
 import { ListImpresorasComponent } from './impresoras/list-impresoras/list-impresoras.component';
 import { AdicionarImpresoraDialogComponent } from './impresoras/adicionar-impresora-dialog/adicionar-impresora-dialog.component';
 import { CredencialesCupsDialogComponent } from './impresoras/credenciales-cups-dialog/credenciales-cups-dialog.component';
+import { AgregarDesdeSucursalDialogComponent } from './impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component';
 
 @NgModule({
   declarations: [
     ListImpresorasComponent,
     AdicionarImpresoraDialogComponent,
     CredencialesCupsDialogComponent,
+    AgregarDesdeSucursalDialogComponent,
     ConfigurarServidorDialogComponent, 
     ListActualizacionComponent, 
     EditActualizacionComponent, 

--- a/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.html
+++ b/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.html
@@ -1,0 +1,85 @@
+<div class="dialog-header">
+  <h2 mat-dialog-title>Agregar desde sucursal</h2>
+  <button mat-icon-button (click)="cancelar()" class="close-btn" tabindex="-1">
+    <mat-icon>close</mat-icon>
+  </button>
+</div>
+
+<mat-dialog-content class="dialog-content-modern">
+  <div class="info-alert">
+    <mat-icon class="info-icon">info</mat-icon>
+    <p class="detalle">
+      Se conecta directo al backend de la sucursal elegida (por IP) y trae las colas CUPS que ya
+      tiene instaladas, con tu sesión actual. No hace falta usuario ni contraseña del sistema
+      operativo de esa PC.
+    </p>
+  </div>
+
+  <div class="form-section">
+    <div class="section-title">
+      <mat-icon>store</mat-icon>
+      <span>Sucursal</span>
+    </div>
+
+    <mat-form-field appearance="outline" class="campo">
+      <mat-label>Sucursal</mat-label>
+      <mat-icon matPrefix>store</mat-icon>
+      <mat-select [formControl]="sucursalControl">
+        <mat-option *ngFor="let s of sucursales" [value]="s.id">{{ s.id }} - {{ s.nombre }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <div class="fila-central" fxLayout="row" fxLayoutGap="16px">
+      <mat-form-field appearance="outline" class="campo" fxFlex>
+        <mat-label>IP de la sucursal</mat-label>
+        <mat-icon matPrefix>dns</mat-icon>
+        <input matInput [formControl]="ipControl" autocomplete="off" placeholder="Ej. 172.25.0.172" />
+        <mat-hint>Autocompletada desde la sucursal, editable si hace falta corregirla</mat-hint>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="campo campo-puerto">
+        <mat-label>Puerto</mat-label>
+        <mat-icon matPrefix>settings_ethernet</mat-icon>
+        <input matInput [formControl]="puertoControl" autocomplete="off" placeholder="Ej. 8082" />
+        <mat-hint>Puede variar por sucursal</mat-hint>
+      </mat-form-field>
+    </div>
+
+    <button mat-stroked-button color="primary" (click)="buscarColas()" [disabled]="buscando || !ipControl.value || !puertoControl.value">
+      <mat-icon>{{ buscando ? 'hourglass_empty' : 'search' }}</mat-icon>
+      {{ buscando ? 'Buscando…' : 'Buscar colas del sistema' }}
+    </button>
+  </div>
+
+  <div class="form-section" *ngIf="errorBusqueda">
+    <div class="error-alert">
+      <mat-icon>error_outline</mat-icon>
+      <span>{{ errorBusqueda }}</span>
+    </div>
+  </div>
+
+  <div class="form-section" *ngIf="buscoAlMenosUnaVez && !errorBusqueda">
+    <div class="section-title">
+      <mat-icon>print</mat-icon>
+      <span>Colas detectadas ({{ colas.length }})</span>
+    </div>
+
+    <p *ngIf="colas.length === 0" class="sin-colas">No se detectaron colas CUPS en esa sucursal.</p>
+
+    <div class="cola-item" *ngFor="let c of colas" (click)="toggle(c)">
+      <mat-checkbox [checked]="c.seleccionada" (click)="$event.stopPropagation(); toggle(c)"></mat-checkbox>
+      <mat-icon class="cola-icon">{{ c.esTermica ? 'receipt_long' : 'print' }}</mat-icon>
+      <span class="cola-nombre">{{ c.nombre }}</span>
+      <span class="cola-tipo">{{ c.esTermica ? 'Térmica' : 'Normal' }}</span>
+    </div>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="dialog-actions-modern">
+  <button mat-button (click)="cancelar()" class="btn-cancelar">Cancelar</button>
+  <button mat-flat-button color="primary" (click)="agregarSeleccionadas()" class="btn-aceptar"
+    [disabled]="guardando || seleccionadas.length === 0">
+    <mat-icon>{{ guardando ? 'hourglass_empty' : 'add' }}</mat-icon>
+    {{ guardando ? 'Agregando…' : 'Agregar (' + seleccionadas.length + ')' }}
+  </button>
+</mat-dialog-actions>

--- a/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.scss
+++ b/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.scss
@@ -1,0 +1,160 @@
+:host {
+  display: block;
+  min-width: 520px;
+}
+
+:host ::ng-deep input {
+  text-transform: none !important;
+}
+
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 24px 0 24px;
+
+  h2 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 500;
+  }
+
+  .close-btn {
+    opacity: 0.6;
+    &:hover {
+      opacity: 1;
+    }
+  }
+}
+
+.dialog-content-modern {
+  padding: 20px 24px !important;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-height: 60vh;
+}
+
+.info-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: rgba(33, 150, 243, 0.08);
+  border-left: 4px solid #2196F3;
+  padding: 14px 16px;
+  border-radius: 4px;
+
+  .info-icon {
+    color: #2196F3;
+    margin-top: 2px;
+  }
+
+  .detalle {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+    opacity: 0.9;
+  }
+}
+
+.error-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: rgba(244, 67, 54, 0.08);
+  border-left: 4px solid #f44336;
+  padding: 14px 16px;
+  border-radius: 4px;
+  font-size: 14px;
+
+  mat-icon {
+    color: #f44336;
+    margin-top: 2px;
+  }
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  .section-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 15px;
+    font-weight: 500;
+    color: #3f51b5;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    padding-bottom: 8px;
+    margin-bottom: 4px;
+
+    mat-icon {
+      font-size: 20px;
+      height: 20px;
+      width: 20px;
+    }
+  }
+}
+
+.campo {
+  width: 100%;
+}
+
+.campo-puerto {
+  max-width: 140px;
+}
+
+.sin-colas {
+  opacity: 0.7;
+  font-size: 14px;
+  margin: 0;
+}
+
+.cola-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(63, 81, 181, 0.08);
+  }
+
+  .cola-icon {
+    opacity: 0.7;
+  }
+
+  .cola-nombre {
+    flex: 1;
+    font-weight: 500;
+  }
+
+  .cola-tipo {
+    font-size: 12px;
+    opacity: 0.6;
+  }
+}
+
+.dialog-actions-modern {
+  padding: 16px 24px 24px !important;
+  margin-bottom: 0;
+
+  .btn-cancelar {
+    margin-right: 8px;
+  }
+
+  .btn-aceptar {
+    padding: 0 24px;
+    mat-icon {
+      margin-right: 8px;
+    }
+  }
+}
+
+::ng-deep .mat-form-field-prefix .mat-icon {
+  margin-right: 8px;
+  opacity: 0.6;
+}

--- a/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.ts
+++ b/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.ts
@@ -1,0 +1,200 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { from, of } from 'rxjs';
+import { catchError, concatMap, map, toArray } from 'rxjs/operators';
+import {
+  NotificacionColor,
+  NotificacionSnackbarService,
+} from '../../../../notificacion-snackbar.service';
+import { Sucursal } from '../../../empresarial/sucursal/sucursal.model';
+import { SucursalService } from '../../../empresarial/sucursal/sucursal.service';
+import { ImpresoraInput } from '../impresora.model';
+import { ImpresoraService } from '../impresora.service';
+
+// Palabras que sugieren que una impresora es termica / de tickets (mismo criterio que el resto del módulo).
+const REGEX_TERMICA = /ticket|term|thermal|\btm[-\s]?\d|xprinter|xp[-\s]?\d|pos.?58|pos.?80|58\s?mm|80\s?mm|receipt|bematech|epson\s?tm/i;
+
+interface ColaVista {
+  nombre: string;
+  seleccionada: boolean;
+  esTermica: boolean;
+}
+
+/**
+ * "Agregar desde sucursal": conecta directo (por IP) al backend filial de una sucursal elegida y
+ * trae sus colas CUPS ya instaladas, para registrarlas como Impresora en el central sin tener que
+ * darlas de alta a mano una por una. Reutiliza el login ya activo (mismo mecanismo que "compartir
+ * impresora" en el diálogo de alta) — no pide usuario/contraseña de sistema operativo.
+ */
+@UntilDestroy()
+@Component({
+  selector: 'app-agregar-desde-sucursal-dialog',
+  templateUrl: './agregar-desde-sucursal-dialog.component.html',
+  styleUrls: ['./agregar-desde-sucursal-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AgregarDesdeSucursalDialogComponent implements OnInit {
+
+  private sucursalService = inject(SucursalService);
+  private impresoraService = inject(ImpresoraService);
+  private notificacion = inject(NotificacionSnackbarService);
+  private cdr = inject(ChangeDetectorRef);
+  private dialogRef = inject(MatDialogRef<AgregarDesdeSucursalDialogComponent>);
+
+  sucursalControl = new FormControl<number | null>(null, Validators.required);
+  ipControl = new FormControl('', Validators.required);
+  // El puerto del backend de cada sucursal puede variar entre instalaciones: siempre se tipea, sin
+  // valor por defecto asumido.
+  puertoControl = new FormControl('', Validators.required);
+
+  sucursales: Sucursal[] = [];
+  colas: ColaVista[] = [];
+  buscando = false;
+  guardando = false;
+  buscoAlMenosUnaVez = false;
+  errorBusqueda: string = null;
+
+  ngOnInit(): void {
+    this.sucursalService.onGetAllSucursales(true)
+      .pipe(untilDestroyed(this))
+      .subscribe((res) => {
+        // La sucursal 0 es el servidor central: no aplica acá (ya tiene su propio flujo en "Nueva impresora").
+        this.sucursales = (res ?? []).filter((s) => s.id !== 0);
+        this.cdr.markForCheck();
+      });
+
+    this.sucursalControl.valueChanges
+      .pipe(untilDestroyed(this))
+      .subscribe((id) => this.alElegirSucursal(id));
+  }
+
+  private alElegirSucursal(id: number | null): void {
+    const s = this.sucursales.find((x) => x.id === id);
+    this.ipControl.setValue(s?.ip ?? '');
+    // El puerto NUNCA se autocompleta: siempre se tipea a mano, aunque ya se haya guardado uno
+    // antes (puede haber cambiado).
+    this.puertoControl.setValue('');
+    this.colas = [];
+    this.buscoAlMenosUnaVez = false;
+    this.errorBusqueda = null;
+    this.cdr.markForCheck();
+  }
+
+  buscarColas(): void {
+    const sucursal = this.sucursales.find((s) => s.id === this.sucursalControl.value);
+    const ip = (this.ipControl.value ?? '').trim();
+    const puerto = (this.puertoControl.value ?? '').trim();
+    if (!sucursal || !ip || !puerto) {
+      this.notificacion.notification$.next({
+        texto: 'Elegí la sucursal y completá IP y puerto.',
+        color: NotificacionColor.warn,
+        duracion: 4,
+      });
+      return;
+    }
+    this.buscando = true;
+    this.errorBusqueda = null;
+    this.cdr.markForCheck();
+    this.impresoraService.delSistemaEnServidorPorIp(ip, puerto)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (res) => {
+          this.colas = (res ?? []).map((nombre) => ({
+            nombre,
+            seleccionada: false,
+            esTermica: REGEX_TERMICA.test(nombre),
+          }));
+          this.buscando = false;
+          this.buscoAlMenosUnaVez = true;
+          this.cdr.markForCheck();
+          // El puerto tipeado funcionó: lo guardamos en la sucursal para que el backend (routing de
+          // impresión real) deje de asumir el default y use este puerto de ahora en más.
+          this.persistirPuertoSiCambio(sucursal, Number(puerto));
+        },
+        error: (e) => {
+          this.buscando = false;
+          this.buscoAlMenosUnaVez = true;
+          this.colas = [];
+          this.errorBusqueda = e?.message || 'No se pudo conectar. Verificá IP, puerto y que la sucursal esté online.';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  private persistirPuertoSiCambio(sucursal: Sucursal, puerto: number): void {
+    if (sucursal.puertoServidor === puerto) { return; }
+    sucursal.puertoServidor = puerto;
+    this.sucursalService.onSaveSucursal(sucursal.toInput(), true)
+      .pipe(untilDestroyed(this))
+      .subscribe();
+  }
+
+  toggle(cola: ColaVista): void {
+    cola.seleccionada = !cola.seleccionada;
+    this.cdr.markForCheck();
+  }
+
+  get seleccionadas(): ColaVista[] {
+    return this.colas.filter((c) => c.seleccionada);
+  }
+
+  agregarSeleccionadas(): void {
+    const sucursal = this.sucursales.find((s) => s.id === this.sucursalControl.value);
+    const seleccionadas = this.seleccionadas;
+    if (!sucursal || seleccionadas.length === 0) { return; }
+
+    this.guardando = true;
+    this.cdr.markForCheck();
+
+    from(seleccionadas)
+      .pipe(
+        concatMap((cola) => this.impresoraService.guardar(this.aInput(cola, sucursal.id), true).pipe(
+          map(() => true),
+          catchError(() => {
+            this.notificacion.notification$.next({
+              texto: 'Error al guardar ' + cola.nombre,
+              color: NotificacionColor.warn,
+              duracion: 5,
+            });
+            return of(false);
+          }),
+        )),
+        toArray(),
+        untilDestroyed(this),
+      )
+      .subscribe((resultados) => {
+        this.guardando = false;
+        const exitosas = resultados.filter(Boolean).length;
+        if (exitosas > 0) {
+          this.notificacion.notification$.next({
+            texto: `${exitosas} impresora(s) agregada(s) desde ${sucursal.nombre}.`,
+            color: NotificacionColor.success,
+            duracion: 4,
+          });
+        }
+        this.cdr.markForCheck();
+        this.dialogRef.close(exitosas > 0);
+      });
+  }
+
+  private aInput(cola: ColaVista, sucursalId: number): ImpresoraInput {
+    const input = new ImpresoraInput();
+    input.nombre = cola.nombre.toUpperCase();
+    input.activo = true;
+    input.esPredeterminada = false;
+    input.sucursalId = sucursalId;
+    input.tipo = cola.esTermica ? 'TERMICA' : 'NORMAL';
+    input.uso = 'TICKET';
+    input.conexion = 'CUPS';
+    input.colaCups = cola.nombre;
+    input.perfilPapel = cola.esTermica ? 'MM_58' : 'A4';
+    input.columnas = 32;
+    return input;
+  }
+
+  cancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/modules/configuracion/impresoras/graphql/graphql-query.ts
+++ b/src/app/modules/configuracion/impresoras/graphql/graphql-query.ts
@@ -90,3 +90,9 @@ export const instalarImpresoraCupsMutation = gql`
     instalarImpresoraCups(nombreCola: $nombreCola, uri: $uri, raw: $raw)
   }
 `;
+
+export const imprimirPruebaEnImpresoraMutation = gql`
+  mutation ($impresoraId: ID!) {
+    data: imprimirPruebaEnImpresora(impresoraId: $impresoraId)
+  }
+`;

--- a/src/app/modules/configuracion/impresoras/graphql/imprimirPruebaEnImpresora.ts
+++ b/src/app/modules/configuracion/impresoras/graphql/imprimirPruebaEnImpresora.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { imprimirPruebaEnImpresoraMutation } from './graphql-query';
+
+export interface Response {
+  data: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ImprimirPruebaEnImpresoraGQL extends Mutation<Response> {
+  document = imprimirPruebaEnImpresoraMutation;
+}

--- a/src/app/modules/configuracion/impresoras/impresora.service.ts
+++ b/src/app/modules/configuracion/impresoras/impresora.service.ts
@@ -12,6 +12,7 @@ import { ImpresoraByIdGQL } from './graphql/impresoraById';
 import { SaveImpresoraGQL } from './graphql/saveImpresora';
 import { DeleteImpresoraGQL } from './graphql/deleteImpresora';
 import { ImpresorasDelSistemaGQL } from './graphql/impresorasDelSistema';
+import { ImprimirPruebaEnImpresoraGQL } from './graphql/imprimirPruebaEnImpresora';
 
 @Injectable({
   providedIn: 'root'
@@ -29,6 +30,7 @@ export class ImpresoraService {
     private impresorasDelSistemaGQL: ImpresorasDelSistemaGQL,
     private dispositivosParaInstalarGQL: DispositivosParaInstalarGQL,
     private instalarImpresoraCupsGQL: InstalarImpresoraCupsGQL,
+    private imprimirPruebaEnImpresoraGQL: ImprimirPruebaEnImpresoraGQL,
   ) { }
 
   /** Registro de impresoras. Vive en el servidor central (administrativo). */
@@ -90,6 +92,21 @@ export class ImpresoraService {
   }
 
   /**
+   * Imprime un ticket de prueba generado server-side y lo rutea al host dueño de la impresora
+   * (`PrintRouterService`, ya existente): si la impresora es de una filial, el central hace proxy
+   * automático a esa filial por `Sucursal.ip`/`puertoServidor`. Se usa como respaldo de "Probar"
+   * cuando la impresión local (Electron) falla porque la cola no existe en esta PC — el caso típico
+   * es una impresora agregada desde "Agregar desde sucursal", que vive en otro host.
+   */
+  probarEnBackend(impresoraId: number, servidor = true): Observable<boolean> {
+    return this.genericService.onCustomMutation(
+      this.imprimirPruebaEnImpresoraGQL,
+      { impresoraId },
+      servidor
+    );
+  }
+
+  /**
    * Instala una cola CUPS en un servidor apuntado por IP (no la config de Apollo). Manda la
    * mutation por HTTP directo a http://<servidorIp>:<servidorPort>/graphql con el token del
    * servidor destino. Se usa al COMPARTIR la impresora local: el servidor (central o filial)
@@ -130,6 +147,33 @@ export class ImpresoraService {
           throw new Error(res.errors[0]?.message || 'Error GraphQL en el servidor');
         }
         return res?.data?.instalarImpresoraCups === true;
+      }),
+    );
+  }
+
+  /**
+   * Lista las colas CUPS ya instaladas en una SUCURSAL elegida, consultando directo por IP (no los
+   * dos Apollo clients fijos de central/local). Se usa para "Agregar desde sucursal": el backend
+   * filial de esa sucursal ya expone `impresorasDelSistema` con el mismo login del usuario (sin
+   * credenciales de sistema operativo, sin instalar nada). El puerto lo escribe el usuario porque
+   * puede variar entre sucursales.
+   */
+  delSistemaEnServidorPorIp(sucursalIp: string, sucursalPort: string | number): Observable<string[]> {
+    const url = `http://${sucursalIp}:${sucursalPort}/graphql`;
+    const token = localStorage.getItem('token') || '';
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/json',
+      Authorization: `Token ${token}`,
+    });
+    const body = {
+      query: 'query { data: impresorasDelSistema }',
+    };
+    return this.http.post<any>(url, body, { headers }).pipe(
+      map((res) => {
+        if (res?.errors?.length) {
+          throw new Error(res.errors[0]?.message || 'Error GraphQL en la sucursal');
+        }
+        return res?.data?.data ?? [];
       }),
     );
   }

--- a/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.html
+++ b/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.html
@@ -18,6 +18,10 @@
         <mat-icon>refresh</mat-icon>
         Actualizar
       </button>
+      <button mat-stroked-button color="primary" (click)="agregarDesdeSucursal()" aria-label="Agregar impresoras desde una sucursal">
+        <mat-icon>store</mat-icon>
+        Agregar desde sucursal
+      </button>
       <button mat-raised-button color="primary" (click)="agregarNuevo()" aria-label="Agregar nueva impresora">
         <mat-icon>add</mat-icon>
         Nueva impresora

--- a/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.ts
+++ b/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.ts
@@ -24,6 +24,7 @@ import {
 } from '../impresora.model';
 import { ImpresoraService } from '../impresora.service';
 import { AdicionarImpresoraDialogComponent } from '../adicionar-impresora-dialog/adicionar-impresora-dialog.component';
+import { AgregarDesdeSucursalDialogComponent } from '../agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component';
 import { ElectronService } from '../../../../commons/core/electron/electron.service';
 
 interface ImpresoraVista {
@@ -174,6 +175,18 @@ export class ListImpresorasComponent implements OnInit {
       });
   }
 
+  agregarDesdeSucursal(): void {
+    this.matDialog
+      .open(AgregarDesdeSucursalDialogComponent, { width: '640px', disableClose: true })
+      .afterClosed()
+      .pipe(untilDestroyed(this))
+      .subscribe((res) => {
+        if (res === true) {
+          this.recargar();
+        }
+      });
+  }
+
   editarItem(impresora: Impresora): void {
     this.matDialog
       .open(AdicionarImpresoraDialogComponent, { data: { impresora }, width: '640px', disableClose: true })
@@ -197,12 +210,13 @@ export class ListImpresorasComponent implements OnInit {
   }
 
   probar(impresora: Impresora): void {
-    // El ticket de prueba se genera e imprime 100% en el frontend (Electron), SIN ningún backend:
-    // el ESC/POS lo arma Electron con los datos de la impresora y lo manda a la impresora local a
-    // esta PC (RED por socket TCP, CUPS/USB por `lp -d <cola> -o raw`). El backend solo instala
-    // impresoras compartidas; nunca genera ni imprime.
+    // El ticket de prueba se intenta primero 100% en el frontend (Electron): el ESC/POS lo arma
+    // Electron con los datos de la impresora y lo manda a la impresora local a esta PC (RED por
+    // socket TCP, CUPS/USB por `lp -d <cola> -o raw`). Si esa cola no existe en esta PC (típico de
+    // una impresora agregada vía "Agregar desde sucursal", que vive en el CUPS de otro host), se
+    // reintenta por el backend (`PrintRouterService`), que rutea al host dueño de la impresora.
     if (!this.electronService.isElectron) {
-      this.notificarFallo(impresora, 'la impresión requiere la app de escritorio');
+      this.probarPorBackend(impresora);
       return;
     }
     this.electronService.printTestLocal({
@@ -221,7 +235,23 @@ export class ListImpresorasComponent implements OnInit {
           if (res?.success) {
             this.notificarEnviado(impresora);
           } else {
-            this.notificarFallo(impresora, res?.error);
+            this.probarPorBackend(impresora);
+          }
+        },
+        error: () => this.probarPorBackend(impresora),
+      });
+  }
+
+  /** Respaldo de "Probar" vía backend, para impresoras que no viven físicamente en esta PC. */
+  private probarPorBackend(impresora: Impresora): void {
+    this.impresoraService.probarEnBackend(impresora.id)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (ok) => {
+          if (ok) {
+            this.notificarEnviado(impresora);
+          } else {
+            this.notificarFallo(impresora, 'verificá que la sucursal esté online y la cola exista');
           }
         },
         error: (e) => this.notificarFallo(impresora, e?.message),
@@ -270,7 +300,7 @@ export class ListImpresorasComponent implements OnInit {
     return i?.colaCups ?? (i?.conexion ?? '');
   }
 
-  @HostListener('window:resize', ['$event'])
+  @HostListener('window:resize')
   onResize() {
     this.calcularColumnas();
   }

--- a/src/app/modules/empresarial/sucursal/graphql/graphql-query.ts
+++ b/src/app/modules/empresarial/sucursal/graphql/graphql-query.ts
@@ -16,6 +16,7 @@ export const sucursalesQuery = gql
       deposito
       ip
       puerto
+      puertoServidor
       direccion
       nroDelivery
       depositoPredeterminado
@@ -51,6 +52,7 @@ export const sucursalesSearch = gql
         }
         ip
         puerto
+        puertoServidor
         direccion
         nroDelivery
         depositoPredeterminado
@@ -79,6 +81,7 @@ export const sucursalesSearchConFiltros = gql
       deposito
       ip
       puerto
+      puertoServidor
       direccion
       nroDelivery
       isConfigured
@@ -102,6 +105,7 @@ export const sucursalQuery = gql
       }
       ip
       puerto
+      puertoServidor
       direccion
       nroDelivery
       depositoPredeterminado
@@ -122,6 +126,7 @@ export const sucursalActualQuery = gql
       }
       ip
       puerto
+      puertoServidor
       direccion
       nroDelivery
       depositoPredeterminado
@@ -143,6 +148,7 @@ export const saveSucursal = gql
         }
         ip
         puerto
+        puertoServidor
         direccion
         nroDelivery
         depositoPredeterminado
@@ -183,6 +189,7 @@ export const sucursalesByNombreQuery = gql`
         }
         ip
         puerto
+        puertoServidor
         direccion
         nroDelivery
         depositoPredeterminado

--- a/src/app/modules/empresarial/sucursal/sucursal.model.ts
+++ b/src/app/modules/empresarial/sucursal/sucursal.model.ts
@@ -13,6 +13,9 @@ export class Sucursal {
   activo: boolean
   ip: string
   puerto: number
+  /** Puerto del backend GraphQL de esta sucursal (filial), usado por el servidor para rutear
+   * impresión y otras operaciones proxy. Puede variar por instalación (ver PrintRouterService). */
+  puertoServidor: number
   creadoEn: Date;
   usuario: Usuario;
   codigoEstablecimientoFactura: string
@@ -35,6 +38,7 @@ export class Sucursal {
       creadoEn: dateToString(this.creadoEn),
       ip: this.ip,
       puerto: this.puerto,
+      puertoServidor: this.puertoServidor,
       direccion: this.direccion,
       nroDelivery: this.nroDelivery,
       isConfigured: this.isConfigured

--- a/src/app/modules/financiero/factura-legal/factura-legal.service.ts
+++ b/src/app/modules/financiero/factura-legal/factura-legal.service.ts
@@ -30,6 +30,8 @@ import { CancelarFacturaLegalGQL } from "./graphql/cancelarFacturaLegal";
 import { SaveFacturaLegalToFilialGQL, SaveFacturaLegalToFilialResponse } from "./graphql/saveFacturaLegalToFilial";
 import { DescargarXmlFacturaElectronicaGQL } from "./graphql/descargarXmlFacturaElectronica";
 import { DescargarPdfFacturaElectronicaGQL } from "./graphql/descargarPdfFacturaElectronica";
+import { ImprimirTicketFacturaEnImpresoraGQL } from "./graphql/imprimirTicketFacturaEnImpresora";
+import { ImprimirPdfFacturaEnImpresoraGQL } from "./graphql/imprimirPdfFacturaEnImpresora";
 
 @Injectable({
   providedIn: "root",
@@ -55,7 +57,9 @@ export class FacturaLegalService {
     private cancelarFacturaLegalGQL: CancelarFacturaLegalGQL,
     private saveFacturaLegalToFilialGQL: SaveFacturaLegalToFilialGQL,
     private descargarXmlFacturaElectronicaGQL: DescargarXmlFacturaElectronicaGQL,
-    private descargarPdfFacturaElectronicaGQL: DescargarPdfFacturaElectronicaGQL
+    private descargarPdfFacturaElectronicaGQL: DescargarPdfFacturaElectronicaGQL,
+    private imprimirTicketFacturaEnImpresoraGQL: ImprimirTicketFacturaEnImpresoraGQL,
+    private imprimirPdfFacturaEnImpresoraGQL: ImprimirPdfFacturaEnImpresoraGQL
   ) {}
 
   onSaveFactura(
@@ -342,6 +346,41 @@ export class FacturaLegalService {
     return this.genericService.onCustomQuery(
       this.descargarPdfFacturaElectronicaGQL,
       { id, sucId },
+      servidor
+    );
+  }
+
+  /**
+   * "Imprimir en la sucursal": genera el mismo ticket de "Reimprimir" pero lo manda a una
+   * impresora registrada (posiblemente en otra sucursal) vía PrintRouterService, en vez de
+   * imprimir local. Aditivo, no reemplaza onReimprimirFactura.
+   */
+  onImprimirTicketFacturaEnImpresora(
+    facturaId: number,
+    sucId: number,
+    impresoraId: number,
+    servidor: boolean = true
+  ): Observable<boolean> {
+    return this.genericService.onCustomMutation(
+      this.imprimirTicketFacturaEnImpresoraGQL,
+      { facturaId, sucId, impresoraId },
+      servidor
+    );
+  }
+
+  /**
+   * "Imprimir en la sucursal": genera el mismo PDF de "Descargar/Abrir PDF" pero lo manda a una
+   * impresora registrada vía PrintRouterService. Aditivo, no reemplaza onDescargarPdfFacturaElectronica.
+   */
+  onImprimirPdfFacturaEnImpresora(
+    facturaId: number,
+    sucId: number,
+    impresoraId: number,
+    servidor: boolean = true
+  ): Observable<boolean> {
+    return this.genericService.onCustomMutation(
+      this.imprimirPdfFacturaEnImpresoraGQL,
+      { facturaId, sucId, impresoraId },
       servidor
     );
   }

--- a/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
@@ -400,6 +400,26 @@ export const descargarPdfFacturaElectronicaQuery = gql`
   }
 `;
 
+export const imprimirTicketFacturaEnImpresoraMutation = gql`
+  mutation ($facturaId: ID!, $sucId: ID!, $impresoraId: ID!) {
+    data: imprimirTicketFacturaEnImpresora(
+      facturaId: $facturaId
+      sucId: $sucId
+      impresoraId: $impresoraId
+    )
+  }
+`;
+
+export const imprimirPdfFacturaEnImpresoraMutation = gql`
+  mutation ($facturaId: ID!, $sucId: ID!, $impresoraId: ID!) {
+    data: imprimirPdfFacturaEnImpresora(
+      facturaId: $facturaId
+      sucId: $sucId
+      impresoraId: $impresoraId
+    )
+  }
+`;
+
 export const saveFacturaLegalToFilialQuery = gql`
   mutation saveFacturaLegalToFilial(
     $entity: FacturaLegalInput!

--- a/src/app/modules/financiero/factura-legal/graphql/imprimirPdfFacturaEnImpresora.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/imprimirPdfFacturaEnImpresora.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { imprimirPdfFacturaEnImpresoraMutation } from './graphql-query';
+
+export interface Response {
+  data: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ImprimirPdfFacturaEnImpresoraGQL extends Mutation<Response> {
+  document = imprimirPdfFacturaEnImpresoraMutation;
+}

--- a/src/app/modules/financiero/factura-legal/graphql/imprimirTicketFacturaEnImpresora.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/imprimirTicketFacturaEnImpresora.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { imprimirTicketFacturaEnImpresoraMutation } from './graphql-query';
+
+export interface Response {
+  data: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ImprimirTicketFacturaEnImpresoraGQL extends Mutation<Response> {
+  document = imprimirTicketFacturaEnImpresoraMutation;
+}

--- a/src/app/modules/financiero/factura-legal/imprimir-en-sucursal-dialog/imprimir-en-sucursal-dialog.component.html
+++ b/src/app/modules/financiero/factura-legal/imprimir-en-sucursal-dialog/imprimir-en-sucursal-dialog.component.html
@@ -1,0 +1,61 @@
+<div class="dialog-header">
+  <h2 mat-dialog-title>{{ titulo }}</h2>
+  <button mat-icon-button (click)="cancelar()" class="close-btn" tabindex="-1">
+    <mat-icon>close</mat-icon>
+  </button>
+</div>
+
+<mat-dialog-content class="dialog-content-modern" [class.con-vista-previa]="esPdf">
+  <p class="detalle">Factura Nro. {{ data.factura?.numeroFactura }} — revisá el documento y elegí la impresora donde va a salir.</p>
+
+  <div class="vista-previa" *ngIf="esPdf">
+    <div *ngIf="cargandoPdf" class="estado-vacio">
+      <mat-icon>hourglass_empty</mat-icon>
+      <span>Generando vista previa…</span>
+    </div>
+    <div *ngIf="!cargandoPdf && errorPdf" class="estado-vacio">
+      <mat-icon>error_outline</mat-icon>
+      <span>No se pudo generar el PDF para previsualizar.</span>
+    </div>
+    <ngx-extended-pdf-viewer
+      *ngIf="!cargandoPdf && pdfBase64"
+      [base64Src]="pdfBase64"
+      height="100%"
+      [textLayer]="true"
+      [showToolbar]="true"
+      [showPrintButton]="false"
+      [minifiedJSLibraries]="false"
+    ></ngx-extended-pdf-viewer>
+  </div>
+
+  <div class="lista-impresoras">
+    <div *ngIf="cargando" class="estado-vacio">
+      <mat-icon>hourglass_empty</mat-icon>
+      <span>Buscando impresoras…</span>
+    </div>
+
+    <div *ngIf="!cargando && impresoras.length === 0" class="estado-vacio">
+      <mat-icon>print_disabled</mat-icon>
+      <span>No hay impresoras {{ data.tipo === 'TERMICA' ? 'térmicas' : 'normales' }} registradas. Agregalas desde el módulo Impresoras.</span>
+    </div>
+
+    <div class="impresora-item" *ngFor="let imp of impresoras" [class.seleccionada]="imp.ref.id === seleccionadaId"
+      (click)="elegir(imp)">
+      <mat-icon class="impresora-icon">{{ data.tipo === 'TERMICA' ? 'receipt_long' : 'print' }}</mat-icon>
+      <div class="impresora-info">
+        <span class="impresora-nombre">{{ imp.nombre }}</span>
+        <span class="impresora-sucursal">{{ imp.sucursalNombre }}</span>
+      </div>
+      <mat-icon *ngIf="imp.ref.id === seleccionadaId" class="check-icon">check_circle</mat-icon>
+    </div>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="dialog-actions-modern">
+  <button mat-button (click)="cancelar()" class="btn-cancelar">Cancelar</button>
+  <button mat-flat-button color="primary" (click)="confirmar()" class="btn-aceptar"
+    [disabled]="enviando || !seleccionadaId || (esPdf && (cargandoPdf || errorPdf))">
+    <mat-icon>{{ enviando ? 'hourglass_empty' : 'print' }}</mat-icon>
+    {{ enviando ? 'Enviando…' : 'Imprimir' }}
+  </button>
+</mat-dialog-actions>

--- a/src/app/modules/financiero/factura-legal/imprimir-en-sucursal-dialog/imprimir-en-sucursal-dialog.component.scss
+++ b/src/app/modules/financiero/factura-legal/imprimir-en-sucursal-dialog/imprimir-en-sucursal-dialog.component.scss
@@ -1,0 +1,133 @@
+:host {
+  display: block;
+  min-width: 480px;
+}
+
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 24px 0 24px;
+
+  h2 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 500;
+  }
+
+  .close-btn {
+    opacity: 0.6;
+    &:hover {
+      opacity: 1;
+    }
+  }
+}
+
+.dialog-content-modern {
+  padding: 20px 24px !important;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 60vh;
+
+  &.con-vista-previa {
+    max-height: 75vh;
+  }
+}
+
+.vista-previa {
+  height: 55vh;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  overflow: hidden;
+  position: relative;
+  margin-bottom: 8px;
+
+  .estado-vacio {
+    height: 100%;
+  }
+}
+
+.lista-impresoras {
+  overflow-y: auto;
+}
+
+.detalle {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  opacity: 0.8;
+}
+
+.estado-vacio {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 32px 0;
+  opacity: 0.7;
+  text-align: center;
+
+  mat-icon {
+    font-size: 32px;
+    height: 32px;
+    width: 32px;
+  }
+}
+
+.impresora-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid transparent;
+
+  &:hover {
+    background: rgba(63, 81, 181, 0.08);
+  }
+
+  &.seleccionada {
+    background: rgba(63, 81, 181, 0.15);
+    border-color: #3f51b5;
+  }
+
+  .impresora-icon {
+    opacity: 0.7;
+  }
+
+  .impresora-info {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
+  .impresora-nombre {
+    font-weight: 500;
+  }
+
+  .impresora-sucursal {
+    font-size: 12px;
+    opacity: 0.6;
+  }
+
+  .check-icon {
+    color: #3f51b5;
+  }
+}
+
+.dialog-actions-modern {
+  padding: 16px 24px 24px !important;
+  margin-bottom: 0;
+
+  .btn-cancelar {
+    margin-right: 8px;
+  }
+
+  .btn-aceptar {
+    padding: 0 24px;
+    mat-icon {
+      margin-right: 8px;
+    }
+  }
+}

--- a/src/app/modules/financiero/factura-legal/imprimir-en-sucursal-dialog/imprimir-en-sucursal-dialog.component.ts
+++ b/src/app/modules/financiero/factura-legal/imprimir-en-sucursal-dialog/imprimir-en-sucursal-dialog.component.ts
@@ -1,0 +1,167 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import {
+  NotificacionColor,
+  NotificacionSnackbarService,
+} from '../../../../notificacion-snackbar.service';
+import { Impresora, TipoImpresora } from '../../../configuracion/impresoras/impresora.model';
+import { ImpresoraService } from '../../../configuracion/impresoras/impresora.service';
+import { FacturaLegal } from '../factura-legal.model';
+import { FacturaLegalService } from '../factura-legal.service';
+
+export interface ImprimirEnSucursalData {
+  tipo: TipoImpresora;
+  factura: FacturaLegal;
+}
+
+interface ImpresoraVista {
+  ref: Impresora;
+  nombre: string;
+  sucursalNombre: string;
+}
+
+/**
+ * "Imprimir en la sucursal": elige una impresora ya registrada (de cualquier sucursal, vía
+ * "Agregar desde sucursal" o alta manual) y manda ahí el ticket o el PDF de la factura, sin pasar
+ * por Reimprimir/Descargar PDF (aditivo, no los reemplaza).
+ */
+@UntilDestroy()
+@Component({
+  selector: 'app-imprimir-en-sucursal-dialog',
+  templateUrl: './imprimir-en-sucursal-dialog.component.html',
+  styleUrls: ['./imprimir-en-sucursal-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ImprimirEnSucursalDialogComponent implements OnInit {
+
+  private impresoraService = inject(ImpresoraService);
+  private facturaLegalService = inject(FacturaLegalService);
+  private notificacion = inject(NotificacionSnackbarService);
+  private cdr = inject(ChangeDetectorRef);
+  private dialogRef = inject(MatDialogRef<ImprimirEnSucursalDialogComponent>);
+
+  impresoras: ImpresoraVista[] = [];
+  seleccionadaId: number = null;
+  cargando = false;
+  enviando = false;
+  titulo: string;
+  esPdf: boolean;
+
+  // Vista previa del PDF antes de mandarlo a imprimir (no aplica al ticket térmico).
+  pdfBase64: string = null;
+  cargandoPdf = false;
+  errorPdf = false;
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: ImprimirEnSucursalData) {
+    this.esPdf = data.tipo === 'NORMAL';
+    this.titulo = this.esPdf ? 'Imprimir PDF en sucursal' : 'Imprimir ticket en sucursal';
+  }
+
+  ngOnInit(): void {
+    this.cargarImpresoras();
+    if (this.esPdf) {
+      this.cargarVistaPrevia();
+    }
+  }
+
+  private cargarImpresoras(): void {
+    this.cargando = true;
+    this.cdr.markForCheck();
+    this.impresoraService.buscarConPagina('', 0, 100, true)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (res) => {
+          this.impresoras = (res?.content ?? [])
+            .filter((i) => i.tipo === this.data.tipo && i.activo)
+            .map((i) => ({
+              ref: i,
+              nombre: i.nombre,
+              sucursalNombre: i.sucursal ? `${i.sucursal.id} - ${i.sucursal.nombre}` : 'Sin sucursal',
+            }));
+          this.cargando = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.impresoras = [];
+          this.cargando = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  /** Trae el mismo PDF que "Abrir PDF", para que se pueda revisar antes de mandarlo a imprimir. */
+  private cargarVistaPrevia(): void {
+    const sucId = this.data.factura.sucursalId ?? this.data.factura.sucursal?.id;
+    this.cargandoPdf = true;
+    this.errorPdf = false;
+    this.cdr.markForCheck();
+    this.facturaLegalService.onDescargarPdfFacturaElectronica(this.data.factura.id, sucId, true)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (base64) => {
+          this.pdfBase64 = base64 || null;
+          this.errorPdf = !base64;
+          this.cargandoPdf = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.pdfBase64 = null;
+          this.errorPdf = true;
+          this.cargandoPdf = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  elegir(imp: ImpresoraVista): void {
+    this.seleccionadaId = imp.ref.id;
+    this.cdr.markForCheck();
+  }
+
+  confirmar(): void {
+    if (!this.seleccionadaId) { return; }
+    const facturaId = this.data.factura.id;
+    const sucId = this.data.factura.sucursalId ?? this.data.factura.sucursal?.id;
+    this.enviando = true;
+    this.cdr.markForCheck();
+
+    const obs = this.data.tipo === 'TERMICA'
+      ? this.facturaLegalService.onImprimirTicketFacturaEnImpresora(facturaId, sucId, this.seleccionadaId)
+      : this.facturaLegalService.onImprimirPdfFacturaEnImpresora(facturaId, sucId, this.seleccionadaId);
+
+    obs.pipe(untilDestroyed(this)).subscribe({
+      next: (ok) => {
+        this.enviando = false;
+        if (ok) {
+          this.notificacion.notification$.next({
+            texto: 'Impresión enviada a la sucursal.',
+            color: NotificacionColor.success,
+            duracion: 3,
+          });
+          this.dialogRef.close(true);
+          return;
+        }
+        this.notificacion.notification$.next({
+          texto: 'No se pudo imprimir: verificá que la sucursal esté online y la impresora exista.',
+          color: NotificacionColor.warn,
+          duracion: 5,
+        });
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.enviando = false;
+        this.notificacion.notification$.next({
+          texto: 'No se pudo imprimir en la sucursal.',
+          color: NotificacionColor.warn,
+          duracion: 5,
+        });
+        this.cdr.markForCheck();
+      },
+    });
+  }
+
+  cancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.html
+++ b/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.html
@@ -430,6 +430,17 @@
               <mat-icon>open_in_browser</mat-icon>
               <span>Abrir PDF</span>
             </button>
+            <button mat-menu-item (click)="onImprimirTicketEnSucursal(factura)">
+              <mat-icon>receipt_long</mat-icon>
+              <span>Imprimir ticket en sucursal</span>
+            </button>
+            <button
+              mat-menu-item
+              (click)="onImprimirPdfEnSucursal(factura)"
+              [disabled]="!esElectronica(factura)">
+              <mat-icon>store</mat-icon>
+              <span>Imprimir PDF en sucursal</span>
+            </button>
           </mat-menu>
         </td>
       </ng-container>

--- a/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
+++ b/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
@@ -13,6 +13,7 @@ import { CargandoDialogService } from "../../../../shared/components/cargando-di
 import { ConfirmDialogComponent } from "../../../../shared/components/confirm-dialog/confirm-dialog.component";
 import { NotificacionSnackbarService } from "../../../../notificacion-snackbar.service";
 import { Sucursal } from "../../../empresarial/sucursal/sucursal.model";
+import { ImprimirEnSucursalDialogComponent } from "../imprimir-en-sucursal-dialog/imprimir-en-sucursal-dialog.component";
 import { SucursalService } from "../../../empresarial/sucursal/sucursal.service";
 import { FacturaLegalService } from "../factura-legal.service";
 import { AddFacturaLegalDialogComponent } from "../add-factura-legal-dialog/add-factura-legal-dialog.component";
@@ -724,5 +725,25 @@ export class ListFacturaLegalComponent implements OnInit {
           this.notificacionService.openAlgoSalioMal('Error al cargar el PDF');
         }
       });
+  }
+
+  /** "Imprimir en la sucursal" (ticket): aditivo, no reemplaza onImprimir (Reimprimir). */
+  onImprimirTicketEnSucursal(factura: FacturaLegal): void {
+    this.matDialog.open(ImprimirEnSucursalDialogComponent, {
+      data: { tipo: 'TERMICA', factura },
+      width: '520px',
+    });
+  }
+
+  /** "Imprimir en la sucursal" (PDF A4): aditivo, no reemplaza onDescargarPdf/onAbrirPdf. */
+  onImprimirPdfEnSucursal(factura: FacturaLegal): void {
+    if (!this.esElectronica(factura)) {
+      this.notificacionService.openAlgoSalioMal('Esta factura no es electrónica');
+      return;
+    }
+    this.matDialog.open(ImprimirEnSucursalDialogComponent, {
+      data: { tipo: 'NORMAL', factura },
+      width: '900px',
+    });
   }
 }

--- a/src/app/modules/financiero/financiero.module.ts
+++ b/src/app/modules/financiero/financiero.module.ts
@@ -25,6 +25,7 @@ import { ListFacturaLegalComponent } from './factura-legal/list-factura-legal/li
 import { AddFacturaLegalDialogComponent } from './factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component';
 import { EditFacturaLegalDialogComponent } from './factura-legal/edit-factura-legal-dialog/edit-factura-legal-dialog.component';
 import { EditFacturaLegalItemComponent } from './factura-legal/edit-factura-legal-item/edit-factura-legal-item.component';
+import { ImprimirEnSucursalDialogComponent } from './factura-legal/imprimir-en-sucursal-dialog/imprimir-en-sucursal-dialog.component';
 import { AddVentaCreditoDialogComponent } from './venta-credito/add-venta-credito-dialog/add-venta-credito-dialog.component';
 import { ListVentaCreditoComponent } from './venta-credito/list-venta-credito/list-venta-credito.component';
 import { FinancieroConfiguracionDialogComponent } from './financiero-configuracion-dialog/financiero-configuracion-dialog.component';
@@ -52,6 +53,7 @@ import { ScanTerminalPosDialogComponent } from "./terminal-pos/scan-terminal-pos
 import { TerminalPosDashboard } from "./terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component";
 import { ListVentaTarjetaComponent } from "./venta-tarjeta/list-venta-tarjeta/list-venta-tarjeta.component";
 import { ConfiguracionVentaTarjetaDialogComponent } from "./venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component";
+import { NgxExtendedPdfViewerModule } from "ngx-extended-pdf-viewer";
 
 @NgModule({
   declarations: [
@@ -76,6 +78,7 @@ import { ConfiguracionVentaTarjetaDialogComponent } from "./venta-tarjeta/config
     AddFacturaLegalDialogComponent,
     EditFacturaLegalDialogComponent,
     EditFacturaLegalItemComponent,
+    ImprimirEnSucursalDialogComponent,
     AddVentaCreditoDialogComponent,
     ListVentaCreditoComponent,
     FinancieroConfiguracionDialogComponent,
@@ -113,7 +116,8 @@ import { ConfiguracionVentaTarjetaDialogComponent } from "./venta-tarjeta/config
     MaterialModule,
     SharedModule,
     FinancieroRoutingModule,
-    BootstrapModule
+    BootstrapModule,
+    NgxExtendedPdfViewerModule
   ],
 })
 export class FinancieroModule { }


### PR DESCRIPTION
## Summary
- "Agregar desde sucursal": nuevo diálogo en el módulo Impresoras que consulta por IP el backend de una filial elegida (reusando el login ya activo, sin credenciales de SO) y registra en el central las colas CUPS detectadas.
- "Probar" en Impresoras ahora hace fallback al backend (routing vía `PrintRouterService`) cuando la impresión local falla, en vez de fallar en silencio.
- Fix: mutation `imprimirPruebaEnImpresora` sin alias `data:` hacía que `onCustomMutation` siempre leyera `undefined` (reportaba fallo aunque hubiera funcionado).
- Lista de Facturas: dos items nuevos de menú, "Imprimir ticket en sucursal" e "Imprimir PDF en sucursal", que mandan el mismo contenido de Reimprimir/Descargar PDF a una impresora elegida (de cualquier sucursal) vía `PrintRouterService`. En modo PDF se muestra primero una vista previa (mismo visor que "Abrir PDF") antes de habilitar imprimir. 100% aditivo, no toca Reimprimir/Descargar PDF/Abrir PDF existentes.
- `Sucursal.puertoServidor` expuesto en el modelo/queries del frontend (ya existía end-to-end en el backend).

## Test plan
- [ ] `npm run check` (ya corrido en la sesión, sin errores)
- [ ] Módulo Impresoras → "Agregar desde sucursal" → elegir sucursal, IP autocompletada, tipear puerto → "Buscar colas del sistema" → agregar una cola
- [ ] "Probar" sobre esa impresora → debe imprimir en la filial remota
- [ ] Lista de Facturas → una factura → "Imprimir ticket en sucursal" y "Imprimir PDF en sucursal" (con vista previa) → confirmar que imprime en la sucursal elegida
- [ ] Repetir "Reimprimir" / "Descargar PDF" / "Abrir PDF" de siempre y confirmar que no cambiaron

Depende de los PRs equivalentes en `franco-system-backend-servidor` y `franco-system-backend-filial` (mismo nombre de branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)