### PR TITLE
feat(pdv): Finalizar con Factura ligado a la venta

### DIFF
--- a/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.html
+++ b/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.html
@@ -342,11 +342,12 @@
       <app-boton
         #imprimirBtb
         (focusEvent)="guardarSub.asObservable()"
-        nombre="Imprimir"
+        [nombre]="data?.ligarAVenta ? 'Finalizar venta' : 'Imprimir'"
         color="accent"
         [disableExpression]="
           rucControl.invalid ||
-          clienteDescripcionControl.invalid
+          clienteDescripcionControl.invalid ||
+          guardando
         "
         (clickEvent)="onGuardar()"
         class="btn-accion"

--- a/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
+++ b/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
@@ -54,6 +54,7 @@ export interface FacturaLegalData {
   ventaItemList: VentaItem[];
   descuento: number;
   isServidor?: boolean;
+  ligarAVenta?: boolean;
 }
 
 @UntilDestroy()
@@ -106,6 +107,8 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
   isNuevoCliente = false;
 
   isServidor = false;
+
+  guardando = false;
   
   // Listas para modo filial
   sucursalList: Sucursal[] = [];
@@ -675,6 +678,13 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
   }
 
   onGuardar() {
+    if (this.guardando) {
+      // Evita disparar un segundo guardado (factura duplicada, con su propio
+      // número correlativo) si el cajero toca el botón más de una vez
+      // mientras la primera solicitud todavía está en curso.
+      return;
+    }
+    this.guardando = true;
     // Si es modo filial, preguntar si desea imprimir (pero el guardado siempre ocurre)
     if (this.isServidor) {
       this.dialogoService
@@ -686,6 +696,11 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
         .subscribe((deseaImprimir) => {
           this.onSaveFactura(deseaImprimir);
         });
+    } else if (this.data?.ligarAVenta) {
+      // La venta está ligada a la factura por configuración: se guarda e
+      // imprime siempre, sin preguntar, para evitar una factura impresa
+      // sin que la venta se haya finalizado.
+      this.onSaveFactura();
     } else {
       // Modo normal (desde venta)
       this.dialogoService
@@ -697,6 +712,8 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
         .subscribe((res) => {
           if (res) {
             this.onSaveFactura(false);
+          } else {
+            this.guardando = false;
           }
         });
     }
@@ -882,10 +899,12 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
               });
             }
           } else {
+            this.guardando = false;
             this.notificacionService.openAlgoSalioMal("Error al guardar la factura en el servidor filial");
           }
         },
         error: (error) => {
+          this.guardando = false;
           console.error("Error al guardar factura en filial:", error);
           this.notificacionService.openAlgoSalioMal("Error al guardar la factura en el servidor filial: " + (error.message || "Error desconocido"));
         },
@@ -945,7 +964,13 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
         next: (resLocal: TimbradoDetalle) => {
           if (resLocal != null) {
             this.handleFacturaSuccess(resLocal);
+          } else {
+            this.guardando = false;
           }
+        },
+        error: () => {
+          this.guardando = false;
+          this.notificacionService.openAlgoSalioMal("Error al guardar la factura en el servidor local");
         },
       });
   }
@@ -956,6 +981,7 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
     this.matDialogRef.close({
       facturado: true,
       cliente: this.selectedCliente,
+      facturaLegalId: res?.facturaLegalId,
     });
   }
 }

