### PR TITLE
fix(personas): cargar y mostrar email en minúsculas

### DIFF
--- a/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
+++ b/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
@@ -153,7 +153,12 @@ export const funcionarioQuery = gql`
       persona {
         id
         nombre
+        apodo
         telefono
+        email
+        direccion
+        sexo
+        socialMedia
         ciudad {
           id
           descripcion
@@ -204,7 +209,12 @@ export const funcionarioPorPersonaQuery = gql`
       persona {
         id
         nombre
+        apodo
         telefono
+        email
+        direccion
+        sexo
+        socialMedia
         ciudad {
           id
           descripcion

--- a/src/app/modules/personas/persona/adicionar-persona-dialog/adicionar-persona-dialog.component.html
+++ b/src/app/modules/personas/persona/adicionar-persona-dialog/adicionar-persona-dialog.component.html
@@ -161,7 +161,7 @@
     </div>
     <div fxFlex="50">
       <mat-form-field class="form-element" style="width: 90%">
-        <input #email matInput placeholder="Email" formControlName="email" (keyup.enter)="guardar.focus()"/>
+        <input #email matInput placeholder="Email" class="email-input" formControlName="email" (input)="onEmailInput($event)" (keyup.enter)="guardar.focus()"/>
       </mat-form-field>
     </div>
   </div>

--- a/src/app/modules/personas/persona/adicionar-persona-dialog/adicionar-persona-dialog.component.scss
+++ b/src/app/modules/personas/persona/adicionar-persona-dialog/adicionar-persona-dialog.component.scss
@@ -1,3 +1,9 @@
 input {
     text-transform: uppercase;
 }
+
+// Anula el uppercase !important global de styles.scss
+:host ::ng-deep input.email-input,
+:host ::ng-deep .email-input.mat-mdc-input-element {
+    text-transform: lowercase !important;
+}

--- a/src/app/modules/personas/persona/adicionar-persona-dialog/adicionar-persona-dialog.component.ts
+++ b/src/app/modules/personas/persona/adicionar-persona-dialog/adicionar-persona-dialog.component.ts
@@ -64,7 +64,7 @@ export class AdicionarPersonaDialogComponent implements OnInit {
       this.apodoControl.setValue(this.selectedPersona?.apodo)
       this.nacimientoControl.setValue(this.selectedPersona?.nacimiento != null ? new Date(this.selectedPersona?.nacimiento) : null);
       this.documentoControl.setValue(this.selectedPersona?.documento)
-      this.emailControl.setValue(this.selectedPersona?.email)
+      this.emailControl.setValue(this.selectedPersona?.email?.toLowerCase() ?? null)
       this.direccionControl.setValue(this.selectedPersona?.direccion)
       this.telefonoControl.setValue(this.selectedPersona?.telefono)
       this.socialMediaControl.setValue(this.selectedPersona?.socialMedia)
@@ -97,6 +97,15 @@ export class AdicionarPersonaDialogComponent implements OnInit {
           this.nacimientoControl.setValue(null)
         }
       })
+    }
+  }
+
+  onEmailInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const lower = input.value?.toLowerCase() ?? '';
+    if (input.value !== lower) {
+      input.value = lower;
+      this.emailControl.setValue(lower, { emitEvent: false });
     }
   }
 
@@ -134,7 +143,7 @@ export class AdicionarPersonaDialogComponent implements OnInit {
     persona.apodo = this.apodoControl.value;
     persona.direccion = this.direccionControl.value;
     persona.documento = this.documentoControl.value;
-    persona.email = this.emailControl.value;
+    persona.email = this.emailControl.value?.toLowerCase()?.trim() ?? null;
     persona.nacimiento = this.nacimientoControl.value;
     persona.telefono = this.telefonoControl.value;
     persona.ciudad = this.selectedCiudad;

--- a/src/app/modules/personas/persona/graphql/graphql-query.ts
+++ b/src/app/modules/personas/persona/graphql/graphql-query.ts
@@ -10,6 +10,7 @@ query ($page: Int) {
       sexo
       direccion
       documento
+      email
       telefono
       socialMedia
       creadoEn
@@ -93,6 +94,7 @@ export const personaQuery = gql`
       apodo
       nacimiento
       documento
+      email
       sexo
       direccion
       telefono


### PR DESCRIPTION
## Summary
- Incluye `email` (y apodo, dirección, sexo, socialMedia) en queries de funcionario para que el diálogo de persona los cargue al reabrir.
- Normaliza el email a minúsculas al escribir y al guardar en el diálogo de persona.
- Anula el `text-transform: uppercase !important` global solo en el campo email.

## Test plan
- [ ] Abrir un funcionario, editar persona y verificar que el email existente se muestra.
- [ ] Escribir un email en mayúsculas y verificar que se ve en minúsculas.
- [ ] Guardar, reabrir el diálogo y confirmar que el email persiste en minúsculas.

Made with [Cursor](https://cursor.com)