### PR TITLE
feat(impresoras): compartir colas agregadas desde sucursal al central

### DIFF
--- a/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.html
+++ b/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.html
@@ -71,6 +71,21 @@
       <mat-icon class="cola-icon">{{ c.esTermica ? 'receipt_long' : 'print' }}</mat-icon>
       <span class="cola-nombre">{{ c.nombre }}</span>
       <span class="cola-tipo">{{ c.esTermica ? 'Térmica' : 'Normal' }}</span>
+      <span class="chip-compartida" *ngIf="c.compartida">
+        <mat-icon inline>cloud_done</mat-icon> Compartida al central
+      </span>
+      <button
+        mat-stroked-button
+        type="button"
+        color="primary"
+        class="btn-compartir"
+        (click)="$event.stopPropagation(); compartir(c)"
+        [disabled]="c.compartiendo || c.compartida"
+        title="Compartir esta cola al servidor central (instala una cola proxy IPP en el central)"
+      >
+        <mat-icon>{{ c.compartiendo ? 'hourglass_empty' : 'cloud_upload' }}</mat-icon>
+        {{ c.compartiendo ? 'Compartiendo…' : (c.compartida ? 'Compartida' : 'Compartir') }}
+      </button>
     </div>
   </div>
 </mat-dialog-content>

--- a/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.scss
+++ b/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.scss
@@ -136,6 +136,22 @@
     font-size: 12px;
     opacity: 0.6;
   }
