### PR TITLE
feat(factura-legal): filtro por numero de venta + fix filtro nro de venta en buscador generico

### DIFF
--- a/src/app/modules/financiero/factura-legal/factura-legal.service.ts
+++ b/src/app/modules/financiero/factura-legal/factura-legal.service.ts
@@ -133,6 +133,7 @@ export class FacturaLegalService {
     isElectronico?: boolean,
     activo?: boolean,
     sinNombre?: boolean,
+    ventaId?: number,
     servidor: boolean = true
   ) {
     return this.genericService.onCustomQuery(
@@ -149,7 +150,8 @@ export class FacturaLegalService {
         iva10,
         isElectronico,
         activo,
-        sinNombre
+        sinNombre,
+        ventaId
       },
       servidor
     );

--- a/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
@@ -14,6 +14,7 @@ export const facturaLegalesQuery = gql`
     $isElectronico: Boolean
     $activo: Boolean
     $sinNombre: Boolean
+    $ventaId: ID
   ) {
     data: facturaLegales(
       page: $page
@@ -28,6 +29,7 @@ export const facturaLegalesQuery = gql`
       isElectronico: $isElectronico
       activo: $activo
       sinNombre: $sinNombre
+      ventaId: $ventaId
     ) {
       getTotalPages
       getTotalElements
@@ -62,6 +64,9 @@ export const facturaLegalesQuery = gql`
             documento
           }
         }
+        venta {
+          id
+        }
         documentoElectronico {
           id
           cdc
@@ -83,6 +88,7 @@ export const facturaLegalesFullInfoQuery = gql`
     $nombre: String
     $iva5: Boolean
     $iva10: Boolean
+    $ventaId: ID
   ) {
     data: facturaLegales(
       page: $page
@@ -94,6 +100,7 @@ export const facturaLegalesFullInfoQuery = gql`
       ruc: $ruc
       iva5: $iva5
       iva10: $iva10
+      ventaId: $ventaId
     ) {
       getTotalPages
       getTotalElements

--- a/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.html
+++ b/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.html
@@ -105,7 +105,7 @@
         fxLayoutGap="10px"
         style="width: 100%"
       >
-        <div fxFlex="33%">
+        <div fxFlex="25%">
           <mat-form-field style="width: 100%">
             <mat-label>Nombre del cliente</mat-label>
             <input
@@ -117,7 +117,7 @@
             />
           </mat-form-field>
         </div>
-        <div fxFlex="33%">
+        <div fxFlex="25%">
           <mat-form-field style="width: 100%">
             <mat-label>Ruc del cliente</mat-label>
             <input
@@ -129,13 +129,25 @@
             />
           </mat-form-field>
         </div>
-        <div fxFlex="34%">
+        <div fxFlex="25%">
           <mat-form-field style="width: 100%">
             <mat-label>CDC</mat-label>
             <input
               type="text"
               matInput
               [formControl]="cdcControl"
+              (keyup.enter)="onFilter()"
+            />
+          </mat-form-field>
+        </div>
+        <div fxFlex="25%">
+          <mat-form-field style="width: 100%">
+            <mat-label>Número de venta</mat-label>
+            <input
+              type="text"
+              inputmode="numeric"
+              matInput
+              [formControl]="ventaIdControl"
               (keyup.enter)="onFilter()"
             />
           </mat-form-field>

--- a/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
+++ b/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
@@ -63,6 +63,7 @@ export class ListFacturaLegalComponent implements OnInit {
   nombreControl = new FormControl(null);
   rucControl = new FormControl(null);
   cdcControl = new FormControl(null);
+  ventaIdControl = new FormControl(null);
   tipoControl = new FormControl('TODOS');
   estadoControl = new FormControl('TODOS');
   fechaInicioControl = new FormControl(null, Validators.required);
@@ -164,6 +165,7 @@ export class ListFacturaLegalComponent implements OnInit {
         this.tipoControl.disable();
         this.estadoControl.disable();
         this.sinNombreControl.disable();
+        this.ventaIdControl.disable();
       } else {
         this.sucursalControl.enable();
         this.nombreControl.enable();
@@ -175,6 +177,7 @@ export class ListFacturaLegalComponent implements OnInit {
         this.tipoControl.enable();
         this.estadoControl.enable();
         this.sinNombreControl.enable();
+        this.ventaIdControl.enable();
       }
     });
 
@@ -270,7 +273,8 @@ export class ListFacturaLegalComponent implements OnInit {
           false,
           isElectronico,
           activo,
-          this.sinNombreControl.value
+          this.sinNombreControl.value,
+          this.toVentaId(this.ventaIdControl.value)
         )
         .subscribe((res) => {
           this.selectedPageInfo = res;
@@ -300,6 +304,15 @@ export class ListFacturaLegalComponent implements OnInit {
       let ruc = removeSecondDigito(f.ruc);
       f.ruc = ruc;
     });
+  }
+
+  // Acepta el nro. de venta con o sin separadores de miles (ej: 756.526 -> 756526)
+  toVentaId(value: any): number {
+    if (value == null || value === '') {
+      return null;
+    }
+    let soloDigitos = String(value).replace(/\D/g, '');
+    return soloDigitos.length > 0 ? parseInt(soloDigitos, 10) : null;
   }
 
   toSucursalesId(sucursales: Sucursal[]) {
@@ -407,6 +420,7 @@ export class ListFacturaLegalComponent implements OnInit {
     this.nombreControl.setValue(null);
     this.rucControl.setValue(null);
     this.sinNombreControl.setValue(null);
+    this.ventaIdControl.setValue(null);
     this.selectedResumenFacturas = null;
     this.dataSource.data = [];
   }

--- a/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.html
+++ b/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.html
@@ -22,10 +22,11 @@
         <div fxFlex="10%">
           <mat-form-field appearance="outline" style="width: 100%;">
             <mat-label>N° de venta</mat-label>
-            <input 
+            <input
               matInput
               placeholder="N° de venta"
-              type="number"
+              type="text"
+              inputmode="numeric"
               [formControl]="idVentaControl"
               (keyup.enter)="onFiltrarConReset()"
             >

--- a/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.ts
+++ b/src/app/modules/operaciones/venta/generic-list-venta/generic-list-venta.component.ts
@@ -172,6 +172,15 @@ export class GenericListVentaComponent implements OnInit {
   }
 
 
+  // Acepta el nro. de venta con o sin separadores de miles (ej: 734.498 -> 734498)
+  toVentaId(value: any): number {
+    if (value == null || value === '') {
+      return null;
+    }
+    let soloDigitos = String(value).replace(/\D/g, '');
+    return soloDigitos.length > 0 ? parseInt(soloDigitos, 10) : null;
+  }
+
   onFiltrarConReset() {
     this.pageIndex = 0;
     this.paginator.firstPage();
@@ -187,7 +196,7 @@ export class GenericListVentaComponent implements OnInit {
 
     this.ventaService
       .onVentasFilter(
-        this.idVentaControl.value,
+        this.toVentaId(this.idVentaControl.value),
         null, // cajaId
         this.pageIndex,
         this.pageSize,
@@ -460,7 +469,7 @@ export class GenericListVentaComponent implements OnInit {
       this.fechaFinControl.value?.toISOString().slice(0, 10) : null;
 
     this.ventaService.onReporteGenericVentas(
-      this.idVentaControl.value,
+      this.toVentaId(this.idVentaControl.value),
       null,
       this.sucursalControl.value,
       this.formaPagoControl.value,
@@ -483,7 +492,7 @@ export class GenericListVentaComponent implements OnInit {
       this.fechaFinControl.value?.toISOString().slice(0, 10) : null;
 
     this.ventaService.onReporteGenericVentasDetallado(
-      this.idVentaControl.value,
+      this.toVentaId(this.idVentaControl.value),
       null,
       this.sucursalControl.value,
       this.formaPagoControl.value,


### PR DESCRIPTION
## Qué resuelve
1. **feat(factura-legal)**: nuevo filtro "Número de venta" en la Lista de Facturas (fila Nombre/RUC/CDC). Se envía como `ventaId` a la query `facturaLegales`, se combina con los demás filtros, se deshabilita al buscar por CDC y se limpia con "Limpiar Filtro". Acepta el número con o sin separadores de miles (`756.526` o `756526`).
2. **fix(ventas)**: el campo "N° de venta" del buscador genérico de ventas enviaba el valor con separador de miles (ej: `734.498`) y el backend fallaba con `Cannot deserialize Long from String "734.498"`. Se sanea el valor (solo dígitos) en el filtro y en los dos reportes (Generar Reporte / Reporte detallado), y el input pasa a `type=text` + `inputmode=numeric`.

**Depende del backend**: GabFrank/franco-system-backend-servidor#160 (parámetro `ventaId` en `facturaLegales`). Sin ese backend, el filtro nuevo de facturas se ignora del lado servidor; el fix de ventas es independiente.

## Cómo probarlo
1. Lista de Facturas → completar "Número de venta" (con o sin puntos) + rango de fecha + sucursal → Buscar → solo facturas de esa venta.
2. Pestaña Ventas → "N° de venta" con `734.498` → Buscar → encuentra la venta sin errores en el log del backend; idem con los reportes.
3. `npm run check` (AOT) corrido en verde.

## Riesgo
Bajo — cambios acotados a los dos componentes de listado; queries GraphQL solo agregan variable opcional y `venta { id }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)