### PR TITLE
feat(sucursal): puerto servidor en lista y edición

### DIFF
--- a/src/app/modules/empresarial/sucursal/edit-sucursal-dialog/edit-sucursal-dialog.component.html
+++ b/src/app/modules/empresarial/sucursal/edit-sucursal-dialog/edit-sucursal-dialog.component.html
@@ -67,7 +67,7 @@
       </div>
     </div>
 
-    <!-- IP y Puerto -->
+    <!-- IP y Puerto Postgres -->
     <div fxLayout="row" fxLayoutGap="10px">
       <div fxFlex="60%">
         <mat-form-field style="width: 100%">
@@ -83,7 +83,7 @@
       </div>
       <div fxFlex="40%">
         <mat-form-field style="width: 100%">
-          <mat-label>Puerto</mat-label>
+          <mat-label>Puerto Postgres</mat-label>
           <input
             matInput
             type="number"
@@ -93,6 +93,28 @@
             El puerto debe ser mayor o igual a 0
           </mat-error>
           <mat-error *ngIf="puertoControl.hasError('max')">
+            El puerto debe ser menor o igual a 65535
+          </mat-error>
+        </mat-form-field>
+      </div>
+    </div>
+
+    <!-- Puerto Servidor (HTTP/GraphQL de la filial) -->
+    <div fxLayout="row" fxLayoutGap="10px">
+      <div fxFlex="100%">
+        <mat-form-field style="width: 100%">
+          <mat-label>Puerto Servidor</mat-label>
+          <input
+            matInput
+            type="number"
+            [formControl]="puertoServidorControl"
+            placeholder="Ej. 8082"
+          />
+          <mat-hint>Puerto HTTP/GraphQL del backend de la sucursal</mat-hint>
+          <mat-error *ngIf="puertoServidorControl.hasError('min')">
+            El puerto debe ser mayor o igual a 0
+          </mat-error>
+          <mat-error *ngIf="puertoServidorControl.hasError('max')">
             El puerto debe ser menor o igual a 65535
           </mat-error>
         </mat-form-field>

--- a/src/app/modules/empresarial/sucursal/edit-sucursal-dialog/edit-sucursal-dialog.component.ts
+++ b/src/app/modules/empresarial/sucursal/edit-sucursal-dialog/edit-sucursal-dialog.component.ts
@@ -36,8 +36,13 @@ export class EditSucursalDialogComponent implements OnInit {
   ipControl = new FormControl(null, [
     Validators.pattern('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$')
   ]);
-  // Puerto control with range validation
+  // Puerto Postgres (replicación) con validación de rango
   puertoControl = new FormControl(null, [
+    Validators.min(0),
+    Validators.max(65535)
+  ]);
+  // Puerto HTTP/GraphQL del backend de la filial
+  puertoServidorControl = new FormControl(null, [
     Validators.min(0),
     Validators.max(65535)
   ]);
@@ -74,6 +79,7 @@ export class EditSucursalDialogComponent implements OnInit {
       codigoEstablecimientoFactura: this.codigoEstablecimientoFacturaControl,
       ip: this.ipControl,
       puerto: this.puertoControl,
+      puertoServidor: this.puertoServidorControl,
       // Add new fields to form group
       direccion: this.direccionControl,
       nroDelivery: this.nroDeliveryControl,
@@ -125,6 +131,7 @@ export class EditSucursalDialogComponent implements OnInit {
     this.codigoEstablecimientoFacturaControl.setValue(this.selectedSucursal.codigoEstablecimientoFactura);
     this.ipControl.setValue(this.selectedSucursal.ip);
     this.puertoControl.setValue(this.selectedSucursal.puerto);
+    this.puertoServidorControl.setValue(this.selectedSucursal.puertoServidor);
     this.direccionControl.setValue(this.selectedSucursal.direccion);
     this.nroDeliveryControl.setValue(this.selectedSucursal.nroDelivery);
     this.isConfiguredControl.setValue(this.selectedSucursal.isConfigured ?? false);
@@ -160,6 +167,7 @@ export class EditSucursalDialogComponent implements OnInit {
     this.selectedSucursal.codigoEstablecimientoFactura = this.codigoEstablecimientoFacturaControl.value?.toUpperCase();
     this.selectedSucursal.ip = this.ipControl.value;
     this.selectedSucursal.puerto = this.puertoControl.value;
+    this.selectedSucursal.puertoServidor = this.puertoServidorControl.value;
     this.selectedSucursal.direccion = this.direccionControl.value?.toUpperCase();
     this.selectedSucursal.nroDelivery = this.nroDeliveryControl.value?.toUpperCase();
     this.selectedSucursal.isConfigured = this.isConfiguredControl.value ?? false;

--- a/src/app/modules/empresarial/sucursal/list-sucursal/list-sucursal.component.html
+++ b/src/app/modules/empresarial/sucursal/list-sucursal/list-sucursal.component.html
@@ -104,6 +104,26 @@
         </td>
       </ng-container>
 
+      <!-- IP Column -->
+      <ng-container matColumnDef="ip">
+        <th mat-header-cell *matHeaderCellDef style="text-align: center">
+          IP
+        </th>
+        <td mat-cell *matCellDef="let sucursal" style="text-align: center">
+          {{ sucursal?.ip || '-' }}
+        </td>
+      </ng-container>
+
+      <!-- Puerto Servidor Column -->
+      <ng-container matColumnDef="puertoServidor">
+        <th mat-header-cell *matHeaderCellDef style="text-align: center">
+          Puerto Servidor
+        </th>
+        <td mat-cell *matCellDef="let sucursal" style="text-align: center">
+          {{ sucursal?.puertoServidor ?? '-' }}
+        </td>
+      </ng-container>
+
       <!-- Deposito Column -->
       <ng-container matColumnDef="deposito">
         <th mat-header-cell *matHeaderCellDef style="text-align: center">

--- a/src/app/modules/empresarial/sucursal/list-sucursal/list-sucursal.component.ts
+++ b/src/app/modules/empresarial/sucursal/list-sucursal/list-sucursal.component.ts
@@ -45,6 +45,8 @@ export class ListSucursalComponent implements OnInit {
     "nombre",
     "localizacion",
     "ciudad",
+    "ip",
+    "puertoServidor",
     "deposito",
     "depositoPredeterminado",
     "codigoEstablecimientoFactura",


### PR DESCRIPTION
## Summary
- Agrega el campo **Puerto Servidor** al formulario de editar/nueva sucursal para persistirlo en el servidor central (`puertoServidor`).
- Distingue el puerto Postgres del puerto HTTP/GraphQL de la filial en el formulario.
- Muestra columnas **IP** y **Puerto Servidor** en la lista de sucursales.

## Test plan
- [ ] Abrir Lista de sucursales y verificar columnas IP y Puerto Servidor
- [ ] Editar una sucursal, cargar Puerto Servidor (ej. 8082) y Guardar
- [ ] Recargar la lista y confirmar que el puerto quedó persistido
- [ ] Verificar que Puerto Postgres sigue guardando el puerto de replicación por separado


Made with [Cursor](https://cursor.com)