### PR TITLE
fix(impresoras): no pisar sucursalId al compartir cola al central

### DIFF
--- a/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.ts
+++ b/src/app/modules/configuracion/impresoras/agregar-desde-sucursal-dialog/agregar-desde-sucursal-dialog.component.ts
@@ -17,16 +17,12 @@ import { ImpresoraService } from '../impresora.service';
 // Palabras que sugieren que una impresora es termica / de tickets (mismo criterio que el resto del módulo).
 const REGEX_TERMICA = /ticket|term|thermal|\btm[-\s]?\d|xprinter|xp[-\s]?\d|pos.?58|pos.?80|58\s?mm|80\s?mm|receipt|bematech|epson\s?tm/i;
 
-// Host del SERVIDOR CENTRAL (sucursalId=0). Mismo criterio que adicionar-impresora-dialog: es el
-// host donde corre el backend central, no la "sucursal central" (que es una sucursal común).
-const HOST_SERVIDOR_CENTRAL_ID = 0;
-
 interface ColaVista {
   nombre: string;
   seleccionada: boolean;
   esTermica: boolean;
   compartiendo: boolean;
-  /** true = ya se compartió e instaló como proxy en el central; se guarda apuntando ahí. */
+  /** true = ya se compartió e instaló como proxy IPP en el central (flag informativo). */
   compartida: boolean;
 }
 
@@ -151,9 +147,13 @@ export class AgregarDesdeSucursalDialogComponent implements OnInit {
    * Comparte esta cola (ya instalada en la sucursal) al servidor CENTRAL, igual que "Compartir al
    * servidor" hace con una impresora local de escritorio:
    * 1) Habilita el compartir CUPS en el backend de la SUCURSAL (por IP, sin credenciales de SO).
