### PR TITLE
feat(factura-legal): habilitar pdf para facturas no electronicas

### DIFF
--- a/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.html
+++ b/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.html
@@ -418,15 +418,13 @@
             </button>
             <button
               mat-menu-item
-              (click)="onDescargarPdf(factura)"
-              [disabled]="!esElectronica(factura)">
+              (click)="onDescargarPdf(factura)">
               <mat-icon>picture_as_pdf</mat-icon>
               <span>Descargar PDF</span>
             </button>
             <button
               mat-menu-item
-              (click)="onAbrirPdf(factura)"
-              [disabled]="!esElectronica(factura)">
+              (click)="onAbrirPdf(factura)">
               <mat-icon>open_in_browser</mat-icon>
               <span>Abrir PDF</span>
             </button>
@@ -436,8 +434,7 @@
             </button>
             <button
               mat-menu-item
-              (click)="onImprimirPdfEnSucursal(factura)"
-              [disabled]="!esElectronica(factura)">
+              (click)="onImprimirPdfEnSucursal(factura)">
               <mat-icon>store</mat-icon>
               <span>Imprimir PDF en sucursal</span>
             </button>

--- a/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
+++ b/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
@@ -653,11 +653,6 @@ export class ListFacturaLegalComponent implements OnInit {
   }
 
   onDescargarPdf(factura: FacturaLegal) {
-    if (!this.esElectronica(factura)) {
-      this.notificacionService.openAlgoSalioMal('Esta factura no es electrónica');
-      return;
-    }
-
     this.cargandoService.openDialog();
     this.facturaService.onDescargarPdfFacturaElectronica(factura.id, factura.sucursalId, true)
       .subscribe({
@@ -683,7 +678,8 @@ export class ListFacturaLegalComponent implements OnInit {
           document.body.appendChild(a);
           a.setAttribute('style', 'display: none');
           a.href = url;
-          a.download = `KuDE-${factura.id}-${factura.cdc}.pdf`;
+          const sufijoArchivo = this.esElectronica(factura) ? factura.cdc : factura.numeroFactura;
+          a.download = `Factura-${factura.id}-${sufijoArchivo}.pdf`;
           a.click();
           window.URL.revokeObjectURL(url);
           a.remove();
@@ -697,11 +693,6 @@ export class ListFacturaLegalComponent implements OnInit {
   }
 
   onAbrirPdf(factura: FacturaLegal) {
-    if (!this.esElectronica(factura)) {
-      this.notificacionService.openAlgoSalioMal('Esta factura no es electrónica');
-      return;
-    }
-
     this.cargandoService.openDialog();
     this.facturaService.onDescargarPdfFacturaElectronica(factura.id, factura.sucursalId, true)
       .subscribe({
@@ -713,7 +704,9 @@ export class ListFacturaLegalComponent implements OnInit {
           }
 
           // Agregar el PDF al servicio de reportes
-          const nombreReporte = `KuDE ${factura.numeroFactura} - ${factura.cdc}`;
+          const nombreReporte = this.esElectronica(factura)
+            ? `KuDE ${factura.numeroFactura} - ${factura.cdc}`
+            : `Factura ${factura.numeroFactura}`;
           this.reporteService.onAdd(nombreReporte, base64String);
 
           // Abrir el componente de reportes en un nuevo tab
@@ -737,10 +730,6 @@ export class ListFacturaLegalComponent implements OnInit {
 
   /** "Imprimir en la sucursal" (PDF A4): aditivo, no reemplaza onDescargarPdf/onAbrirPdf. */
   onImprimirPdfEnSucursal(factura: FacturaLegal): void {
-    if (!this.esElectronica(factura)) {
-      this.notificacionService.openAlgoSalioMal('Esta factura no es electrónica');
-      return;
-    }
     this.matDialog.open(ImprimirEnSucursalDialogComponent, {
       data: { tipo: 'NORMAL', factura },
       width: '900px',


### PR DESCRIPTION
## Qué resuelve

En el listado de Facturas Legales, los botones **Descargar PDF**, **Abrir PDF** e **Imprimir PDF en sucursal** estaban deshabilitados para facturas no electrónicas (`esElectronica()` = tiene CDC). Con el backend generando ahora el PDF legal para timbrados no electrónicos (PR GabFrank/franco-system-backend-servidor#158), esos botones se habilitan para cualquier factura.

### Cambios
- `list-factura-legal.component.html`: se quita `[disabled]="!esElectronica(factura)"` de los 3 botones de PDF.
- `list-factura-legal.component.ts`: se quitan los guard-clauses equivalentes; el nombre de archivo/reporte usa `numeroFactura` cuando no hay `cdc` (`Factura-{id}-{numeroFactura}.pdf` en vez de un `undefined`). `esElectronica()` sigue gateando lo que sí es exclusivo de electrónica (XML, cancelación SIFEN).

## Cómo probarlo
1. Backend con el PR GabFrank/franco-system-backend-servidor#158 desplegado.
2. Facturas Legales → factura **sin CDC** → los 3 botones habilitados; Descargar/Abrir PDF genera el formato legal; Imprimir PDF en sucursal rutea a la impresora.
3. Regresión: factura electrónica → mismos botones + XML siguen funcionando igual.

## Riesgo
Bajo — solo UI/guards; sin cambios de schema GraphQL ni de servicios. Verificado con `npm run check` (AOT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)