+
+  .chip-compartida {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: #4caf50;
+    white-space: nowrap;
+  }
+
+  .btn-compartir {
+    flex-shrink: 0;
+    mat-icon {
+      margin-right: 4px;
+    }
+  }
 }
 
 .dialog-actions-modern {

--- a/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.ts
+++ b/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.ts
@@ -8,6 +8,7 @@ import {
   NotificacionColor,
   NotificacionSnackbarService,
 } from '../../../../notificacion-snackbar.service';
+import { ConfiguracionService } from '../../../../shared/services/configuracion.service';
 import { Sucursal } from '../../../empresarial/sucursal/sucursal.model';
 import { SucursalService } from '../../../empresarial/sucursal/sucursal.service';
 import { ImpresoraInput } from '../impresora.model';
@@ -16,10 +17,17 @@ import { ImpresoraService } from '../impresora.service';
 // Palabras que sugieren que una impresora es termica / de tickets (mismo criterio que el resto del módulo).
 const REGEX_TERMICA = /ticket|term|thermal|\btm[-\s]?\d|xprinter|xp[-\s]?\d|pos.?58|pos.?80|58\s?mm|80\s?mm|receipt|bematech|epson\s?tm/i;
 
+// Host del SERVIDOR CENTRAL (sucursalId=0). Mismo criterio que adicionar-impresora-dialog: es el
+// host donde corre el backend central, no la "sucursal central" (que es una sucursal común).
+const HOST_SERVIDOR_CENTRAL_ID = 0;
+
 interface ColaVista {
   nombre: string;
   seleccionada: boolean;
   esTermica: boolean;
+  compartiendo: boolean;
+  /** true = ya se compartió e instaló como proxy en el central; se guarda apuntando ahí. */
+  compartida: boolean;
 }
 
 /**
@@ -39,6 +47,7 @@ export class AgregarDesdeSucursalDialogComponent implements OnInit {
 
   private sucursalService = inject(SucursalService);
   private impresoraService = inject(ImpresoraService);
+  private configuracionService = inject(ConfiguracionService);
   private notificacion = inject(NotificacionSnackbarService);
   private cdr = inject(ChangeDetectorRef);
   private dialogRef = inject(MatDialogRef<AgregarDesdeSucursalDialogComponent>);
@@ -105,6 +114,8 @@ export class AgregarDesdeSucursalDialogComponent implements OnInit {
             nombre,
             seleccionada: false,
             esTermica: REGEX_TERMICA.test(nombre),
+            compartiendo: false,
+            compartida: false,
           }));
           this.buscando = false;
           this.buscoAlMenosUnaVez = true;
@@ -134,6 +145,94 @@ export class AgregarDesdeSucursalDialogComponent implements OnInit {
   toggle(cola: ColaVista): void {
     cola.seleccionada = !cola.seleccionada;
     this.cdr.markForCheck();
+  }
+
+  /**
+   * Comparte esta cola (ya instalada en la sucursal) al servidor CENTRAL, igual que "Compartir al
+   * servidor" hace con una impresora local de escritorio:
+   * 1) Habilita el compartir CUPS en el backend de la SUCURSAL (por IP, sin credenciales de SO).
+   * 2) El central instala una cola proxy que apunta por IPP a la sucursal.
+   * Al guardar, esta cola queda registrada apuntando al central (no a la sucursal), porque desde
+   * ahí es de donde efectivamente se imprime.
+   */
+  compartir(cola: ColaVista): void {
+    const ip = (this.ipControl.value ?? '').trim();
+    const puerto = (this.puertoControl.value ?? '').trim();
+    if (!ip || !puerto) {
+      return;
+    }
+    const config = this.configuracionService.getConfig();
+    const centralIp = config?.serverCentralIp ?? '';
+    const centralPort = config?.serverCentralPort ?? '8081';
+    if (!centralIp) {
+      this.notificacion.notification$.next({
+        texto: 'No hay IP del servidor central configurada.',
+        color: NotificacionColor.warn,
+        duracion: 5,
+      });
+      return;
+    }
+    cola.compartiendo = true;
+    this.cdr.markForCheck();
+    this.impresoraService.compartirColaEnServidorPorIp(cola.nombre, ip, puerto, centralIp)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (ok) => {
+          if (!ok) {
+            cola.compartiendo = false;
+            this.notificacion.notification$.next({
+              texto: 'No se pudo habilitar el compartir en la sucursal (verificá permisos de CUPS ahí).',
+              color: NotificacionColor.warn,
+              duracion: 7,
+            });
+            this.cdr.markForCheck();
+            return;
+          }
+          const uri = `ipp://${ip}:631/printers/${cola.nombre}`;
+          this.impresoraService
+            .instalarEnServidorPorIp(cola.nombre, uri, cola.esTermica, centralIp, centralPort, true)
+            .pipe(untilDestroyed(this))
+            .subscribe({
+              next: (okInstalado) => {
+                cola.compartiendo = false;
+                if (okInstalado) {
+                  cola.compartida = true;
+                  cola.seleccionada = true;
+                  this.notificacion.notification$.next({
+                    texto: 'Cola compartida e instalada en el central: ' + cola.nombre,
+                    color: NotificacionColor.success,
+                    duracion: 4,
+                  });
+                } else {
+                  this.notificacion.notification$.next({
+                    texto: 'Se compartió en la sucursal pero el central no pudo instalarla.',
+                    color: NotificacionColor.warn,
+                    duracion: 7,
+                  });
+                }
+                this.cdr.markForCheck();
+              },
+              error: (e) => {
+                cola.compartiendo = false;
+                this.notificacion.notification$.next({
+                  texto: 'El central rechazó la instalación: ' + (e?.message || 'error desconocido'),
+                  color: NotificacionColor.warn,
+                  duracion: 8,
+                });
+                this.cdr.markForCheck();
+              },
+            });
+        },
+        error: (e) => {
+          cola.compartiendo = false;
+          this.notificacion.notification$.next({
+            texto: 'No se pudo contactar la sucursal para compartir: ' + (e?.message || 'error desconocido'),
+            color: NotificacionColor.warn,
+            duracion: 8,
+          });
+          this.cdr.markForCheck();
+        },
+      });
   }
 
   get seleccionadas(): ColaVista[] {
@@ -184,7 +283,8 @@ export class AgregarDesdeSucursalDialogComponent implements OnInit {
     input.nombre = cola.nombre.toUpperCase();
     input.activo = true;
     input.esPredeterminada = false;
-    input.sucursalId = sucursalId;
+    // Si se compartió, la cola vive en el central (cola proxy instalada ahí), no en la sucursal.
+    input.sucursalId = cola.compartida ? HOST_SERVIDOR_CENTRAL_ID : sucursalId;
     input.tipo = cola.esTermica ? 'TERMICA' : 'NORMAL';
     input.uso = 'TICKET';
     input.conexion = 'CUPS';

--- a/src/app/modules/configuracion/impresoras/impresora.service.ts
+++ b/src/app/modules/configuracion/impresoras/impresora.service.ts
@@ -177,4 +177,39 @@ export class ImpresoraService {
       }),
     );
   }
