### PR TITLE
fix(graphql): cortar carga a 3s cuando el servidor central esta offline

### DIFF
--- a/src/app/generics/generic-crud.service.ts
+++ b/src/app/generics/generic-crud.service.ts
@@ -65,19 +65,26 @@ export class GenericCrudService {
           }
         )
         .pipe(untilDestroyed(this))
-        .subscribe((res) => {
-          this.cargandoService.closeDialog(requestId);
-          this.isLoading = false;
-          if (res.errors == null) {
-            obs.next(res.data["data"]);
-            obs.complete();
-          } else {
-            this.notificacionSnackBar.notification$.next({
-              texto: "Ups! Algo salió mal: " + res.errors[0].message + res,
-              color: NotificacionColor.danger,
-              duracion: 3,
-            });
-          }
+        .subscribe({
+          next: (res) => {
+            this.cargandoService.closeDialog(requestId);
+            this.isLoading = false;
+            if (res.errors == null) {
+              obs.next(res.data["data"]);
+              obs.complete();
+            } else {
+              this.notificacionSnackBar.notification$.next({
+                texto: "Ups! Algo salió mal: " + res.errors[0].message + res,
+                color: NotificacionColor.danger,
+                duracion: 3,
+              });
+            }
+          },
+          error: () => {
+            // Ej: servidor central offline. Cerrar el spinner en vez de colgarse.
+            this.cargandoService.closeDialog(requestId);
+            this.isLoading = false;
+          },
         });
     });
   }
@@ -232,21 +239,29 @@ export class GenericCrudService {
           },
         })
         .pipe(untilDestroyed(this))
-        .subscribe((res) => {
-          if (cargando == true) {
-            this.cargandoService.closeDialog(requestId);
-          }
-          this.isLoading = false;
-          if (res.errors == null) {
-            obs.next(res.data["data"]);
-            obs.complete();
-          } else {
-            this.notificacionSnackBar.notification$.next({
-              texto: "Ups! Algo salió mal: " + res.errors[0].message + res,
-              color: NotificacionColor.danger,
-              duracion: 3,
-            });
-          }
+        .subscribe({
+          next: (res) => {
+            if (cargando == true) {
+              this.cargandoService.closeDialog(requestId);
+            }
+            this.isLoading = false;
+            if (res.errors == null) {
+              obs.next(res.data["data"]);
+              obs.complete();
+            } else {
+              this.notificacionSnackBar.notification$.next({
+                texto: "Ups! Algo salió mal: " + res.errors[0].message + res,
+                color: NotificacionColor.danger,
+                duracion: 3,
+              });
+            }
+          },
+          error: () => {
+            if (cargando == true) {
+              this.cargandoService.closeDialog(requestId);
+            }
+            this.isLoading = false;
+          },
         });
     });
   }
@@ -481,27 +496,34 @@ export class GenericCrudService {
           },
         })
         .pipe(untilDestroyed(this))
-        .subscribe((res) => {
-          this.isLoading = false;
-          this.cargandoService.closeDialog(requestId);
-          if (res.errors == null) {
-            obs.next(res.data["data"]);
-            obs.complete();
-            this.notificacionSnackBar.notification$.next({
-              texto: "Guardado con éxito",
-              duracion: 2,
-              color: NotificacionColor.success,
-            });
-          } else {
-            this.notificacionSnackBar.notification$.next({
-              texto:
-                "Ups! Algo salió mal en operacion: " +
-                res.errors[0].message +
-                res,
-              color: NotificacionColor.danger,
-              duracion: 5,
-            });
-          }
+        .subscribe({
+          next: (res) => {
+            this.isLoading = false;
+            this.cargandoService.closeDialog(requestId);
+            if (res.errors == null) {
+              obs.next(res.data["data"]);
+              obs.complete();
+              this.notificacionSnackBar.notification$.next({
+                texto: "Guardado con éxito",
+                duracion: 2,
+                color: NotificacionColor.success,
+              });
+            } else {
+              this.notificacionSnackBar.notification$.next({
+                texto:
+                  "Ups! Algo salió mal en operacion: " +
+                  res.errors[0].message +
+                  res,
+                color: NotificacionColor.danger,
+                duracion: 5,
+              });
+            }
+          },
+          error: (error) => {
+            this.isLoading = false;
+            this.cargandoService.closeDialog(requestId);
+            obs.error(error);
+          },
         });
     });
   }
