### PR TITLE
feat: venta con tarjeta offline-first (desktop)

### DIFF
--- a/src/app/modules/financiero/pdv/caja/adicionar-caja-dialog/adicionar-caja-dialog.component.ts
+++ b/src/app/modules/financiero/pdv/caja/adicionar-caja-dialog/adicionar-caja-dialog.component.ts
@@ -28,6 +28,7 @@ import { Conteo } from "../../../conteo/conteo.model";
 import { AdicionarMaletinDialogComponent } from "../../../maletin/adicionar-maletin-dialog/adicionar-maletin-dialog.component";
 import { Maletin } from "../../../maletin/maletin.model";
 import { MaletinService } from "../../../maletin/maletin.service";
+import { ConfirmDialogComponent } from "../../../../../shared/components/confirm-dialog/confirm-dialog.component";
 import { PdvCaja, PdvCajaInput } from "../caja.model";
 import { CajaService } from "../caja.service";
 
@@ -617,9 +618,33 @@ export class AdicionarCajaDialogComponent implements OnInit {
             .subscribe({
               next: (pendientes) => {
                 if (pendientes > 0) {
-                  this.notificacionBar.openWarn(
-                    `Posee ${pendientes} venta(s) con tarjeta sin registrar en la app móvil`
-                  );
+                  this.matDialog.open(ConfirmDialogComponent, {
+                    width: "480px",
+                    data: {
+                      title: "Ventas con tarjeta sin registrar",
+                      message: `Posee ${pendientes} venta(s) con tarjeta sin registrar en la app móvil. ` +
+                        `Si cierra la caja, quedarán marcadas como NO COMPLETADAS y ya no podrán registrarse. ¿Desea cerrar igualmente?`,
+                      confirmText: "Cerrar igualmente",
+                      cancelText: "Volver",
+                    },
+                  }).afterClosed().pipe(take(1)).subscribe((confirmado) => {
+                    if (confirmado === true) {
+                      this.ventaTarjetaService.onMarcarNoCompletadas(this.selectedCaja.id, this.selectedCaja.sucursalId)
+                        .pipe(take(1))
+                        .subscribe({
+                          next: () => {
+                            this.stepper.selectedIndex = 1;
+                            this.stepper.selectedIndex = 2;
+                            this.focusToCierreSub.next(null);
+                          },
+                          error: () => {
+                            this.notificacionBar.openWarn(
+                              "No se pudo actualizar las ventas con tarjeta pendientes. Intente nuevamente."
+                            );
+                          },
+                        });
+                    }
+                  });
                 } else {
                   this.stepper.selectedIndex = 1;
                   this.stepper.selectedIndex = 2;

--- a/src/app/modules/financiero/venta-tarjeta/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/venta-tarjeta/graphql/graphql-query.ts
@@ -95,3 +95,9 @@ export const saveConfiguracionVentaTarjeta = gql`
     }
   }
 `;
+
+export const marcarVentasTarjetaNoCompletadasMutation = gql`
+  mutation marcarVentasTarjetaNoCompletadas($cajaId: ID!, $sucId: ID!) {
+    data: marcarVentasTarjetaNoCompletadas(cajaId: $cajaId, sucId: $sucId)
+  }
+`;

--- a/src/app/modules/financiero/venta-tarjeta/graphql/marcarVentasTarjetaNoCompletadas.ts
+++ b/src/app/modules/financiero/venta-tarjeta/graphql/marcarVentasTarjetaNoCompletadas.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { marcarVentasTarjetaNoCompletadasMutation } from './graphql-query';
+
+export interface MarcarVentasTarjetaNoCompletadasResponse {
+  data: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MarcarVentasTarjetaNoCompletadasGQL extends Mutation<MarcarVentasTarjetaNoCompletadasResponse> {
+  document = marcarVentasTarjetaNoCompletadasMutation;
+}

--- a/src/app/modules/financiero/venta-tarjeta/list-venta-tarjeta/list-venta-tarjeta.component.ts
+++ b/src/app/modules/financiero/venta-tarjeta/list-venta-tarjeta/list-venta-tarjeta.component.ts
@@ -45,7 +45,7 @@ export class ListVentaTarjetaComponent implements OnInit {
   sucursales: Sucursal[] = [];
   terminalesDescripciones: string[] = [];
   terminales: { descripcion: string; codigo: string }[] = [];
-  estados = ['PENDIENTE', 'COMPLETADO', 'CANCELADO'];
+  estados = ['PENDIENTE', 'COMPLETADO', 'CANCELADO', 'NO_COMPLETADO'];
 
   get terminalesCodigos(): string[] {
     const desc = this.terminalDescripcionControl.value;

--- a/src/app/modules/financiero/venta-tarjeta/venta-tarjeta.service.ts
+++ b/src/app/modules/financiero/venta-tarjeta/venta-tarjeta.service.ts
@@ -6,6 +6,7 @@ import { CountVentasTarjetaSinRegistrarDesktopGQL } from './graphql/countVentasT
 import { CancelarVentaTarjetaPorVentaIdGQL } from './graphql/cancelarVentaTarjetaPorVentaId';
 import { FiltrarVentasTarjetaGQL } from './graphql/filtrarVentasTarjeta';
 import { ImprimirReporteVentaTarjetaGQL } from './graphql/imprimirReporteVentaTarjeta';
+import { MarcarVentasTarjetaNoCompletadasGQL } from './graphql/marcarVentasTarjetaNoCompletadas';
 import { PageInfo } from '../../../app.component';
 import { VentaTarjeta } from './venta-tarjeta.model';
 import { MainService } from '../../../main.service';
@@ -35,20 +36,21 @@ export class VentaTarjetaService {
     private cancelarVentaTarjetaGQL: CancelarVentaTarjetaPorVentaIdGQL,
     private filtrarVentasTarjetaGQL: FiltrarVentasTarjetaGQL,
     private imprimirReporteVentaTarjetaGQL: ImprimirReporteVentaTarjetaGQL,
+    private marcarVentasTarjetaNoCompletadasGQL: MarcarVentasTarjetaNoCompletadasGQL,
     private mainService: MainService,
     private reporteService: ReporteService,
     private tabService: TabService
   ) {}
 
   onSavePendiente(input: VentaTarjetaInput): Observable<VentaTarjetaResult> {
-    return this.genericService.onCustomMutation(this.saveVentaTarjetaGQL, { entity: input }, true);
+    return this.genericService.onCustomMutation(this.saveVentaTarjetaGQL, { entity: input }, false);
   }
 
   onCountSinRegistrar(cajaId: number, sucId: number): Observable<number> {
     return this.genericService.onCustomQuery(
       this.countVentasTarjetaGQL,
       { cajaId, sucId },
-      true,
+      false,
       null,
       true
     );
@@ -58,8 +60,16 @@ export class VentaTarjetaService {
     return this.genericService.onCustomMutation(
       this.cancelarVentaTarjetaGQL,
       { ventaId, sucId },
-      true,
+      false,
       true
+    );
+  }
+
+  onMarcarNoCompletadas(cajaId: number, sucId: number): Observable<number> {
+    return this.genericService.onCustomMutation(
+      this.marcarVentasTarjetaNoCompletadasGQL,
+      { cajaId, sucId },
+      false
     );
   }
 

--- a/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.ts
@@ -626,7 +626,8 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
       return;
     }
 
-    this.configuracionVentaTarjetaService.onGetConfiguracion().subscribe({
+    // Config replicada del central: se consulta al filial para funcionar sin internet
+    this.configuracionVentaTarjetaService.onGetConfiguracion(false).subscribe({
       next: (config) => {
         if (!config?.habilitado) {
           // Flujo de registro de venta con tarjeta deshabilitado: el cobro con


### PR DESCRIPTION
## Resumen
El flujo operativo de venta con tarjeta pasa al **servidor filial** (`servidor=false`) — funciona sin internet:
- `pago-touch`: configuración leída local (replicada del central).
- `onSavePendiente` / `onCountSinRegistrar` / `onCancelarPorVentaId` → filial.
- **Cierre de caja con pendientes**: diálogo de confirmación → `marcarVentasTarjetaNoCompletadas` (estado nuevo NO_COMPLETADO) → cierra. Cancelar no marca nada.
- Listado: NO_COMPLETADO agregado al filtro de estados. Pantallas administrativas (listado/reporte/config) siguen contra el central.

## Dependencias
Requiere desplegados antes: backend filial GabFrank/franco-system-backend-filial#79 y central GabFrank/franco-system-backend-servidor#162. Ver runbook en workspace DEV-FRC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)