+
+  /**
+   * Habilita el compartir CUPS (por red, via IPP) de una cola ya instalada en una SUCURSAL, para
+   * que otro host (típicamente el central) pueda instalar una cola proxy que reenvíe hacia ella.
+   * Se usa desde "Agregar desde sucursal": la sucursal ya tiene la cola instalada localmente, pero
+   * no expuesta por red hasta que se llama esta mutation en SU PROPIO backend (por IP). Reutiliza
+   * el login actual, igual que {@link delSistemaEnServidorPorIp}.
+   */
+  compartirColaEnServidorPorIp(
+    nombreCola: string,
+    sucursalIp: string,
+    sucursalPort: string | number,
+    ipDestino: string,
+  ): Observable<boolean> {
+    const url = `http://${sucursalIp}:${sucursalPort}/graphql`;
+    const token = localStorage.getItem('token') || '';
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/json',
+      Authorization: `Token ${token}`,
+    });
+    const body = {
+      query:
+        'mutation($nombreCola: String!, $ipDestino: String) { '
+        + 'compartirColaCups(nombreCola: $nombreCola, ipDestino: $ipDestino) }',
+      variables: { nombreCola, ipDestino },
+    };
+    return this.http.post<any>(url, body, { headers }).pipe(
+      map((res) => {
+        if (res?.errors?.length) {
+          throw new Error(res.errors[0]?.message || 'Error GraphQL en la sucursal');
+        }
+        return res?.data?.compartirColaCups === true;
+      }),
+    );
+  }
 }


### PR DESCRIPTION
## Resumen
- En "Agregar desde sucursal", cada cola detectada tiene ahora un botón **Compartir** que:
  1. Llama a la mutation `compartirColaCups` (nueva, ver backends filial/central) directo al backend de la sucursal por IP, para habilitar `cupsctl --share-printers` ahí.
  2. Instala una cola proxy IPP en el central reutilizando `instalarEnServidorPorIp` (ya existente, usado por "Nueva impresora" > "Compartir al servidor").
  3. Al guardar, esa cola se registra apuntando al central (`sucursalId=0`) en vez de a la sucursal de origen — mismo comportamiento que al compartir una impresora física conectada a una PC de escritorio.
- Nuevo método `ImpresoraService.compartirColaEnServidorPorIp()`.

## Backends relacionados (requeridos para que esto funcione)
- https://github.com/GabFrank/franco-system-backend-filial/pull/71
- https://github.com/GabFrank/franco-system-backend-servidor/pull/141

## Cómo probarlo
1. Con los 2 PRs de backend desplegados (al menos en la sucursal de prueba y el central).
2. Abrir "Impresoras" → "Agregar desde sucursal", elegir una sucursal, buscar sus colas.
3. Click en "Compartir" en una cola → debe mostrar "Cola compartida e instalada en el central: ...".
4. Seleccionarla y "Agregar" → verificar que la impresora queda registrada con sucursal = central (id 0).
5. Probar imprimir un ticket de prueba desde esa impresora.

## Riesgo
Bajo-medio. No es retrocompatible con backends que no tengan la mutation `compartirColaCups` todavía (el botón "Compartir" fallaría con `FieldUndefined` contra un backend viejo) — requiere que los PRs de backend estén desplegados primero. No afecta el flujo existente de "Agregar desde sucursal" sin usar "Compartir".