### PR TITLE
fix(inventario): sistema de carga en lista de productos vencidos

### DIFF
--- a/src/app/modules/operaciones/inventario/list-productos-vencidos/list-productos-vencidos.component.ts
+++ b/src/app/modules/operaciones/inventario/list-productos-vencidos/list-productos-vencidos.component.ts
@@ -3,8 +3,8 @@ import { FormControl, FormGroup } from "@angular/forms";
 import { MatTableDataSource } from "@angular/material/table";
 import { MatDialog } from "@angular/material/dialog";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import { BehaviorSubject, forkJoin } from "rxjs";
-import { debounceTime, distinctUntilChanged, switchMap, tap } from "rxjs/operators";
+import { BehaviorSubject, forkJoin, of } from "rxjs";
+import { catchError, debounceTime, distinctUntilChanged, finalize, switchMap, tap } from "rxjs/operators";
 
 import {
   SearchListDialogComponent,
@@ -33,6 +33,7 @@ import { TabData } from "../../../../layouts/tab/tab.service";
 import { Transferencia, TransferenciaEstado, TipoTransferencia, EtapaTransferencia, TransferenciaItem } from "../../transferencia/transferencia.model";
 import { TransferenciaService } from "../../transferencia/transferencia.service";
 import { SeleccionarSucursalDialogComponent } from "../../transferencia/seleccionar-sucursal-dialog/seleccionar-sucursal-dialog.component";
+import { CargandoDialogService } from "../../../../shared/components/cargando-dialog/cargando-dialog.service";
 import { Presentacion } from "../../../productos/presentacion/presentacion.model";
 
 export interface ProductosVencidosFilters {
@@ -111,7 +112,8 @@ export class ListProductosVencidosComponent implements OnInit, OnDestroy {
     private cdRef: ChangeDetectorRef,
     private mainService: MainService,
     private notificacion: NotificacionSnackbarService,
-    private transferenciaService: TransferenciaService
+    private transferenciaService: TransferenciaService,
+    private cargandoService: CargandoDialogService
   ) {
     this.fechaFormGroup = new FormGroup({
       inicio: new FormControl(),
@@ -193,9 +195,16 @@ export class ListProductosVencidosComponent implements OnInit, OnDestroy {
   }
 
   private loadProductosVencidos(filters: ProductosVencidosFilters) {
+    const { requestId, signal } = this.cargandoService.openDialog(
+      false,
+      "Buscando..."
+    );
     return this.productosVencidosGQL.fetch(filters, {
       fetchPolicy: 'no-cache',
       errorPolicy: 'all',
+      context: {
+        fetchOptions: { signal },
+      },
     }).pipe(
       tap(result => {
         if (result.errors?.length) {
@@ -208,7 +217,17 @@ export class ListProductosVencidosComponent implements OnInit, OnDestroy {
           return;
         }
         this.handleProductosVencidosResponse(result);
-      })
+      }),
+      catchError(error => {
+        // Ej: servidor offline. Mostrar aviso en vez de matar la suscripción de filtros.
+        console.error('Error en productosVencidos:', error);
+        this.notificacion.openAlgoSalioMal('Error al buscar productos vencidos');
+        this.setEmptyData();
+        this.cdRef.detectChanges();
+        return of(null);
+      }),
+      // Cierra el spinner en éxito, error o cancelación (switchMap al cambiar filtros).
+      finalize(() => this.cargandoService.closeDialog(requestId))
     );
   }
 


### PR DESCRIPTION
## Qué resuelve

La **Lista de productos vencidos** no tenía indicador de carga: al filtrar o cambiar de página la pantalla quedaba congelada hasta que de golpe aparecían los datos. Se integra el mismo sistema de carga (`CargandoDialogService` → overlay "Buscando...") que ya usan el resto de los módulos vía `generic-crud`.

## Cambios

- **`openDialog` + `finalize`**: spinner en cada búsqueda (Buscar, cambio de página, limpiar filtro, selección de producto/usuario). Cierre garantizado en éxito, error **y cancelación** cuando `switchMap` descarta un request previo por cambio rápido de filtros.
- **`AbortSignal`** propagado al `fetch` de Apollo (`context.fetchOptions.signal`) para cancelar el request real, igual que `generic-crud.service.ts`.
- **`catchError`**: antes un error de red (servidor offline) mataba silenciosamente la suscripción de `filtersSubject` y la pantalla dejaba de responder a filtros. Ahora avisa por snackbar, vacía la tabla y la suscripción sigue viva.

## Cómo probarlo

1. Abrir **Operaciones → Inventario → Lista de productos vencidos**.
2. Aplicar un filtro o cambiar de página → aparece el overlay "Buscando..." y se cierra al llegar la respuesta.
3. Cambiar filtros rápido varias veces seguidas → el spinner no queda colgado.
4. (Opcional) Con el servidor caído: muestra snackbar de error y la pantalla sigue respondiendo a nuevos filtros.

## Riesgo

**Bajo** — cambio acotado a un solo componente. `npm run check` (AOT) pasó sin errores.

## Impacto auto-update

Ninguno — no toca `installer.nsh`, `electron-builder.json` ni manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)