@@ -535,28 +557,34 @@ export class GenericCrudService {
             }
           )
           .pipe(untilDestroyed(this))
-          .subscribe((res) => {
-            this.cargandoService.closeDialog(requestId);
-            if (res.errors == null) {
-              this.notificacionSnackBar.notification$.next({
-                texto: "Eliminado con éxito",
-                duracion: 2,
-                color: NotificacionColor.success,
-              });
-              obs.next(true);
-              obs.complete();
-            } else {
-              {
+          .subscribe({
+            next: (res) => {
+              this.cargandoService.closeDialog(requestId);
+              if (res.errors == null) {
                 this.notificacionSnackBar.notification$.next({
-                  texto:
-                    "Ups! Ocurrió algun problema al eliminar: " +
-                    res.errors[0].message,
-                  duracion: 3,
-                  color: NotificacionColor.danger,
+                  texto: "Eliminado con éxito",
+                  duracion: 2,
+                  color: NotificacionColor.success,
                 });
-                obs.next(null);
+                obs.next(true);
+                obs.complete();
+              } else {
+                {
+                  this.notificacionSnackBar.notification$.next({
+                    texto:
+                      "Ups! Ocurrió algun problema al eliminar: " +
+                      res.errors[0].message,
+                    duracion: 3,
+                    color: NotificacionColor.danger,
+                  });
+                  obs.next(null);
+                }
               }
-            }
+            },
+            error: () => {
+              this.cargandoService.closeDialog(requestId);
+              obs.next(null);
+            },
           });
       } else {
         this.dialogoService
@@ -581,29 +609,36 @@ export class GenericCrudService {
                     },
                   }
                 )
-                .subscribe((res) => {
-                  this.cargandoService.closeDialog(requestId);
-                  if (res.errors == null) {
-                    this.notificacionSnackBar.notification$.next({
-                      texto: "Eliminado con éxito",
-                      duracion: 2,
-                      color: NotificacionColor.success,
-                    });
-                    obs.next(true);
-                    obs.complete();
-                  } else {
-                    {
+                .subscribe({
+                  next: (res) => {
+                    this.cargandoService.closeDialog(requestId);
+                    if (res.errors == null) {
                       this.notificacionSnackBar.notification$.next({
-                        texto:
-                          "Ups! Ocurrió algun problema al eliminar: " +
-                          res.errors[0].message,
-                        duracion: 3,
-                        color: NotificacionColor.danger,
+                        texto: "Eliminado con éxito",
+                        duracion: 2,
+                        color: NotificacionColor.success,
                       });
-                      obs.next(null);
+                      obs.next(true);
                       obs.complete();
+                    } else {
+                      {
+                        this.notificacionSnackBar.notification$.next({
+                          texto:
+                            "Ups! Ocurrió algun problema al eliminar: " +
+                            res.errors[0].message,
+                          duracion: 3,
+                          color: NotificacionColor.danger,
+                        });
+                        obs.next(null);
+                        obs.complete();
+                      }
                     }
-                  }
+                  },
+                  error: () => {
+                    this.cargandoService.closeDialog(requestId);
+                    obs.next(null);
+                    obs.complete();
+                  },
                 });
             } else {
             }
@@ -642,28 +677,34 @@ export class GenericCrudService {
             }
           )
           .pipe(untilDestroyed(this))
-          .subscribe((res) => {
-            this.cargandoService.closeDialog(requestId);
-            if (res.errors == null) {
-              this.notificacionSnackBar.notification$.next({
-                texto: "Eliminado con éxito",
-                duracion: 2,
-                color: NotificacionColor.success,
-              });
-              obs.next(true);
-              obs.complete();
-            } else {
-              {
+          .subscribe({
+            next: (res) => {
+              this.cargandoService.closeDialog(requestId);
+              if (res.errors == null) {
                 this.notificacionSnackBar.notification$.next({
-                  texto:
-                    "Ups! Ocurrió algun problema al eliminar: " +
-                    res.errors[0].message,
-                  duracion: 3,
-                  color: NotificacionColor.danger,
+                  texto: "Eliminado con éxito",
+                  duracion: 2,
+                  color: NotificacionColor.success,
                 });
-                obs.next(null);
+                obs.next(true);
+                obs.complete();
+              } else {
+                {
+                  this.notificacionSnackBar.notification$.next({
+                    texto:
+                      "Ups! Ocurrió algun problema al eliminar: " +
+                      res.errors[0].message,
+                    duracion: 3,
+                    color: NotificacionColor.danger,
+                  });
+                  obs.next(null);
+                }
               }
-            }
+            },
+            error: () => {
+              this.cargandoService.closeDialog(requestId);
+              obs.next(null);
+            },
           });
       } else {
         this.dialogoService
@@ -688,29 +729,36 @@ export class GenericCrudService {
                     },
                   }
                 )
-                .subscribe((res) => {
-                  this.cargandoService.closeDialog(requestId);
-                  if (res.errors == null) {
-                    this.notificacionSnackBar.notification$.next({
-                      texto: "Eliminado con éxito",
-                      duracion: 2,
-                      color: NotificacionColor.success,
-                    });
-                    obs.next(true);
-                    obs.complete();
-                  } else {
-                    {
+                .subscribe({
+                  next: (res) => {
+                    this.cargandoService.closeDialog(requestId);
+                    if (res.errors == null) {
                       this.notificacionSnackBar.notification$.next({
-                        texto:
-                          "Ups! Ocurrió algun problema al eliminar: " +
-                          res.errors[0].message,
-                        duracion: 3,
-                        color: NotificacionColor.danger,
+                        texto: "Eliminado con éxito",
+                        duracion: 2,
+                        color: NotificacionColor.success,
                       });
-                      obs.next(null);
+                      obs.next(true);
                       obs.complete();
+                    } else {
+                      {
+                        this.notificacionSnackBar.notification$.next({
+                          texto:
+                            "Ups! Ocurrió algun problema al eliminar: " +
+                            res.errors[0].message,
+                          duracion: 3,
+                          color: NotificacionColor.danger,
+                        });
+                        obs.next(null);
+                        obs.complete();
+                      }
                     }
-                  }
+                  },
+                  error: () => {
+                    this.cargandoService.closeDialog(requestId);
+                    obs.next(null);
+                    obs.complete();
+                  },
                 });
             } else {
             }
@@ -766,18 +814,24 @@ export class GenericCrudService {
           }
         )
         .pipe(untilDestroyed(this))
-        .subscribe((res) => {
-          this.cargandoService.closeDialog(requestId);
-          if (res.errors == null) {
-            obs.next(res.data["data"]);
-            obs.complete();
-          } else {
-            this.notificacionSnackBar.notification$.next({
-              texto: "Ups! Algo salió mal: " + res.errors[0].message,
-              color: NotificacionColor.danger,
-              duracion: 3,
-            });
-          }
+        .subscribe({
+          next: (res) => {
+            this.cargandoService.closeDialog(requestId);
+            if (res.errors == null) {
+              obs.next(res.data["data"]);
+              obs.complete();
+            } else {
+              this.notificacionSnackBar.notification$.next({
+                texto: "Ups! Algo salió mal: " + res.errors[0].message,
+                color: NotificacionColor.danger,
+                duracion: 3,
+              });
+            }
+          },
+          error: () => {
+            this.cargandoService.closeDialog(requestId);
+            this.isLoading = false;
+          },
         });
     });
   }
@@ -813,35 +867,46 @@ export class GenericCrudService {
           }
         )
         .pipe(untilDestroyed(this))
-        .subscribe((res) => {
-          this.cargandoService.closeDialog(requestId);
-          if (res.errors == null) {
-            this.notificacionBar.notification$.next({
-              texto: "Guardado con éxito!!",
-              color: NotificacionColor.success,
-              duracion: 2,
-            });
-            if (error) {
-              obs.next({ data: res.data["data"] });
-              obs.complete();
+        .subscribe({
+          next: (res) => {
+            this.cargandoService.closeDialog(requestId);
+            if (res.errors == null) {
+              this.notificacionBar.notification$.next({
+                texto: "Guardado con éxito!!",
+                color: NotificacionColor.success,
+                duracion: 2,
+              });
+              if (error) {
+                obs.next({ data: res.data["data"] });
+                obs.complete();
+              } else {
+                obs.next(res.data["data"]);
+                obs.complete();
+              }
             } else {
-              obs.next(res.data["data"]);
-              obs.complete();
+              this.notificacionBar.notification$.next({
+                texto: "Ups!! Algo salio mal: " + res.errors[0].message,
+                color: NotificacionColor.danger,
+                duracion: 5,
+              });
+              if (error) {
+                obs.next({ error: res.errors });
+                obs.complete();
+              } else {
+                obs.next(null);
+                obs.complete();
+              }
             }
-          } else {
-            this.notificacionBar.notification$.next({
-              texto: "Ups!! Algo salio mal: " + res.errors[0].message,
-              color: NotificacionColor.danger,
-              duracion: 5,
-            });
+          },
+          error: (err) => {
+            this.cargandoService.closeDialog(requestId);
             if (error) {
-              obs.next({ error: res.errors });
-              obs.complete();
+              obs.next({ error: err });
             } else {
               obs.next(null);
-              obs.complete();
             }
-          }
+            obs.complete();
+          },
         });
     });
   }

--- a/src/app/modules/login/login.service.ts
+++ b/src/app/modules/login/login.service.ts
@@ -16,7 +16,7 @@ export interface LoginResponse {
 
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Observable, of } from "rxjs";
-import { catchError, tap } from 'rxjs/operators';
+import { catchError, tap, timeout } from 'rxjs/operators';
 import { DeviceDetectorService } from "ngx-device-detector";
 import { generateUUID } from "../../commons/core/utils/string-utils";
 import { ElectronService } from "../../commons/core/electron/electron.service";
@@ -209,6 +209,9 @@ export class LoginService {
       nickname: nickname,
       password: password
     }, this.httpOptions).pipe(
+      // Si el central está offline, no dejar esta petición colgada: se corta a
+      // los 3s y el catchError la resuelve silenciosamente (es fire-and-forget).
+      timeout(3000),
       tap((res: any) => {
         if (res && res.token) {
           localStorage.setItem("token_central", res.token);

--- a/src/app/shared/services/graphql-connection.service.ts
+++ b/src/app/shared/services/graphql-connection.service.ts
@@ -34,6 +34,12 @@ export class GraphqlConnectionService {
   private isDev = !environment.production;
   private isLocal = true;
 
+  // Tiempo máximo que se espera a una operación HTTP contra el servidor CENTRAL
+  // cuando este NO está confirmado como online. Evita que la app quede
+  // "Cargando..." de forma indefinida si el central está offline (sin internet,
+  // caído, etc.). Solo aplica al central; el servidor local no se ve afectado.
+  private readonly centralOfflineTimeoutMs = 3000;
+
   constructor(
     private configService: ConfiguracionService,
     private notificationService: NotificacionSnackbarService
@@ -214,7 +220,11 @@ export class GraphqlConnectionService {
     }
 
     // Create an HTTP link for central server (always required)
+    // El centralTimeoutLink va primero: corta la operación en pocos segundos si
+    // el central está offline, en vez de dejar la request colgada. Solo se aplica
+    // a este link (central), nunca al local ni a las subscriptions.
     const http2 = ApolloLink.from([
+      this.createCentralTimeoutLink(),
       basic,
       auth,
       httpLink.create({
@@ -314,6 +324,66 @@ export class GraphqlConnectionService {
 
         return () => {
           controller.abort();
+          subscription.unsubscribe();
+        };
+      });
+    });
+  }
+
+  /**
+   * Link de timeout SOLO para operaciones HTTP contra el servidor central.
+   *
+   * Cuando el central no está confirmado como online (WebSocket central no
+   * conectado), limita cada operación a `centralOfflineTimeoutMs`. Al vencer,
+   * emite un resultado con `errors` (mismo patrón que createAbortableLink) en
+   * lugar de lanzar un error: así los métodos de GenericCrudService cierran el
+   * spinner "Cargando..." de inmediato (todos llaman a closeDialog en su handler
+   * `next`) y muestran el aviso, en vez de quedar colgados hasta 60s / 5min.
+   *
+   * Si el central SÍ está online (cloudConnectionStatusSub === true) no se impone
+   * ningún límite: se preserva el comportamiento normal para operaciones válidas.
+   */
+  private createCentralTimeoutLink(): ApolloLink {
+    return new ApolloLink((operation, forward) => {
+      // Central confirmado online: no imponer timeout artificial.
+      if (cloudConnectionStatusSub.value === true) {
+        return forward(operation);
+      }
+
+      return new Observable((observer) => {
+        let finished = false;
+
+        const timer = setTimeout(() => {
+          if (finished) return;
+          finished = true;
+          // Emitir un error de red: GenericCrudService lo maneja cerrando el
+          // diálogo de carga (mismo camino que un ERR_CONNECTION_REFUSED).
+          const err: any = new Error("El servidor central no responde (offline).");
+          err.networkError = true;
+          observer.error(err);
+        }, this.centralOfflineTimeoutMs);
+
+        const subscription = forward(operation).subscribe({
+          next: (result) => {
+            if (finished) return;
+            observer.next(result);
+          },
+          error: (error) => {
+            if (finished) return;
+            finished = true;
+            clearTimeout(timer);
+            observer.error(error);
+          },
+          complete: () => {
+            if (finished) return;
+            finished = true;
+            clearTimeout(timer);
+            observer.complete();
+          },
+        });
+
+        return () => {
+          clearTimeout(timer);
           subscription.unsubscribe();
         };
       });


### PR DESCRIPTION
## Qué resuelve

Cuando el **servidor central** está caído o inalcanzable (sin internet, host down, etc.), la app quedaba en **"Cargando..." de forma indefinida** (o hasta 60s/5min). Causas:

1. El link HTTP al central (`http2`) no tenía **ningún timeout**.
2. Varios métodos de `GenericCrudService` hacían `.subscribe(next)` **sin manejador de `error`**, por lo que al fallar la request nunca llamaban a `closeDialog()` y el spinner quedaba colgado.

## Cambios

- **`graphql-connection.service.ts`**: nuevo `centralTimeoutLink` insertado **solo** en la cadena del central (`http2`). Cuando el central **no está confirmado online** (`cloudConnectionStatusSub !== true`), corta la operación a los **3s** con un error de red. No afecta al servidor local ni a las subscriptions, y **no impone límite cuando el central está online** (cero regresión).
- **`generic-crud.service.ts`**: agregado manejo de `error` (cierra el diálogo de carga) en `onGetAll`, `onCustomSub`, `onSaveCustom`, `onGetByFecha`, `onSaveConDetalle`, `onDelete` y `onDeleteWithSucId`. Así **cualquier** fallo al central (conexión rechazada o timeout) cierra el spinner de inmediato. No se modificó el camino de éxito.
- **`login.service.ts`**: `timeout(3s)` en `autenticarEnCentral` para no dejar colgada la autenticación en el central (ya era fire-and-forget con `catchError`).

## Cómo probarlo

1. Iniciar la app con el **servidor central apagado** (en este entorno el central está en `localhost:8086`).
2. Hacer login normal contra el servidor local.
3. Verificar que el overlay "Cargando..." se cierra en **≤3s** (o al instante si la conexión es rechazada), en vez de quedar colgado.
4. Con el central **encendido**, verificar que todo funciona igual que antes (sin cortes a los 3s).

## Riesgo

**Bajo.** El timeout solo actúa cuando el central no está confirmado online; el servidor local, las subscriptions y las queries a un central online no se ven afectados. Los cambios en `generic-crud` solo **agregan** limpieza en el camino de error, sin tocar el de éxito.

## Impacto en auto-update

Ninguno. No se tocan `installer.nsh`, `electron-builder.json`, manifests YAML ni nombres de artefactos.

## Verificación

`npm run check` (build AOT de producción) pasa con **EXIT 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)