--- a/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta-dialog.component.html
+++ b/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta-dialog.component.html
@@ -1,0 +1,35 @@
+<h2 mat-dialog-title>Configuración de Facturación</h2>
+
+<mat-dialog-content>
+    <div fxLayout="column" fxLayoutGap="15px" style="margin-top: 10px;">
+        <div class="config-item">
+            <div class="config-item-info">
+                <div class="config-item-title">Finalizar venta al facturar</div>
+                <div class="config-item-desc">
+                    Cuando está activado, el botón de factura del punto de venta pasa a ser
+                    "Finalizar con Factura". Al generar la factura, la venta se finaliza
+                    automáticamente en la misma operación, evitando que una factura quede
+                    impresa sin que la venta se haya procesado.
+                    Si está desactivado, la factura se puede finalizar sin tener una venta realizada.
+                </div>
+            </div>
+            <div class="config-item-toggle">
+                <mat-slide-toggle
+                    [checked]="config.habilitado"
+                    (change)="onToggleHabilitado()"
+                    color="accent">
+                </mat-slide-toggle>
+                <span class="toggle-label" [class.active]="config.habilitado" [class.desactive]="!config.habilitado">
+                    {{ config.habilitado ? 'ACTIVADO' : 'DESACTIVADO' }}
+                </span>
+            </div>
+        </div>
+    </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+    <button mat-button (click)="onCancelar()">Cancelar</button>
+    <button mat-raised-button color="primary" (click)="onGuardar()">
+        <mat-icon>save</mat-icon> Guardar
+    </button>
+</mat-dialog-actions>

--- a/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta-dialog.component.scss
+++ b/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta-dialog.component.scss
@@ -1,0 +1,58 @@
+.config-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: border-color 0.2s ease;
+
+  &:hover {
+    border-color: #90caf9;
+  }
+}
+
+.config-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.config-item-title {
+  font-size: 18px;
+  font-weight: 500;
+  color: #e0e0e0;
+}
+
+.config-item-desc {
+  font-size: 15px;
+  color: #9e9e9e;
+  line-height: 1.4;
+}
+
+.config-item-toggle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 90px;
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #757575;
+  letter-spacing: 0.5px;
+  transition: color 0.2s ease;
+
+  &.active {
+    color: #81c784;
+  }
+
+  &.desactive {
+    color: #f44336;
+  }
+}

