### PR TITLE
fix(impresoras): quitar boton duplicado del estado vacio y subir el mensaje

### DIFF
--- a/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.html
+++ b/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.html
@@ -29,7 +29,8 @@
     </div>
   </div>
 
-  <cdk-virtual-scroll-viewport itemSize="260" class="viewport-container" (scrolledIndexChange)="nextBatch($event, 2)">
+  <cdk-virtual-scroll-viewport *ngIf="cargando || total > 0" itemSize="260" class="viewport-container"
+    (scrolledIndexChange)="nextBatch($event, 2)">
     <div *cdkVirtualFor="let fila of filas" class="fila-grid" fxLayout="row" fxLayoutGap="16px">
       <ng-container *ngFor="let imp of fila">
         <mat-card *ngIf="imp" class="impresora-card theme-color-{{ imp.colorIndex }}" [class.inactiva]="!imp.activo"
@@ -99,10 +100,6 @@
   <div *ngIf="!cargando && total === 0" class="sin-datos" fxLayout="column" fxLayoutAlign="center center">
     <mat-icon class="icono-vacio">print_disabled</mat-icon>
     <p>No hay impresoras que coincidan con la búsqueda.</p>
-    <button mat-raised-button color="primary" (click)="agregarNuevo()">
-      <mat-icon>add</mat-icon>
-      Agregar nueva
-    </button>
   </div>
 
 </div>

--- a/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.scss
+++ b/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.scss
@@ -176,7 +176,7 @@
 }
 
 .sin-datos {
-  margin-top: 60px;
+  margin-top: 24px;
   gap: 12px;
   opacity: 0.8;
 


### PR DESCRIPTION
## Qué resuelve

En el listado de Impresoras, el estado vacío mostraba un botón **Agregar nueva** que duplicaba la acción del botón **Nueva Impresora** del header (ambos llaman a `agregarNuevo()`). Además, el mensaje de estado vacío quedaba empujado hacia abajo porque el `cdk-virtual-scroll-viewport` (con `flex: 1`) ocupaba toda la altura aunque no hubiera items.

## Cambios

- Se elimina el botón "Agregar nueva" del estado vacío.
- El viewport virtual ahora tiene `*ngIf="cargando || total > 0"` (condición inversa exacta del estado vacío), así el mensaje queda justo debajo del buscador.
- `margin-top` de `.sin-datos` reducido de 60px a 24px.

## Cómo probarlo

1. Configuración → Impresoras, sin impresoras registradas (o buscar algo sin coincidencias).
2. Verificar que el estado vacío (ícono + mensaje) aparece arriba, debajo del buscador, sin botón.
3. Con impresoras registradas, verificar que la grilla se sigue renderizando y scrolleando normal.

## Riesgo

Bajo — solo template/SCSS de un componente. Sin impacto en auto-update.

`npm run check` (AOT) pasó OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)