-   * 2) El central instala una cola proxy que apunta por IPP a la sucursal.
-   * Al guardar, esta cola queda registrada apuntando al central (no a la sucursal), porque desde
-   * ahí es de donde efectivamente se imprime.
+   * 2) El central instala una cola proxy que apunta por IPP a la sucursal (util para imprimir
+   *    directo desde el SO de esa PC; la app NO depende de esta cola para imprimir).
+   * Al guardar, la impresora sigue registrada con `sucursalId` apuntando a la SUCURSAL real (no al
+   * central): así `PrintRouterService` sigue haciendo el proxy GraphQL correcto hacia la sucursal
+   * en vez de imprimir "local" contra la cola IPP-proxy del central (que quedaba colgada ante
+   * cualquier hiccup de red — "Unable to add document to print job"). `compartida` solo se guarda
+   * como flag informativo (`compartidaEnCentral`).
    */
   compartir(cola: ColaVista): void {
     const ip = (this.ipControl.value ?? '').trim();
@@ -283,14 +283,17 @@ export class AgregarDesdeSucursalDialogComponent implements OnInit {
     input.nombre = cola.nombre.toUpperCase();
     input.activo = true;
     input.esPredeterminada = false;
-    // Si se compartió, la cola vive en el central (cola proxy instalada ahí), no en la sucursal.
-    input.sucursalId = cola.compartida ? HOST_SERVIDOR_CENTRAL_ID : sucursalId;
+    // sucursalId siempre es el host REAL (donde vive físicamente la cola), se haya compartido o
+    // no: es lo que PrintRouterService usa para decidir si imprime local o hace proxy GraphQL.
+    input.sucursalId = sucursalId;
     input.tipo = cola.esTermica ? 'TERMICA' : 'NORMAL';
     input.uso = 'TICKET';
     input.conexion = 'CUPS';
     input.colaCups = cola.nombre;
     input.perfilPapel = cola.esTermica ? 'MM_58' : 'A4';
     input.columnas = 32;
+    // Solo informativo: indica que además existe una cola proxy IPP en el central.
+    input.compartidaEnCentral = cola.compartida;
     return input;
   }
 

--- a/src/app/modules/configuracion/impresoras/graphql/graphql-query.ts
+++ b/src/app/modules/configuracion/impresoras/graphql/graphql-query.ts
@@ -21,6 +21,7 @@ const CAMPOS = `
   altoMm
   marca
   codepage
+  compartidaEnCentral
   creadoEn
 `;
 

--- a/src/app/modules/configuracion/impresoras/impresora.model.ts
+++ b/src/app/modules/configuracion/impresoras/impresora.model.ts
@@ -31,6 +31,9 @@ export class Impresora {
   altoMm: number;
   marca: string;
   codepage: string;
+  /** true = ademas de vivir en `sucursal`, tiene una cola CUPS proxy (IPP) instalada en el
+   * central via "compartir al central" (informativo; `sucursal` sigue siendo el host real). */
+  compartidaEnCentral: boolean;
   creadoEn: Date;
   usuario: Usuario;
 
@@ -53,6 +56,7 @@ export class Impresora {
     input.altoMm = this?.altoMm;
     input.marca = this?.marca;
     input.codepage = this?.codepage;
+    input.compartidaEnCentral = this?.compartidaEnCentral;
     return input;
   }
 }
@@ -75,5 +79,6 @@ export class ImpresoraInput {
   altoMm?: number;
   marca?: string;
   codepage?: string;
+  compartidaEnCentral?: boolean;
   usuarioId?: number = null;
 }

--- a/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.html
+++ b/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.html
@@ -37,6 +37,8 @@
           <div class="sucursal-badge">
             <mat-icon>store</mat-icon>
             <span>{{ imp.sucursalNombre }}</span>
+            <mat-icon *ngIf="imp.compartidaEnCentral"
+              title="Además tiene una cola proxy IPP instalada en el central">cloud_done</mat-icon>
           </div>
 
           <div class="card-top" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="12px">

--- a/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.ts
+++ b/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.ts
@@ -40,6 +40,7 @@ interface ImpresoraVista {
   esPredeterminada: boolean;
   sucursalNombre: string;
   colorIndex: number;
+  compartidaEnCentral: boolean;
 }
 
 const PERFIL_LABEL: Record<PerfilPapel, string> = {
@@ -288,7 +289,8 @@ export class ListImpresorasComponent implements OnInit {
       activo: i?.activo === true,
       esPredeterminada: i?.esPredeterminada === true,
       sucursalNombre: i?.sucursal ? `${i.sucursal.id} - ${i.sucursal.nombre}` : 'Sin sucursal',
-      colorIndex: sucursalId % 6
+      colorIndex: sucursalId % 6,
+      compartidaEnCentral: i?.compartidaEnCentral === true,
     };
   }
 


### PR DESCRIPTION
## Summary
- "Compartir al central" (diálogo "Agregar desde sucursal") guardaba `sucursalId = 0` para una impresora que en realidad vive en una sucursal, lo que rompía el routing del backend (`PrintRouterService`): terminaba imprimiendo "local" en el central contra una cola CUPS-proxy IPP en vez de reenviar por GraphQL a la sucursal dueña — causaba jobs colgados ("Unable to add document to print job") al imprimir facturas/tickets a una impresora compartida.
- `sucursalId` ahora siempre es el host real. Se agrega `compartidaEnCentral` (informativo) al modelo/queries y un badge (ícono `cloud_done`) en `list-impresoras` para no perder esa información en la UI.

## PR hermanos (mismo fix, coordinar merge)
- `franco-system-backend-servidor`: https://github.com/GabFrank/franco-system-backend-servidor/pull/143
- `franco-system-backend-filial`: https://github.com/GabFrank/franco-system-backend-filial/pull/74 (incluye también un fix de performance en el cache de impresión)

## Test plan
- [ ] `npm run check` (ya corrido localmente, sin errores nuevos)
- [ ] Compartir una cola de una sucursal al central desde "Agregar desde sucursal", verificar que la impresora quede registrada con la sucursal real (no "Central") y con el badge de compartida visible
- [ ] Imprimir una factura desde el central a esa impresora compartida y confirmar que llega (antes quedaba colgada)
- [ ] Impresoras existentes no compartidas siguen funcionando igual

Riesgo: bajo.