--- a/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta-dialog.component.ts
+++ b/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta-dialog.component.ts
@@ -1,0 +1,65 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MainService } from '../../../../main.service';
+import { NotificacionSnackbarService } from '../../../../notificacion-snackbar.service';
+import { ConfiguracionFacturaConVentaService } from './configuracion-factura-con-venta.service';
+import { ConfiguracionFacturaConVenta } from './configuracion-factura-con-venta.model';
+
+@Component({
+  selector: 'app-configuracion-factura-con-venta-dialog',
+  templateUrl: './configuracion-factura-con-venta-dialog.component.html',
+  styleUrls: ['./configuracion-factura-con-venta-dialog.component.scss']
+})
+export class ConfiguracionFacturaConVentaDialogComponent implements OnInit {
+
+  config: ConfiguracionFacturaConVenta = new ConfiguracionFacturaConVenta();
+  isLoading = true;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: MatDialogRef<ConfiguracionFacturaConVentaDialogComponent>,
+    private configuracionService: ConfiguracionFacturaConVentaService,
+    private notificacionService: NotificacionSnackbarService,
+    public mainService: MainService
+  ) { }
+
+  ngOnInit(): void {
+    this.configuracionService.onGetConfiguracion().subscribe({
+      next: (res) => {
+        if (res != null) {
+          Object.assign(this.config, res);
+        }
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+        this.notificacionService.openAlgoSalioMal('Error al cargar la configuración');
+      }
+    });
+  }
+
+  onToggleHabilitado(): void {
+    this.config.habilitado = !this.config.habilitado;
+  }
+
+  onGuardar(): void {
+    const input = this.config.toInput();
+    input.usuarioId = this.mainService.usuarioActual?.id;
+    this.configuracionService.onSaveConfiguracion(input).subscribe({
+      next: (res) => {
+        if (res != null) {
+          this.config = res;
+          this.notificacionService.openSucess('Configuración guardada correctamente');
+          this.dialogRef.close(this.config);
+        }
+      },
+      error: () => {
+        this.notificacionService.openAlgoSalioMal('Error al guardar la configuración');
+      }
+    });
+  }
+
+  onCancelar(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta.model.ts
+++ b/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta.model.ts
@@ -1,0 +1,23 @@
+import { Usuario } from "../../../personas/usuarios/usuario.model";
+
+export class ConfiguracionFacturaConVenta {
+  id: number;
+  habilitado: boolean;
+  usuario: Usuario;
+  creadoEn: Date;
+  modificadoEn: Date;
+
+  toInput(): ConfiguracionFacturaConVentaInput {
+    let input = new ConfiguracionFacturaConVentaInput();
+    input.id = this?.id;
+    input.habilitado = this?.habilitado;
+    input.usuarioId = this?.usuario?.id;
+    return input;
+  }
+}
+
+export class ConfiguracionFacturaConVentaInput {
+  id?: number;
+  habilitado?: boolean;
+  usuarioId?: number;
+}

--- a/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta.service.ts
+++ b/src/app/modules/financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { GenericCrudService } from '../../../../generics/generic-crud.service';
+import { ConfiguracionFacturaConVenta, ConfiguracionFacturaConVentaInput } from './configuracion-factura-con-venta.model';
+import { GetConfiguracionFacturaConVentaGQL } from '../graphql/getConfiguracionFacturaConVenta';
+import { SaveConfiguracionFacturaConVentaGQL } from '../graphql/saveConfiguracionFacturaConVenta';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfiguracionFacturaConVentaService {
+
+  constructor(
+    private genericCrudService: GenericCrudService,
+    private getConfiguracionGQL: GetConfiguracionFacturaConVentaGQL,
+    private saveConfiguracionGQL: SaveConfiguracionFacturaConVentaGQL
+  ) { }
+
+  onGetConfiguracion(servidor = true): Observable<ConfiguracionFacturaConVenta> {
+    return this.genericCrudService.onCustomQuery(this.getConfiguracionGQL, {}, servidor);
+  }
+
+  onSaveConfiguracion(input: ConfiguracionFacturaConVentaInput, servidor = true): Observable<ConfiguracionFacturaConVenta> {
+    return this.genericCrudService.onSave(this.saveConfiguracionGQL, input, null, null, servidor);
+  }
+}

--- a/src/app/modules/financiero/factura-legal/factura-legal-dashboard/factura-legal-dashboard.component.html
+++ b/src/app/modules/financiero/factura-legal/factura-legal-dashboard/factura-legal-dashboard.component.html
@@ -1,0 +1,16 @@
+<div fxLayout="row" style="width: 100%; height: 80%" fxLayoutAlign="center center">
+  <div fxFlex="60" fxLayout="column">
+    <div fxFlex fxLayout="row wrap" fxLayoutAlign="start start" fxLayoutGap="10px">
+      <div fxFlex="30%" style="height: 250px">
+        <app-boton nombre="Lista de facturas" icon="move_up" [iconSize]="4" (clickEvent)="onListaFacturas()"></app-boton>
+      </div>
+      <div fxFlex="30%" style="height: 250px" *ngIf="
+                mainService.usuarioActual?.roles.includes(
+                  ROLES.ADMIN
+                )
+              ">
+        <app-boton nombre="Configurar facturación" icon="tune" [iconSize]="4" (clickEvent)="onAbrirConfiguracion()"></app-boton>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/modules/financiero/factura-legal/factura-legal-dashboard/factura-legal-dashboard.component.ts
+++ b/src/app/modules/financiero/factura-legal/factura-legal-dashboard/factura-legal-dashboard.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from "@angular/core";
+import { TabService } from "../../../../layouts/tab/tab.service";
+import { Tab } from "../../../../layouts/tab/tab.model";
+import { MainService } from "../../../../main.service";
+import { ROLES } from "../../../personas/roles/roles.enum";
+import { MatDialog } from "@angular/material/dialog";
+import { ListFacturaLegalComponent } from "../list-factura-legal/list-factura-legal.component";
+import { ConfiguracionFacturaConVentaDialogComponent } from "../configuracion-factura-con-venta-dialog/configuracion-factura-con-venta-dialog.component";
+
+@Component({
+  selector: 'app-factura-legal-dashboard',
+  templateUrl: './factura-legal-dashboard.component.html',
+  styleUrls: ['./factura-legal-dashboard.component.scss']
+})
+export class FacturaLegalDashboard  implements OnInit{
+
+  readonly ROLES = ROLES;
+  ngOnInit(): void {
+    
+  }
+
+  constructor(
+    private tabService: TabService,
+    public mainService: MainService,
+    private matDialog: MatDialog
+  ) {}
+
+  onListaFacturas() {
+    this.tabService.addTab(new Tab(ListFacturaLegalComponent, 'Lista de facturas', null, FacturaLegalDashboard));
+  }
+
+  onAbrirConfiguracion() {
+    this.matDialog.open(ConfiguracionFacturaConVentaDialogComponent, {
+      width: '560px',
+      disableClose: false,
+      panelClass: 'custom-dialog-container'
+    });
+  }
+}

--- a/src/app/modules/financiero/factura-legal/factura-legal.service.ts
+++ b/src/app/modules/financiero/factura-legal/factura-legal.service.ts
@@ -32,6 +32,7 @@ import { DescargarXmlFacturaElectronicaGQL } from "./graphql/descargarXmlFactura
 import { DescargarPdfFacturaElectronicaGQL } from "./graphql/descargarPdfFacturaElectronica";
 import { ImprimirTicketFacturaEnImpresoraGQL } from "./graphql/imprimirTicketFacturaEnImpresora";
 import { ImprimirPdfFacturaEnImpresoraGQL } from "./graphql/imprimirPdfFacturaEnImpresora";
+import { VincularFacturaLegalAVentaGQL } from "./graphql/vincularFacturaLegalAVenta";
 
 @Injectable({
   providedIn: "root",
@@ -59,8 +60,21 @@ export class FacturaLegalService {
     private descargarXmlFacturaElectronicaGQL: DescargarXmlFacturaElectronicaGQL,
     private descargarPdfFacturaElectronicaGQL: DescargarPdfFacturaElectronicaGQL,
     private imprimirTicketFacturaEnImpresoraGQL: ImprimirTicketFacturaEnImpresoraGQL,
-    private imprimirPdfFacturaEnImpresoraGQL: ImprimirPdfFacturaEnImpresoraGQL
+    private imprimirPdfFacturaEnImpresoraGQL: ImprimirPdfFacturaEnImpresoraGQL,
+    private vincularFacturaLegalAVentaGQL: VincularFacturaLegalAVentaGQL
   ) {}
+
+  onVincularFacturaAVenta(
+    facturaLegalId: number,
+    ventaId: number,
+    servidor: boolean = false
+  ): Observable<any> {
+    return this.genericService.onCustomMutation(
+      this.vincularFacturaLegalAVentaGQL,
+      { facturaLegalId, ventaId },
+      servidor
+    );
+  }
 
   onSaveFactura(
     input: FacturaLegalInput,

--- a/src/app/modules/financiero/factura-legal/graphql/getConfiguracionFacturaConVenta.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/getConfiguracionFacturaConVenta.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { configuracionFacturaConVentaQuery } from './graphql-query';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class GetConfiguracionFacturaConVentaGQL extends Query<any> {
+    document = configuracionFacturaConVentaQuery;
+}

--- a/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
@@ -277,7 +277,19 @@ export const saveFacturaLegal = gql`
         rangoDesde
         rangoHasta
         numeroActual
+        facturaLegalId
       }
+  }
+`;
+
+export const vincularFacturaLegalAVenta = gql`
+  mutation vincularFacturaLegalAVenta($facturaLegalId: ID!, $ventaId: ID!) {
+    data: vincularFacturaLegalAVenta(facturaLegalId: $facturaLegalId, ventaId: $ventaId) {
+      id
+      venta {
+        id
+      }
+    }
   }
 `;
 
@@ -417,6 +429,36 @@ export const imprimirPdfFacturaEnImpresoraMutation = gql`
       sucId: $sucId
       impresoraId: $impresoraId
     )
+  }
+`;
+
+export const configuracionFacturaConVentaQuery = gql`
+  {
+    data: configuracionFacturaConVenta {
+      id
+      habilitado
+      usuario {
+        id
+        nickname
+      }
+      creadoEn
+      modificadoEn
+    }
+  }
+`;
+
+export const saveConfiguracionFacturaConVenta = gql`
+  mutation saveConfiguracionFacturaConVenta($entity: ConfiguracionFacturaConVentaInput!) {
+    data: saveConfiguracionFacturaConVenta(input: $entity) {
+      id
+      habilitado
+      usuario {
+        id
+        nickname
+      }
+      creadoEn
+      modificadoEn
+    }
   }
 `;
 

--- a/src/app/modules/financiero/factura-legal/graphql/saveConfiguracionFacturaConVenta.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/saveConfiguracionFacturaConVenta.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { saveConfiguracionFacturaConVenta } from './graphql-query';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class SaveConfiguracionFacturaConVentaGQL extends Mutation<any> {
+    document = saveConfiguracionFacturaConVenta;
+}

--- a/src/app/modules/financiero/factura-legal/graphql/vincularFacturaLegalAVenta.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/vincularFacturaLegalAVenta.ts
@@ -1,0 +1,10 @@
+import { Injectable } from "@angular/core";
+import { Mutation } from "apollo-angular";
+import { vincularFacturaLegalAVenta } from "./graphql-query";
+
+@Injectable({
+  providedIn: "root",
+})
+export class VincularFacturaLegalAVentaGQL extends Mutation<any> {
+  document = vincularFacturaLegalAVenta;
+}

--- a/src/app/modules/financiero/financiero.module.ts
+++ b/src/app/modules/financiero/financiero.module.ts
@@ -54,6 +54,8 @@ import { TerminalPosDashboard } from "./terminal-pos/terminal-pos-dashboard/term
 import { ListVentaTarjetaComponent } from "./venta-tarjeta/list-venta-tarjeta/list-venta-tarjeta.component";
 import { ConfiguracionVentaTarjetaDialogComponent } from "./venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component";
 import { NgxExtendedPdfViewerModule } from "ngx-extended-pdf-viewer";
+import { ConfiguracionFacturaConVentaDialogComponent } from "./factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta-dialog.component";
+import { FacturaLegalDashboard } from "./factura-legal/factura-legal-dashboard/factura-legal-dashboard.component";
 
 @NgModule({
   declarations: [
@@ -102,7 +104,9 @@ import { NgxExtendedPdfViewerModule } from "ngx-extended-pdf-viewer";
     ScanTerminalPosDialogComponent,
     TerminalPosDashboard,
     ListVentaTarjetaComponent,
-    ConfiguracionVentaTarjetaDialogComponent
+    ConfiguracionVentaTarjetaDialogComponent,
+    ConfiguracionFacturaConVentaDialogComponent,
+    FacturaLegalDashboard
 
   ],
   providers: [

--- a/src/app/modules/financiero/timbrado/timbrado.modal.ts
+++ b/src/app/modules/financiero/timbrado/timbrado.modal.ts
@@ -136,6 +136,7 @@ export class TimbradoDetalle {
     barrio: string
     direccion: string
     telefono: string
+    facturaLegalId: number
 
     toInput(): TimbradoDetallInput {
         let input = new TimbradoDetallInput;

--- a/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.css
+++ b/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.css
@@ -1,3 +1,8 @@
 .shrinking-mat-form-field ::ng-deep .mat-mdc-text-field-wrapper .mat-mdc-form-field-flex .mat-mdc-form-field-infix {
   transform: translateY(-10px) !important;
 }
+
+::ng-deep .btn-factura button,
+::ng-deep .btn-factura button div {
+  white-space: unset !important;
+}

--- a/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.html
+++ b/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.html
@@ -707,11 +707,12 @@
       <div fxFlex="12" style="height: 100%">
         <app-boton
           color="primary"
-          nombre="Factura (F12)"
+          [nombre]="finalizarConFacturaHabilitado ? 'Finalizar con Factura (F12)' : 'Factura (F12)'"
           [disableExpression]="false"
           (clickEvent)="onFactura()"
           icon="receipt"
           [iconSize]="2"
+          class="btn-factura"
         ></app-boton>
       </div>
 

--- a/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.ts
@@ -54,6 +54,7 @@ export interface PagoResponseData {
   ticket?: boolean;
   cliente?: Cliente;
   tarjetaPagos?: TarjetaPago[];
+  facturaLegalId?: number;
 }
 
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
@@ -77,6 +78,7 @@ import { BotonComponent } from "../../../../../shared/components/boton/boton.com
 import { MonedaService } from "../../../../financiero/moneda/moneda.service";
 import { ScanTerminalPosDialogComponent, ScanTerminalPosResult } from "../../../../financiero/terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component";
 import { ConfiguracionVentaTarjetaService } from "../../../../financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta.service";
+import { ConfiguracionFacturaConVentaService } from "../../../../financiero/factura-legal/configuracion-factura-con-venta-dialog/configuracion-factura-con-venta.service";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -122,6 +124,8 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
   facturado = false;
   selectedCliente: Cliente;
   isCredito = false;
+  finalizarConFacturaHabilitado = false;
+  facturaLegalId: number;
 
   selectedCurrency: any;
 
@@ -168,7 +172,8 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
     private formaPagoService: FormaPagoService,
     private cargandoDialog: CargandoDialogService,
     private ventaService: VentaService,
-    private configuracionVentaTarjetaService: ConfiguracionVentaTarjetaService
+    private configuracionVentaTarjetaService: ConfiguracionVentaTarjetaService,
+    private configuracionFacturaConVentaService: ConfiguracionFacturaConVentaService
   ) {
     this.formaPagoList = [];
     if (data.delivery != null) {
@@ -184,6 +189,14 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
     this.setPrecios();
     this.getFormaPagos();
     this.createForm();
+    this.configuracionFacturaConVentaService.onGetConfiguracion().subscribe({
+      next: (res) => {
+        this.finalizarConFacturaHabilitado = res?.habilitado === true;
+      },
+      error: () => {
+        this.finalizarConFacturaHabilitado = false;
+      }
+    });
     setTimeout(() => {
       this.setFocusToValorInput();
       this.cargandoDialog.closeDialog();
@@ -678,6 +691,7 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
       ticket,
       cliente: this.selectedCliente,
       tarjetaPagos,
+      facturaLegalId: this.facturaLegalId,
     };
     this.dialogRef.close(response);
   }
@@ -773,6 +787,20 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
   onPresupuesto() { }
 
   onFactura() {
+    if (this.isDialogOpen) {
+      // Evita abrir dos veces el diálogo de factura si el cajero toca el
+      // botón repetidas veces antes de que se registre el primer click.
+      return;
+    }
+    if (
+      this.finalizarConFacturaHabilitado &&
+      this.formGroup.controls.saldo.value != 0
+    ) {
+      this.notificacionSnackbar.openWarn(
+        "Debe completar el pago antes de finalizar con factura"
+      );
+      return;
+    }
     this.isDialogOpen = true;
     let venta = new Venta();
     let descuento = 0;
@@ -791,6 +819,7 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
           venta,
           ventaItemList: this.data.itemList,
           descuento,
+          ligarAVenta: this.finalizarConFacturaHabilitado,
         },
         width: "100%",
         height: "80vh",
@@ -800,8 +829,13 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
         if (res) {
           this.facturado = res?.facturado;
           this.selectedCliente = res?.cliente;
+          this.facturaLegalId = res?.facturaLegalId;
         }
         this.isDialogOpen = false;
+        if (res?.facturado && this.finalizarConFacturaHabilitado) {
+          this.onFinalizar();
+          return;
+        }
         setTimeout(() => {
           this.setFocusToValorInput();
         }, 0);

--- a/src/app/modules/pdv/comercial/venta-touch/venta-touch.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/venta-touch.component.ts
@@ -96,6 +96,7 @@ import { Delivery } from "../../../operaciones/delivery/delivery.model";
 import { DeliveryEstado } from "../../../operaciones/delivery/enums";
 import { VentaEstado } from "../../../operaciones/venta/enums/venta-estado.enums";
 import { VentaService } from "../../../operaciones/venta/venta.service";
+import { FacturaLegalService } from "../../../financiero/factura-legal/factura-legal.service";
 import { DeliveryService } from "./delivery-dialog/delivery.service";
 import {
   ListDeliveryComponent,
@@ -191,7 +192,8 @@ export class VentaTouchComponent implements OnInit, OnDestroy, AfterViewInit {
     private gastoService: GastoService,
     private movimientoStockService: MovimientoStockService,
     private puntoDeVentaService: PuntoDeVentaService,
-    private ventaTarjetaService: VentaTarjetaService
+    private ventaTarjetaService: VentaTarjetaService,
+    private facturaLegalService: FacturaLegalService
   ) {
     this.winHeigth = windowInfo.innerHeight + "px";
     this.winWidth = windowInfo.innerWidth + "px";
@@ -987,7 +989,8 @@ export class VentaTouchComponent implements OnInit, OnDestroy, AfterViewInit {
                 response.ticket == true,
                 !response?.facturado,
                 ventaCredito?.toInput(),
-                ventaCreditoCuotaInputList
+                ventaCreditoCuotaInputList,
+                response?.facturaLegalId
               ).subscribe((ventaRes) => { });
             }
             this.dialogReference = undefined;
@@ -1073,7 +1076,8 @@ export class VentaTouchComponent implements OnInit, OnDestroy, AfterViewInit {
     ticket,
     facturar?,
     ventaCreditoInput?,
-    ventaCreditoCuotaInputList?
+    ventaCreditoCuotaInputList?,
+    facturaLegalId?: number
   ): Observable<Venta> {
     if (facturar == null) {
       facturar = ticket == true;
@@ -1099,6 +1103,17 @@ export class VentaTouchComponent implements OnInit, OnDestroy, AfterViewInit {
               texto: "Venta guardada con éxito",
               duracion: 2,
             });
+            if (facturaLegalId != null) {
+              // La factura se generó manualmente antes de que la venta existiera
+              // (flujo "Finalizar con Factura"): se vincula ahora que ya tenemos el id.
+              this.facturaLegalService
+                .onVincularFacturaAVenta(facturaLegalId, res.id, false)
+                .pipe(untilDestroyed(this))
+                .subscribe({
+                  error: (err) =>
+                    console.error("Error al vincular factura a la venta:", err),
+                });
+            }
             if (ventaCreditoInput != null && ventaCreditoInput.clienteId != null) {
               const sucursalId = ventaCreditoInput.sucursalId || this.mainService.sucursalActual?.id;
               const personaId = venta.cliente?.persona?.id;

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -33,7 +33,6 @@ import { TransferenciaComponent } from './../../../modules/operaciones/transfere
 import { CompraDashboardComponent } from "../../../modules/operaciones/compra/compra-dashboard/compra-dashboard.component";
 import { ListSolicitudPagoComponent } from "../../../modules/operaciones/solicitud-pago/list-solicitud-pago/list-solicitud-pago.component";
 import { ListRetiroComponent } from "../../../modules/financiero/retiro/list-retiro/list-retiro.component";
-import { ListFacturaLegalComponent } from "../../../modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component";
 import { UsuarioService } from "../../../modules/personas/usuarios/usuario.service";
 import { InicioSesion } from "../../../modules/configuracion/models/inicio-sesion.model";
 import { ListSucursalComponent } from "../../../modules/empresarial/sucursal/list-sucursal/list-sucursal.component";
@@ -53,8 +52,8 @@ import { ListMarcacionComponent } from '../../../modules/administrativo/marcacio
 import { MarcarHorarioComponent } from '../../../modules/administrativo/marcacion/pages/marcar-horario/marcar-horario.component';
 import { VehiculosDashboardComponent } from '../../../modules/activos/dashboard/vehiculos-dashboard/vehiculos-dashboard.component';
 import { BienesDashboardComponent } from '../../../modules/activos/dashboard/bienes-dashboard/bienes-dashboard.component';
-import { ListTerminalPosComponent } from '../../../modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component';
 import { TerminalPosDashboard } from '../../../modules/financiero/terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component';
+import { FacturaLegalDashboard } from '../../../modules/financiero/factura-legal/factura-legal-dashboard/factura-legal-dashboard.component';
 
 
 interface BaseNavigationItem {
@@ -261,7 +260,7 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
         {
           name: 'Facturas',
           icon: 'receipt',
-          action: 'list-facturas',
+          action: 'factura-dashboard',
           visibilityRoles: [ROLES.ANALISIS_DE_CAJA]
         },
         {
@@ -721,8 +720,8 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
       case "list-retiros":
         this.openTabIfAuthorized(ROLES.ANALISIS_DE_CAJA, ListRetiroComponent, "Lista de retiros");
         break;
-      case "list-facturas":
-        this.openTabIfAuthorized(ROLES.ANALISIS_DE_CAJA, ListFacturaLegalComponent, "Lista de facturas");
+      case "factura-dashboard":
+        this.openTabIfAuthorized(ROLES.ANALISIS_DE_CAJA, FacturaLegalDashboard, "Factura dashboard");
         break;
       case "analisis-diferencias":
         this.openTabIfAuthorized(ROLES.ADMIN, AnalisisDiferenciaComponent, "Análisis de diferencias");


### PR DESCRIPTION
## Summary
- Nueva configuración global (activable/desactivable) que cambia el botón "Factura (F12)" del POS a "Finalizar con Factura", generando la factura legal manual y finalizando la venta en la misma operación.
- Resuelve el problema de facturas impresas sin que la venta se haya procesado (cajero podía cancelar/olvidarse de finalizar tras facturar).
- Guardas de reentrada (doble click / doble submit) para evitar facturas duplicadas.
- Nueva mutation `vincularFacturaLegalAVenta`: una vez persistida la Venta, se liga el `venta_id` a la FacturaLegal creada manualmente antes de que la venta existiera.

## Dependencias
Requiere los PRs correspondientes en:
- `franco-system-backend-servidor` (entidad `ConfiguracionFacturaConVenta`)
- `franco-system-backend-filial` (mutation `vincularFacturaLegalAVenta`, fix de facturación silenciosa duplicada)

## Test plan
- [ ] `npm run check` (AOT build) pasa sin errores
- [ ] Con la config desactivada: comportamiento de F12 sin cambios
- [ ] Con la config activada: F12 exige saldo en 0, abre diálogo de cliente ("Finalizar venta"), factura+venta se persisten juntas
- [ ] Confirmar que no se generan facturas duplicadas (un solo registro por venta, con `venta_id` poblado tras la vinculación)
- [ ] Probar con SIFEN habilitado (timbrado electrónico) — sin cambios en el DE generado

## Riesgo
Medio — toca el flujo central de cobro/facturación del POS (`pago-touch`, `venta-touch`), pero queda detrás de un flag desactivado por defecto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)