### PR TITLE
feat(grafico): graficos de costos, inflacion y ventas con delivery

### DIFF
--- a/src/app/layouts/default/tab-content/tab-content.component.ts
+++ b/src/app/layouts/default/tab-content/tab-content.component.ts
@@ -5,7 +5,11 @@ import { SkeletonComponent } from '../../../skeleton.component';
 
 @Component({
   selector: 'app-tab-content',
-  template: '<ng-template style="height: 100%; flex: 1; display: flex; flex-direction: column;" content-container></ng-template>'
+  template: '<ng-template style="height: 100%; flex: 1; display: flex; flex-direction: column;" content-container></ng-template>',
+  // El contenedor del tab acota su alto al del área de contenido (que ya es de alto fijo).
+  // Sin esto, la pantalla del tab crece con su contenido y el overflow-y de la pantalla nunca
+  // se activa: el contenido que sobra se recorta en vez de poder scrollear.
+  styles: [':host { display: block; height: 100%; }']
 })
 
 export class TabContentComponent implements OnInit {

--- a/src/app/modules/grafico/delivery-sucursal/delivery-sucursal-datos-grafico-procesados.model.ts
+++ b/src/app/modules/grafico/delivery-sucursal/delivery-sucursal-datos-grafico-procesados.model.ts
@@ -1,0 +1,6 @@
+import { EChartsOption } from "echarts";
+
+export interface DeliverySucursalDatosGraficoProcesados {
+  opciones: EChartsOption;
+  hayDatos: boolean;
+}

--- a/src/app/modules/grafico/delivery-sucursal/delivery-sucursal-item.model.ts
+++ b/src/app/modules/grafico/delivery-sucursal/delivery-sucursal-item.model.ts
@@ -1,0 +1,9 @@
+import { ConDesglosePeriodoGrafico } from "../utils/grafico-desglose-periodo.model";
+
+export interface DeliverySucursalItem extends ConDesglosePeriodoGrafico {
+  sucId?: number;
+  nombre?: string;
+  total?: number;
+  /** Cantidad de deliveries concluidos en el período. */
+  cantidadVentas?: number;
+}

--- a/src/app/modules/grafico/delivery-sucursal/delivery-sucursal.component.html
+++ b/src/app/modules/grafico/delivery-sucursal/delivery-sucursal.component.html
@@ -1,0 +1,118 @@
+<div class="delivery-sucursal-layout grafico-pantalla">
+  <div class="grafico-filtros">
+    <mat-form-field
+      appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--anho"
+    >
+      <mat-label>Años</mat-label>
+      <mat-select [formControl]="filtroPeriodo.anhoControl" multiple>
+        <mat-option
+          *ngFor="let y of filtroPeriodo.anhos"
+          [value]="y"
+        >
+          {{ y }}
+        </mat-option>
+      </mat-select>
+      <mat-icon matPrefix>calendar_today</mat-icon>
+    </mat-form-field>
+
+    <mat-form-field
+      appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--mes"
+    >
+      <mat-label>Meses</mat-label>
+      <mat-select
+        [formControl]="filtroPeriodo.mesControl"
+        multiple
+        (selectionChange)="filtroPeriodo.onMesesChange($event.value)"
+      >
+        <mat-option
+          *ngFor="let m of filtroPeriodo.meses"
+          [value]="m.valor"
+        >
+          {{ m.nombre }}
+        </mat-option>
+      </mat-select>
+      <mat-icon matPrefix>date_range</mat-icon>
+    </mat-form-field>
+
+    <mat-form-field
+      appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--rango filter-rango"
+      [class.filter-rango--inactivo]="!filtroPeriodo.rangoDiasActivo"
+    >
+      <mat-label>Rango de días</mat-label>
+      <mat-date-range-input
+        [formGroup]="filtroPeriodo.fechaRangoGroup"
+        [rangePicker]="pickerRango"
+      >
+        <input
+          matStartDate
+          formControlName="inicio"
+          placeholder="Desde"
+          [min]="filtroPeriodo.minFechaRango"
+          [max]="filtroPeriodo.maxFechaRango"
+        />
+        <input
+          matEndDate
+          formControlName="fin"
+          placeholder="Hasta"
+          [min]="filtroPeriodo.minFechaRango"
+          [max]="filtroPeriodo.maxFechaRango"
+        />
+      </mat-date-range-input>
+      <mat-datepicker-toggle matSuffix [for]="pickerRango"></mat-datepicker-toggle>
+      <mat-date-range-picker #pickerRango></mat-date-range-picker>
+    </mat-form-field>
+
+    <div class="grafico-filtros__acciones">
+      <button
+        mat-raised-button
+        color="primary"
+        type="button"
+        (click)="filtrar()"
+        [disabled]="cargando$ | async"
+        aria-label="Aplicar filtros"
+      >
+        Filtrar
+      </button>
+
+      <button
+        mat-stroked-button
+        type="button"
+        class="grafico-filtros__btn-secundario"
+        (click)="exportarExcel()"
+        [disabled]="(cargando$ | async) || (exportando$ | async) || !(puedeExportar$ | async)"
+        matTooltip="Exportar gráfico y detalle a Excel"
+        aria-label="Exportar a Excel"
+      >
+        <mat-icon>download</mat-icon>
+        Excel
+      </button>
+
+      <button
+        mat-icon-button
+        type="button"
+        class="grafico-filtros__limpiar"
+        (click)="limpiarFiltros()"
+        matTooltip="Limpiar filtros"
+        aria-label="Limpiar filtros"
+      >
+        <mat-icon>filter_alt_off</mat-icon>
+      </button>
+    </div>
+  </div>
+
+  <ng-container *ngIf="vista$ | async as vista">
+    <frc-grafico-shell
+      class="delivery-sucursal-layout__grafico"
+      titulo="Ventas con Delivery"
+      [opciones]="vista.opciones"
+      [cargando]="vista.cargando"
+      [hayDatos]="vista.hayDatos"
+      [datosListos]="vista.datosListos"
+      mensajeVacio="No hay datos para mostrar en este período"
+      mensajeInicial="Seleccione filtros y pulse Filtrar para visualizar datos"
+    ></frc-grafico-shell>
+  </ng-container>
+</div>

--- a/src/app/modules/grafico/delivery-sucursal/delivery-sucursal.component.scss
+++ b/src/app/modules/grafico/delivery-sucursal/delivery-sucursal.component.scss
@@ -1,0 +1,16 @@
+@import '../styles/grafico-filtros';
+
+:host {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.delivery-sucursal-layout {
+  gap: 0;
+
+  &__grafico {
+    flex: 1;
+    min-height: 0;
+  }
+}

--- a/src/app/modules/grafico/delivery-sucursal/delivery-sucursal.component.spec.ts
+++ b/src/app/modules/grafico/delivery-sucursal/delivery-sucursal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeliverySucursalComponent } from './delivery-sucursal.component';
+
+describe('DeliverySucursalComponent', () => {
+  let component: DeliverySucursalComponent;
+  let fixture: ComponentFixture<DeliverySucursalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DeliverySucursalComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeliverySucursalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/grafico/delivery-sucursal/delivery-sucursal.component.ts
+++ b/src/app/modules/grafico/delivery-sucursal/delivery-sucursal.component.ts
@@ -1,0 +1,328 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  OnInit,
+  inject,
+} from "@angular/core";
+import { EChartsOption } from "echarts";
+import {
+  BehaviorSubject,
+  Observable,
+  combineLatest,
+  debounceTime,
+  finalize,
+  map,
+  Subject,
+  startWith,
+  switchMap,
+  tap,
+} from "rxjs";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { VistaGraficoShell } from "../../../shared/models/grafico-vista.model";
+import {
+  degradadoBarraVertical,
+  ejeCategoriaOscuro,
+  ejeValorOscuro,
+  formatoMonedaPy,
+  gridGraficoOscuro,
+  GRAFICO_COLORES,
+  GRAFICO_PALETA_BARRAS,
+  tituloGraficoCentrado,
+} from "../../../shared/utils/grafico-echarts.theme";
+import { GraficoService } from "../grafico.service";
+import { GraficoFiltrosPeriodo } from "../utils/grafico-filtro-rango-fechas.helper";
+import { periodosDesdeFiltro } from "../utils/grafico-consulta-multi.helper";
+import { formatearTooltipGraficoPeriodo } from "../utils/grafico-tooltip-periodo.util";
+import { DeliverySucursalItem } from "./delivery-sucursal-item.model";
+import { DeliverySucursalDatosGraficoProcesados } from "./delivery-sucursal-datos-grafico-procesados.model";
+import {
+  descargarExcelBase64,
+  etiquetasFiltroPeriodoGrafico,
+  nombreArchivoGraficoExcel,
+} from "../utils/grafico-excel-export.util";
+
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: "app-delivery-sucursal",
+  templateUrl: "./delivery-sucursal.component.html",
+  styleUrls: ["./delivery-sucursal.component.scss"],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "delivery-sucursal-host",
+  },
+})
+export class DeliverySucursalComponent implements OnInit {
+  private graficoService = inject(GraficoService);
+  private cdr = inject(ChangeDetectorRef);
+
+  readonly filtroPeriodo = new GraficoFiltrosPeriodo();
+
+  private readonly datosSubject =
+    new BehaviorSubject<DeliverySucursalDatosGraficoProcesados | null>(null);
+  private readonly cargandoSubject = new BehaviorSubject<boolean>(false);
+  private readonly exportandoSubject = new BehaviorSubject<boolean>(false);
+  private readonly filtrarSubject = new Subject<void>();
+
+  private datosCrudos: DeliverySucursalItem[] = [];
+
+  readonly vista$: Observable<VistaGraficoShell> = combineLatest([
+    this.datosSubject,
+    this.cargandoSubject,
+  ]).pipe(
+    map(([datos, cargando]) => ({
+      opciones: datos?.opciones ?? null,
+      hayDatos: datos?.hayDatos ?? false,
+      cargando,
+      datosListos: datos !== null,
+    }))
+  );
+  readonly cargando$ = this.cargandoSubject.asObservable();
+  readonly exportando$ = this.exportandoSubject.asObservable();
+  readonly puedeExportar$ = this.datosSubject.pipe(
+    map((datos) => !!(datos?.hayDatos))
+  );
+
+  ngOnInit(): void {
+    this.filtroPeriodo.configurarLimitesRangoDias(
+      (source) => source.pipe(untilDestroyed(this)),
+      () => this.cdr.markForCheck()
+    );
+    this.configurarDataStream();
+  }
+
+  limpiarFiltros(): void {
+    this.filtroPeriodo.limpiar();
+    this.filtrar();
+    this.cdr.markForCheck();
+  }
+
+  filtrar(): void {
+    this.filtrarSubject.next();
+  }
+
+  exportarExcel(): void {
+    if (!this.datosCrudos.length || this.exportandoSubject.value) {
+      return;
+    }
+    this.exportandoSubject.next(true);
+    const filtros = etiquetasFiltroPeriodoGrafico(this.filtroPeriodo);
+    this.graficoService
+      .exportarGraficoExcel("DELIVERY_SUCURSAL", {
+        periodos: periodosDesdeFiltro(this.filtroPeriodo),
+        ...filtros,
+      })
+      .pipe(
+        finalize(() => {
+          this.exportandoSubject.next(false);
+          this.cdr.markForCheck();
+        }),
+        untilDestroyed(this)
+      )
+      .subscribe((base64) => {
+        descargarExcelBase64(
+          base64,
+          nombreArchivoGraficoExcel("DELIVERY_SUCURSAL")
+        );
+      });
+  }
+
+  private configurarDataStream(): void {
+    this.filtrarSubject
+      .pipe(
+        startWith(void 0),
+        debounceTime(300),
+        tap(() => this.cargandoSubject.next(true)),
+        switchMap(() => this.consultarDelivery()),
+        untilDestroyed(this)
+      )
+      .subscribe((datos) => {
+        this.datosCrudos = datos || [];
+        this.datosSubject.next(this.procesarDatos(this.datosCrudos));
+        this.cdr.markForCheck();
+      });
+  }
+
+  private consultarDelivery(): Observable<DeliverySucursalItem[]> {
+    return this.graficoService
+      .obtenerDeliveryPorSucursalMulti(periodosDesdeFiltro(this.filtroPeriodo))
+      .pipe(finalize(() => this.cargandoSubject.next(false)));
+  }
+
+  private procesarDatos(
+    data: DeliverySucursalItem[]
+  ): DeliverySucursalDatosGraficoProcesados {
+    const validas = [...(data || [])].sort(
+      (a, b) => (b.total || 0) - (a.total || 0)
+    );
+    const totalGeneral = validas.reduce(
+      (sum, item) => sum + (item.total || 0),
+      0
+    );
+    const anhosComparativa = this.extraerAnhosComparativa(validas);
+    const opciones =
+      anhosComparativa.length > 1
+        ? this.construirOpcionesComparativaAnhos(
+            validas,
+            anhosComparativa,
+            totalGeneral
+          )
+        : this.construirOpcionesSimple(validas, totalGeneral);
+
+    return { opciones, hayDatos: validas.length > 0 };
+  }
+
+  private extraerAnhosComparativa(items: DeliverySucursalItem[]): number[] {
+    const anhosFiltro = this.filtroPeriodo.normalizarAnhosSeleccionados();
+    if (anhosFiltro.length > 1) {
+      return anhosFiltro;
+    }
+
+    const anhos = new Set<number>();
+    for (const item of items) {
+      for (const d of item.desgloseAnhos ?? []) {
+        if (d.total !== 0 || (d.cantidad ?? 0) > 0) {
+          anhos.add(d.anio);
+        }
+      }
+    }
+    return Array.from(anhos).sort((a, b) => a - b);
+  }
+
+  private nombreSucursal(item: DeliverySucursalItem): string {
+    return item.nombre || `Suc ${item.sucId}`;
+  }
+
+  private totalPorAnho(item: DeliverySucursalItem, anio: number): number {
+    return (
+      item.desgloseAnhos?.find((d) => d.anio === anio)?.total ?? 0
+    );
+  }
+
+  private etiquetaValorBarra(valor: number): string {
+    if (valor >= 1_000_000) {
+      return (valor / 1_000_000).toFixed(1) + "M";
+    }
+    return valor.toLocaleString("es-PY");
+  }
+
+  private labelBarraSuperior() {
+    return {
+      show: true,
+      position: "top" as const,
+      color: GRAFICO_COLORES.text,
+      formatter: (p: { value?: unknown }) =>
+        this.etiquetaValorBarra(Number(p.value)),
+    };
+  }
+
+  private formatearTooltipSucursal(
+    validas: DeliverySucursalItem[],
+    dataIndex: number
+  ): string {
+    const item = validas[dataIndex];
+    if (!item) {
+      return "";
+    }
+    const lineasExtra =
+      item.cantidadVentas != null && item.cantidadVentas > 0
+        ? [`Cant. deliveries: ${item.cantidadVentas.toLocaleString("es-PY")}`]
+        : undefined;
+
+    return formatearTooltipGraficoPeriodo({
+      titulo: this.nombreSucursal(item),
+      total: item.total ?? 0,
+      desglosePeriodos: item.desglosePeriodos,
+      desgloseAnhos: item.desgloseAnhos,
+      lineasExtra,
+    });
+  }
+
+  private construirOpcionesSimple(
+    validas: DeliverySucursalItem[],
+    totalGeneral: number
+  ): EChartsOption {
+    return {
+      title: tituloGraficoCentrado(
+        "Ventas con Delivery",
+        `Total Período: ${formatoMonedaPy(totalGeneral)}`
+      ),
+      tooltip: {
+        trigger: "axis",
+        axisPointer: { type: "shadow" },
+        formatter: (params: unknown) => {
+          const fila = Array.isArray(params) ? params[0] : params;
+          if (!fila || typeof fila !== "object") {
+            return "";
+          }
+          const p = fila as { dataIndex: number };
+          return this.formatearTooltipSucursal(validas, p.dataIndex);
+        },
+      },
+      grid: gridGraficoOscuro(),
+      xAxis: ejeCategoriaOscuro(validas.map((v) => this.nombreSucursal(v)), 30),
+      yAxis: ejeValorOscuro(),
+      series: [
+        {
+          name: "Delivery",
+          type: "bar",
+          data: validas.map((v) => v.total),
+          itemStyle: {
+            color: degradadoBarraVertical(),
+            borderRadius: [4, 4, 0, 0],
+          },
+          label: this.labelBarraSuperior(),
+        },
+      ],
+    };
+  }
+
+  private construirOpcionesComparativaAnhos(
+    validas: DeliverySucursalItem[],
+    anhos: number[],
+    totalGeneral: number
+  ): EChartsOption {
+    const etiquetaAnhos = anhos.join(" · ");
+
+    return {
+      title: tituloGraficoCentrado(
+        "Ventas con Delivery",
+        `Comparando ${etiquetaAnhos} · Total: ${formatoMonedaPy(totalGeneral)}`
+      ),
+      tooltip: {
+        trigger: "axis",
+        axisPointer: { type: "shadow" },
+        formatter: (params: unknown) => {
+          const filas = Array.isArray(params) ? params : [params];
+          const primera = filas[0];
+          if (!primera || typeof primera !== "object") {
+            return "";
+          }
+          return this.formatearTooltipSucursal(
+            validas,
+            (primera as { dataIndex: number }).dataIndex
+          );
+        },
+      },
+      legend: {
+        data: anhos.map(String),
+        bottom: 0,
+        textStyle: { color: GRAFICO_COLORES.textSecondary },
+      },
+      grid: gridGraficoOscuro("18%"),
+      xAxis: ejeCategoriaOscuro(validas.map((v) => this.nombreSucursal(v)), 30),
+      yAxis: ejeValorOscuro(),
+      series: anhos.map((anio, idx) => ({
+        name: String(anio),
+        type: "bar" as const,
+        data: validas.map((v) => this.totalPorAnho(v, anio)),
+        barGap: "10%",
+        itemStyle: {
+          color: GRAFICO_PALETA_BARRAS[idx % GRAFICO_PALETA_BARRAS.length],
+          borderRadius: [4, 4, 0, 0],
+        },
+        label: this.labelBarraSuperior(),
+      })),
+    };
+  }
+}

--- a/src/app/modules/grafico/evolucion-costo/evolucion-costo.component.html
+++ b/src/app/modules/grafico/evolucion-costo/evolucion-costo.component.html
@@ -1,0 +1,159 @@
+<div class="evolucion-costo-container grafico-pantalla">
+  <div class="grafico-filtros">
+    <mat-form-field
+      appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--producto"
+    >
+      <mat-label>Producto</mat-label>
+      <input
+        matInput
+        readonly
+        [value]="etiquetaProducto"
+        placeholder="Seleccione un producto"
+        (click)="abrirBusquedaProducto()"
+      >
+      <button
+        mat-icon-button
+        matSuffix
+        type="button"
+        (click)="abrirBusquedaProducto(); $event.stopPropagation()"
+        matTooltip="Buscar producto"
+        aria-label="Buscar producto"
+      >
+        <mat-icon>search</mat-icon>
+      </button>
+      <button
+        mat-icon-button
+        matSuffix
+        type="button"
+        *ngIf="productoSeleccionado"
+        (click)="limpiarProducto(); $event.stopPropagation()"
+        matTooltip="Quitar producto"
+        aria-label="Quitar producto"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+
+    <mat-form-field
+      appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--rango"
+    >
+      <mat-label>Período</mat-label>
+      <mat-date-range-input
+        [formGroup]="fechaRangoGroup"
+        [rangePicker]="pickerRango"
+      >
+        <input
+          matStartDate
+          formControlName="inicio"
+          placeholder="Desde"
+        >
+        <input
+          matEndDate
+          formControlName="fin"
+          placeholder="Hasta"
+        >
+      </mat-date-range-input>
+      <mat-datepicker-toggle
+        matSuffix
+        [for]="pickerRango"
+      ></mat-datepicker-toggle>
+      <mat-date-range-picker #pickerRango></mat-date-range-picker>
+    </mat-form-field>
+
+    <div class="grafico-filtros__acciones">
+      <button
+        mat-raised-button
+        color="primary"
+        type="button"
+        [disabled]="!productoSeleccionado"
+        (click)="filtrar()"
+      >
+        <mat-icon>filter_alt</mat-icon>
+        Filtrar
+      </button>
+      <button
+        mat-icon-button
+        type="button"
+        (click)="limpiarFiltros()"
+        matTooltip="Limpiar filtros"
+        aria-label="Limpiar filtros"
+      >
+        <mat-icon>filter_alt_off</mat-icon>
+      </button>
+    </div>
+  </div>
+
+  <div
+    class="loading-overlay"
+    *ngIf="cargando"
+  >
+    <mat-spinner diameter="40"></mat-spinner>
+  </div>
+
+  <ng-container *ngIf="datos$ | async as datos; else sinProducto">
+    <div
+      class="stats-row"
+      *ngIf="datos.hayDatos"
+    >
+      <div class="stat-card">
+        <span class="stat-label">Costo inicial</span>
+        <span class="stat-value">{{ datos.costoInicial }}</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-label">Costo final</span>
+        <span class="stat-value">{{ datos.costoFinal }}</span>
+      </div>
+      <div
+        class="stat-card"
+        [class.stat-card--sube]="datos.variacionPositiva"
+        [class.stat-card--baja]="!datos.variacionPositiva"
+      >
+        <span class="stat-label">Variación</span>
+        <span class="stat-value">{{ datos.variacion }}</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-label">Costo promedio</span>
+        <span class="stat-value">{{ datos.costoPromedio }}</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-label">Período más caro</span>
+        <span class="stat-value">{{ datos.periodoPico }}</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-label">Compras</span>
+        <span class="stat-value">{{ datos.totalCompras }}</span>
+      </div>
+    </div>
+
+    <div
+      class="chart-panel"
+      *ngIf="datos.hayDatos"
+    >
+      <div
+        echarts
+        [options]="datos.chartOptions"
+        class="chart"
+      ></div>
+    </div>
+
+    <div
+      class="no-data-message"
+      *ngIf="!datos.hayDatos && !cargando"
+    >
+      <mat-icon>request_quote</mat-icon>
+      <span>No hay compras registradas de este producto en el período seleccionado</span>
+    </div>
+  </ng-container>
+
+  <ng-template #sinProducto>
+    <div
+      class="no-data-message"
+      *ngIf="!cargando"
+    >
+      <mat-icon>inventory_2</mat-icon>
+      <span>Seleccione un producto para ver la evolución de su costo de compra</span>
+    </div>
+  </ng-template>
+</div>

--- a/src/app/modules/grafico/evolucion-costo/evolucion-costo.component.scss
+++ b/src/app/modules/grafico/evolucion-costo/evolucion-costo.component.scss
@@ -1,0 +1,118 @@
+@import '../styles/grafico-filtros';
+
+$primary: #689F38;
+$accent: #009688;
+$warn: #F44336;
+$warning: #FF9800;
+$background: #424242;
+$background-dark: #303030;
+$text: #E0E0E0;
+$text-secondary: #9E9E9E;
+$border: #555;
+
+.evolucion-costo-container {
+  min-height: 100%;
+  position: relative;
+}
+
+.vista-toggle {
+  flex-shrink: 0;
+}
+
+.grafico-filtros__campo--producto input[readonly] {
+  cursor: pointer;
+}
+
+.loading-overlay {
+  position: absolute;
+  top: 120px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+}
+
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.stat-card {
+  background: $background;
+  border: 1px solid $border;
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  &--sube {
+    border-color: rgba($warn, 0.7);
+
+    .stat-value {
+      color: $warn;
+    }
+  }
+
+  &--baja {
+    border-color: rgba($primary, 0.7);
+
+    .stat-value {
+      color: #8BC34A;
+    }
+  }
+}
+
+.stat-label {
+  font-size: 0.65rem;
+  color: $text-secondary;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.stat-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: $text;
+}
+
+.chart-panel {
+  background: $background;
+  border: 1px solid $border;
+  border-radius: 12px;
+  padding: 8px;
+}
+
+.chart {
+  width: 100%;
+  height: 440px;
+}
+
+.no-data-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px;
+  color: $text-secondary;
+  text-align: center;
+
+  mat-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+  }
+}
+
+@media (max-width: 1200px) {
+  .stats-row {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 700px) {
+  .stats-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/src/app/modules/grafico/evolucion-costo/evolucion-costo.component.ts
+++ b/src/app/modules/grafico/evolucion-costo/evolucion-costo.component.ts
@@ -1,0 +1,397 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { EChartsOption } from 'echarts';
+import { BehaviorSubject, Observable, catchError, of } from 'rxjs';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { MatDialog } from '@angular/material/dialog';
+import { Producto } from '../../productos/producto/producto.model';
+import {
+  PdvSearchProductoData,
+  PdvSearchProductoDialogComponent,
+  PdvSearchProductoResponseData
+} from '../../productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component';
+import { GraficoService } from '../grafico.service';
+import { dateToString } from '../../../commons/core/utils/dateUtils';
+import { formatoMonedaPy } from '../../../shared/utils/grafico-echarts.theme';
+import { ProductoCostoPorPeriodo } from './interfaces/producto-costo-periodo.model';
+import { EvolucionCostoResponse } from './interfaces/evolucion-costo-response.model';
+import { EvolucionCostoVista } from './interfaces/evolucion-costo-vista.model';
+
+type VistaTemporal = 'dia' | 'mes';
+
+interface RangoFechas {
+  inicio: string;
+  fin: string;
+  inicioDate: Date;
+  finDate: Date;
+}
+
+interface SerieCosto {
+  etiquetas: string[];
+  tooltips: string[];
+  promedios: (number | null)[];
+  minimos: (number | null)[];
+  maximos: (number | null)[];
+  cantidades: number[];
+  comprasCount: number[];
+}
+
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'evolucion-costo',
+  templateUrl: './evolucion-costo.component.html',
+  styleUrls: ['./evolucion-costo.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'evolucion-costo-host' }
+})
+export class EvolucionCostoComponent implements OnInit {
+
+  private graficoService = inject(GraficoService);
+  private dialog = inject(MatDialog);
+  private cdr = inject(ChangeDetectorRef);
+
+  private datosSubject = new BehaviorSubject<EvolucionCostoVista | null>(null);
+  datos$: Observable<EvolucionCostoVista | null> = this.datosSubject.asObservable();
+
+  cargando = false;
+  productoSeleccionado: Producto | null = null;
+  etiquetaProducto = 'Seleccione un producto';
+
+  fechaRangoGroup = new FormGroup({
+    inicio: new FormControl<Date | null>(null),
+    fin: new FormControl<Date | null>(null)
+  });
+
+  // El costo de compra se registra de forma global (no por sucursal) y la vista es siempre mensual.
+  private readonly vista: VistaTemporal = 'mes';
+
+  private meses = [
+    'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+    'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'
+  ];
+
+  private colores = {
+    text: '#E0E0E0',
+    textSecondary: '#9E9E9E',
+    primary: '#689F38',
+    accent: '#009688',
+    warn: '#F44336'
+  };
+
+  ngOnInit(): void {
+    this.inicializarRangoPorDefecto();
+  }
+
+  private inicializarRangoPorDefecto(): void {
+    const hoy = new Date();
+    // Últimos 12 meses por defecto: la tendencia de costo es más útil que un solo mes.
+    const inicio = new Date(hoy.getFullYear(), hoy.getMonth() - 11, 1);
+    this.fechaRangoGroup.setValue({ inicio, fin: hoy }, { emitEvent: false });
+  }
+
+  /** Aplica los filtros manualmente (botón Filtrar). */
+  filtrar(): void {
+    this.cargarDatos();
+  }
+
+  abrirBusquedaProducto(): void {
+    const data: PdvSearchProductoData = {
+      mostrarOpciones: false,
+      mostrarStock: true,
+      conservarUltimaBusqueda: true,
+      modoSeleccionMultiple: false,
+      productosSeleccionados: this.productoSeleccionado ? [this.productoSeleccionado] : []
+    };
+
+    this.dialog.open(PdvSearchProductoDialogComponent, {
+      data,
+      width: '75%',
+      height: '85%',
+      maxWidth: '95vw'
+    }).afterClosed().pipe(untilDestroyed(this)).subscribe((res: PdvSearchProductoResponseData) => {
+      // El diálogo en modo simple devuelve `producto`; el array `productos` solo en modo múltiple.
+      const producto = res?.productos?.length ? res.productos[0] : res?.producto;
+      if (producto) {
+        this.seleccionarProducto(producto);
+      }
+    });
+  }
+
+  private seleccionarProducto(producto: Producto): void {
+    this.productoSeleccionado = producto;
+    this.etiquetaProducto = producto.descripcion;
+    this.cargarDatos();
+  }
+
+  limpiarProducto(): void {
+    this.productoSeleccionado = null;
+    this.etiquetaProducto = 'Seleccione un producto';
+    this.datosSubject.next(null);
+    this.cdr.markForCheck();
+  }
+
+  private obtenerRangoFechas(): RangoFechas | null {
+    const inicio = this.fechaRangoGroup.value.inicio;
+    const fin = this.fechaRangoGroup.value.fin;
+    if (!inicio || !fin) return null;
+
+    const inicioDate = new Date(inicio);
+    const finDate = new Date(fin);
+    inicioDate.setHours(0, 0, 0, 0);
+    finDate.setHours(0, 0, 0, 0);
+    if (finDate < inicioDate) return null;
+
+    const finExclusive = new Date(finDate);
+    finExclusive.setDate(finExclusive.getDate() + 1);
+
+    return {
+      inicio: `${dateToString(inicioDate, 'yyyy-MM-dd')} 00:00:00`,
+      fin: `${dateToString(finExclusive, 'yyyy-MM-dd')} 00:00:00`,
+      inicioDate,
+      finDate
+    };
+  }
+
+  private cargarDatos(): void {
+    if (!this.productoSeleccionado) return;
+    const rango = this.obtenerRangoFechas();
+    if (!rango) return;
+
+    this.cargando = true;
+    this.cdr.markForCheck();
+
+    const productoId = Number(this.productoSeleccionado.id);
+    const vista = this.vista;
+
+    this.graficoService.obtenerEvolucionCostoProducto(rango.inicio, rango.fin, productoId, vista).pipe(
+      catchError(() => of(null)),
+      untilDestroyed(this)
+    ).subscribe(respuesta => {
+      this.cargando = false;
+      this.datosSubject.next(this.construirVista(respuesta, vista, rango));
+      this.cdr.markForCheck();
+    });
+  }
+
+  /** Toma la serie + resumen (ya calculado en backend) y los prepara para presentación. */
+  private construirVista(respuesta: EvolucionCostoResponse | null, vista: VistaTemporal, rango: RangoFechas): EvolucionCostoVista {
+    const nombre = this.productoSeleccionado?.descripcion || 'Producto';
+    const periodos = respuesta?.periodos || [];
+    const resumen = respuesta?.resumen;
+    const serie = vista === 'mes'
+      ? this.prepararSerieMensual(periodos, rango)
+      : this.prepararSerieDiaria(periodos, rango);
+
+    const variacionPct = resumen?.variacionPorcentual ?? 0;
+    const periodoPico = this.formatearPeriodo(resumen?.periodoConMayorCosto || '-', vista);
+
+    return {
+      chartOptions: this.construirChart(serie, nombre, vista),
+      hayDatos: resumen?.hayDatos ?? false,
+      productoNombre: nombre,
+      costoInicial: formatoMonedaPy(Math.round(resumen?.costoInicial ?? 0)),
+      costoFinal: formatoMonedaPy(Math.round(resumen?.costoFinal ?? 0)),
+      variacion: `${variacionPct >= 0 ? '+' : ''}${variacionPct.toFixed(1)}%`,
+      variacionPositiva: variacionPct > 0,
+      costoPromedio: formatoMonedaPy(Math.round(resumen?.costoPromedioPonderado ?? 0)),
+      periodoPico,
+      totalCompras: resumen?.totalCompras ?? 0
+    };
+  }
+
+  private construirChart(serie: SerieCosto, nombreProducto: string, vista: VistaTemporal): EChartsOption {
+    const rotar = serie.etiquetas.length > 14;
+    const titulo = vista === 'mes' ? 'Evolución mensual del costo' : 'Evolución diaria del costo';
+
+    return {
+      title: {
+        text: `${titulo}: ${this.truncar(nombreProducto, 35)}`,
+        subtext: 'Costo unitario de compra (ponderado por cantidad)',
+        left: 'center',
+        textStyle: { color: this.colores.text, fontSize: 14, fontWeight: 'bold' },
+        subtextStyle: { color: this.colores.textSecondary, fontSize: 11 }
+      },
+      tooltip: {
+        trigger: 'axis',
+        formatter: (params: any) => {
+          const idx = params[0]?.dataIndex ?? 0;
+          const prom = serie.promedios[idx];
+          if (prom == null) {
+            return `<strong>${serie.tooltips[idx]}</strong><br/>Sin compras`;
+          }
+          return `<strong>${serie.tooltips[idx]}</strong><br/>
+            Costo promedio: ${formatoMonedaPy(Math.round(prom))}<br/>
+            Costo mínimo: ${formatoMonedaPy(Math.round(serie.minimos[idx] || 0))}<br/>
+            Costo máximo: ${formatoMonedaPy(Math.round(serie.maximos[idx] || 0))}<br/>
+            Cantidad comprada: ${(serie.cantidades[idx] || 0).toLocaleString('es-PY')}<br/>
+            Compras: ${serie.comprasCount[idx] || 0}`;
+        }
+      },
+      legend: {
+        data: ['Costo promedio', 'Costo mínimo', 'Costo máximo'],
+        bottom: 0,
+        textStyle: { color: this.colores.textSecondary, fontSize: 10 }
+      },
+      grid: { left: '3%', right: '4%', bottom: rotar ? '22%' : '14%', top: '20%', containLabel: true },
+      xAxis: {
+        type: 'category',
+        data: serie.etiquetas,
+        boundaryGap: false,
+        axisLabel: {
+          color: this.colores.textSecondary,
+          rotate: rotar ? 45 : 0,
+          fontSize: 9,
+          interval: this.calcularIntervaloEtiquetas(serie.etiquetas.length)
+        },
+        axisLine: { lineStyle: { color: '#555' } }
+      },
+      yAxis: {
+        type: 'value',
+        scale: true,
+        axisLabel: {
+          color: this.colores.textSecondary,
+          formatter: (v: number) => this.formatoEjeGs(v)
+        },
+        splitLine: { lineStyle: { color: '#444' } }
+      },
+      series: [
+        {
+          name: 'Costo promedio',
+          type: 'line',
+          data: serie.promedios,
+          connectNulls: true,
+          smooth: true,
+          symbol: 'circle',
+          symbolSize: 7,
+          lineStyle: { color: this.colores.primary, width: 3 },
+          itemStyle: { color: this.colores.primary },
+          areaStyle: {
+            color: {
+              type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
+              colorStops: [
+                { offset: 0, color: 'rgba(104,159,56,0.35)' },
+                { offset: 1, color: 'rgba(104,159,56,0.02)' }
+              ]
+            }
+          }
+        },
+        {
+          name: 'Costo mínimo',
+          type: 'line',
+          data: serie.minimos.map((v, i) => (serie.promedios[i] == null ? null : v)),
+          connectNulls: true,
+          smooth: true,
+          symbol: 'none',
+          lineStyle: { color: this.colores.accent, width: 1, type: 'dashed' }
+        },
+        {
+          name: 'Costo máximo',
+          type: 'line',
+          data: serie.maximos.map((v, i) => (serie.promedios[i] == null ? null : v)),
+          connectNulls: true,
+          smooth: true,
+          symbol: 'none',
+          lineStyle: { color: this.colores.warn, width: 1, type: 'dashed' }
+        }
+      ]
+    };
+  }
+
+  private prepararSerieDiaria(costos: ProductoCostoPorPeriodo[], rango: RangoFechas): SerieCosto {
+    const mapa = new Map<string, ProductoCostoPorPeriodo>();
+    for (const c of costos) {
+      mapa.set(this.normalizarFechaPeriodo(c.periodo), c);
+    }
+
+    const serie = this.serieVacia();
+    const cursor = new Date(rango.inicioDate);
+    while (cursor <= rango.finDate) {
+      const key = dateToString(cursor, 'yyyy-MM-dd');
+      const dia = String(cursor.getDate()).padStart(2, '0');
+      const mes = String(cursor.getMonth() + 1).padStart(2, '0');
+      serie.etiquetas.push(`${dia}/${mes}`);
+      serie.tooltips.push(`${dia}/${mes}/${cursor.getFullYear()}`);
+      this.empujarPunto(serie, mapa.get(key));
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    return serie;
+  }
+
+  private prepararSerieMensual(costos: ProductoCostoPorPeriodo[], rango: RangoFechas): SerieCosto {
+    const mapa = new Map<string, ProductoCostoPorPeriodo>();
+    for (const c of costos) {
+      mapa.set(c.periodo, c);
+    }
+
+    const serie = this.serieVacia();
+    const cursor = new Date(rango.inicioDate.getFullYear(), rango.inicioDate.getMonth(), 1);
+    const finMes = new Date(rango.finDate.getFullYear(), rango.finDate.getMonth(), 1);
+    while (cursor <= finMes) {
+      const key = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, '0')}`;
+      serie.etiquetas.push(`${this.meses[cursor.getMonth()].substring(0, 3)} ${cursor.getFullYear()}`);
+      serie.tooltips.push(`${this.meses[cursor.getMonth()]} ${cursor.getFullYear()}`);
+      this.empujarPunto(serie, mapa.get(key));
+      cursor.setMonth(cursor.getMonth() + 1);
+    }
+    return serie;
+  }
+
+  private empujarPunto(serie: SerieCosto, dato?: ProductoCostoPorPeriodo): void {
+    serie.promedios.push(dato ? dato.costoPromedio : null);
+    serie.minimos.push(dato ? dato.costoMinimo : null);
+    serie.maximos.push(dato ? dato.costoMaximo : null);
+    serie.cantidades.push(dato ? dato.cantidad : 0);
+    serie.comprasCount.push(dato ? dato.cantidadCompras : 0);
+  }
+
+  private serieVacia(): SerieCosto {
+    return { etiquetas: [], tooltips: [], promedios: [], minimos: [], maximos: [], cantidades: [], comprasCount: [] };
+  }
+
+  /** Convierte el período crudo del backend (YYYY-MM o YYYY-MM-DD) a etiqueta legible. */
+  private formatearPeriodo(periodo: string, vista: VistaTemporal): string {
+    if (!periodo || periodo === '-') return '-';
+    if (vista === 'mes') {
+      const partes = periodo.split('-');
+      if (partes.length >= 2) {
+        const mesIdx = Number(partes[1]) - 1;
+        if (mesIdx >= 0 && mesIdx < 12) return `${this.meses[mesIdx].substring(0, 3)} ${partes[0]}`;
+      }
+      return periodo;
+    }
+    const key = this.normalizarFechaPeriodo(periodo);
+    const partes = key.split('-');
+    return partes.length === 3 ? `${partes[2]}/${partes[1]}/${partes[0]}` : periodo;
+  }
+
+  private normalizarFechaPeriodo(periodo: string): string {
+    if (!periodo) return '';
+    const texto = periodo.substring(0, 10);
+    if (/^\d{4}-\d{2}-\d{2}$/.test(texto)) return texto;
+    const d = new Date(periodo);
+    if (!isNaN(d.getTime())) return dateToString(d, 'yyyy-MM-dd');
+    return texto;
+  }
+
+  private calcularIntervaloEtiquetas(total: number): number | 'auto' {
+    if (total <= 15) return 0;
+    if (total <= 31) return 1;
+    if (total <= 60) return 2;
+    return Math.floor(total / 20);
+  }
+
+  private formatoEjeGs(valor: number): string {
+    if (valor >= 1_000_000) return (valor / 1_000_000).toFixed(1) + 'M';
+    if (valor >= 1_000) return (valor / 1_000).toFixed(0) + 'k';
+    return valor.toString();
+  }
+
+  private truncar(texto: string, max: number): string {
+    return texto.length > max ? texto.substring(0, max - 2) + '…' : texto;
+  }
+
+  limpiarFiltros(): void {
+    this.inicializarRangoPorDefecto();
+    this.cargarDatos();
+  }
+}

--- a/src/app/modules/grafico/evolucion-costo/interfaces/evolucion-costo-response.model.ts
+++ b/src/app/modules/grafico/evolucion-costo/interfaces/evolucion-costo-response.model.ts
@@ -1,0 +1,16 @@
+import { ProductoCostoPorPeriodo } from './producto-costo-periodo.model';
+
+export interface EvolucionCostoResumen {
+  costoInicial: number;
+  costoFinal: number;
+  variacionPorcentual: number;
+  costoPromedioPonderado: number;
+  periodoConMayorCosto: string;
+  totalCompras: number;
+  hayDatos: boolean;
+}
+
+export interface EvolucionCostoResponse {
+  periodos: ProductoCostoPorPeriodo[];
+  resumen: EvolucionCostoResumen;
+}

--- a/src/app/modules/grafico/evolucion-costo/interfaces/evolucion-costo-vista.model.ts
+++ b/src/app/modules/grafico/evolucion-costo/interfaces/evolucion-costo-vista.model.ts
@@ -1,0 +1,15 @@
+import { EChartsOption } from 'echarts';
+
+export interface EvolucionCostoVista {
+  chartOptions: EChartsOption;
+  hayDatos: boolean;
+  productoNombre: string | null;
+  costoInicial: string;
+  costoFinal: string;
+  variacion: string;
+  /** true = el costo subió en el período (desfavorable). */
+  variacionPositiva: boolean;
+  costoPromedio: string;
+  periodoPico: string;
+  totalCompras: number;
+}

--- a/src/app/modules/grafico/evolucion-costo/interfaces/producto-costo-periodo.model.ts
+++ b/src/app/modules/grafico/evolucion-costo/interfaces/producto-costo-periodo.model.ts
@@ -1,0 +1,8 @@
+export interface ProductoCostoPorPeriodo {
+  periodo: string;
+  costoPromedio: number;
+  costoMinimo: number;
+  costoMaximo: number;
+  cantidad: number;
+  cantidadCompras: number;
+}

--- a/src/app/modules/grafico/grafico.service.ts
+++ b/src/app/modules/grafico/grafico.service.ts
@@ -12,6 +12,7 @@ import { VentasPorFuncionarioMultiGQL } from './graphql/ventas-por-funcionario-m
 import { FormaPagoEstadisticasMultiGQL } from './graphql/forma-pago-estadisticas-multi.gql';
 import { GastosPorCategoriaMultiGQL } from './graphql/gastos-por-categoria-multi.gql';
 import { VentasPorSucursalMultiGQL } from './graphql/ventas-por-sucursal-multi.gql';
+import { DeliveryPorSucursalMultiGQL } from './graphql/delivery-por-sucursal-multi.gql';
 import { VentasPorCiudadMultiGQL } from './graphql/ventas-por-ciudad-multi.gql';
 import { ExportarGraficoExcelGQL } from './graphql/exportar-grafico-excel.gql';
 import {
@@ -54,6 +55,7 @@ export class GraficoService {
   private formaPagoMultiGQL = inject(FormaPagoEstadisticasMultiGQL);
   private gastosPorCategoriaMultiGQL = inject(GastosPorCategoriaMultiGQL);
   private ventasPorSucursalMultiGQL = inject(VentasPorSucursalMultiGQL);
+  private deliveryPorSucursalMultiGQL = inject(DeliveryPorSucursalMultiGQL);
   private ventasPorCiudadMultiGQL = inject(VentasPorCiudadMultiGQL);
   private exportarGraficoExcelGQL = inject(ExportarGraficoExcelGQL);
   private productosMasVendidosMultiGQL = inject(ProductosMasVendidosMultiGQL);
@@ -267,6 +269,18 @@ export class GraficoService {
   ): Observable<VentaSucursalItem[]> {
     return this.genericService.onCustomQuery(
       this.ventasPorSucursalMultiGQL,
+      { periodos },
+      true,
+      null,
+      true
+    );
+  }
+
+  obtenerDeliveryPorSucursalMulti(
+    periodos: PeriodoGraficoInput[]
+  ): Observable<VentaSucursalItem[]> {
+    return this.genericService.onCustomQuery(
+      this.deliveryPorSucursalMultiGQL,
       { periodos },
       true,
       null,

--- a/src/app/modules/grafico/grafico.service.ts
+++ b/src/app/modules/grafico/grafico.service.ts
@@ -26,6 +26,10 @@ import { VentasProductoPorDiaGQL } from './graphql/ventas-producto-por-dia.gql';
 import { VentasProductoPorMesGQL } from './graphql/ventas-producto-por-mes.gql';
 import { ComprasProductoPorDiaGQL } from './graphql/compras-producto-por-dia.gql';
 import { ComprasProductoPorMesGQL } from './graphql/compras-producto-por-mes.gql';
+import { EvolucionCostoProductoGQL } from './graphql/evolucion-costo-producto.gql';
+import { EvolucionCostoResponse } from './evolucion-costo/interfaces/evolucion-costo-response.model';
+import { RankingInflacionCostoGQL } from './graphql/ranking-inflacion-costo.gql';
+import { RankingInflacionItem } from './ranking-inflacion/interfaces/ranking-inflacion-item.model';
 import { ProductoVentaPorPeriodo } from './producto-vendido/interfaces/producto-venta-periodo.model';
 import { ProductoCompraPorPeriodo } from './producto-vendido/interfaces/producto-compra-periodo.model';
 import { FormaPagoEstadistica } from './forma-pago/interfaces/forma-pago-estadistica.model';
@@ -59,6 +63,8 @@ export class GraficoService {
   private ventasProductoPorMesGQL = inject(VentasProductoPorMesGQL);
   private comprasProductoPorDiaGQL = inject(ComprasProductoPorDiaGQL);
   private comprasProductoPorMesGQL = inject(ComprasProductoPorMesGQL);
+  private evolucionCostoProductoGQL = inject(EvolucionCostoProductoGQL);
+  private rankingInflacionCostoGQL = inject(RankingInflacionCostoGQL);
 
   obtenerSucursales(): Observable<Sucursal[]> {
     return this.sucursalService.onGetAllSucursales(true);
@@ -155,6 +161,50 @@ export class GraficoService {
         inicio, fin,
         productoId: String(productoId),
         sucursalId: sucId ? String(sucId) : null
+      },
+      true,
+      null,
+      true
+    );
+  }
+
+  obtenerEvolucionCostoProducto(
+    inicio: string,
+    fin: string,
+    productoId: number,
+    agrupacion: 'dia' | 'mes',
+    sucId?: number
+  ): Observable<EvolucionCostoResponse> {
+    return this.genericService.onCustomQuery(
+      this.evolucionCostoProductoGQL,
+      {
+        inicio, fin,
+        productoId: String(productoId),
+        sucursalId: sucId ? String(sucId) : null,
+        agrupacion
+      },
+      true,
+      null,
+      true
+    );
+  }
+
+  obtenerRankingInflacionCosto(
+    inicio: string,
+    fin: string,
+    limit: number,
+    orden: 'suba' | 'baja',
+    sucId?: number,
+    familiaId?: number
+  ): Observable<RankingInflacionItem[]> {
+    return this.genericService.onCustomQuery(
+      this.rankingInflacionCostoGQL,
+      {
+        inicio, fin,
+        sucursalId: sucId ? String(sucId) : null,
+        familiaId: familiaId ? String(familiaId) : null,
+        limit,
+        orden
       },
       true,
       null,

--- a/src/app/modules/grafico/graficos.module.ts
+++ b/src/app/modules/grafico/graficos.module.ts
@@ -16,6 +16,7 @@ import { VentasDiasComponent } from './ventas-dias/ventas-dias.component';
 import { GastoCategoriaComponent } from './gasto-categoria/gasto-categoria.component';
 import { IngresoGastoComponent } from './ingreso-gasto/ingreso-gasto.component';
 import { VentaSucursalComponent } from './venta-sucursal/venta-sucursal.component';
+import { DeliverySucursalComponent } from './delivery-sucursal/delivery-sucursal.component';
 import { VentaCiudadComponent } from './venta-ciudad/venta-ciudad.component';
 import { VentaMesComponent } from './venta-mes/venta-mes.component';
 import { EvolucionCostoComponent } from './evolucion-costo/evolucion-costo.component';
@@ -54,6 +55,7 @@ export function loadEcharts() {
         GastoCategoriaComponent,
         IngresoGastoComponent,
         VentaSucursalComponent,
+        DeliverySucursalComponent,
         VentaCiudadComponent,
         VentaMesComponent,
         EvolucionCostoComponent,

--- a/src/app/modules/grafico/graficos.module.ts
+++ b/src/app/modules/grafico/graficos.module.ts
@@ -18,6 +18,8 @@ import { IngresoGastoComponent } from './ingreso-gasto/ingreso-gasto.component';
 import { VentaSucursalComponent } from './venta-sucursal/venta-sucursal.component';
 import { VentaCiudadComponent } from './venta-ciudad/venta-ciudad.component';
 import { VentaMesComponent } from './venta-mes/venta-mes.component';
+import { EvolucionCostoComponent } from './evolucion-costo/evolucion-costo.component';
+import { RankingInflacionComponent } from './ranking-inflacion/ranking-inflacion.component';
 
 export function loadEcharts() {
     return import('echarts/core').then(echarts => {
@@ -54,6 +56,8 @@ export function loadEcharts() {
         VentaSucursalComponent,
         VentaCiudadComponent,
         VentaMesComponent,
+        EvolucionCostoComponent,
+        RankingInflacionComponent,
     ],
     imports: [
         CommonModule,

--- a/src/app/modules/grafico/graficos/graficos-dashboard-mock.data.ts
+++ b/src/app/modules/grafico/graficos/graficos-dashboard-mock.data.ts
@@ -20,6 +20,15 @@ export const MOCK_VENTAS_POR_SUCURSAL: VentaSucursalItem[] = [
   { sucId: 6, nombre: "Fiesta", total: 78_000_000 },
 ];
 
+export const MOCK_DELIVERY_POR_SUCURSAL: VentaSucursalItem[] = [
+  { sucId: 4, nombre: "Renacer", total: 12_400_000 },
+  { sucId: 1, nombre: "Canindeyu 1", total: 9_800_000 },
+  { sucId: 6, nombre: "Fiesta", total: 8_600_000 },
+  { sucId: 2, nombre: "Curuguaty 2", total: 6_300_000 },
+  { sucId: 3, nombre: "Paloma 2", total: 5_100_000 },
+  { sucId: 5, nombre: "KM2", total: 3_700_000 },
+];
+
 export const MOCK_VENTAS_POR_CIUDAD: VentaCiudadItem[] = [
   { ciudadId: 1, nombre: "Katuete", total: 157_000_000 },
   { ciudadId: 2, nombre: "Curuguaty", total: 72_000_000 },

--- a/src/app/modules/grafico/graficos/graficos-dashboard-opciones.util.ts
+++ b/src/app/modules/grafico/graficos/graficos-dashboard-opciones.util.ts
@@ -31,6 +31,7 @@ import {
   MOCK_VENTAS_FUNCIONARIO,
   MOCK_VENTAS_POR_HORA,
   MOCK_VENTAS_POR_SUCURSAL,
+  MOCK_DELIVERY_POR_SUCURSAL,
   MOCK_VENTAS_POR_CIUDAD,
   SUBTITULO_VISTA_PREVIA,
 } from "./graficos-dashboard-mock.data";
@@ -68,6 +69,38 @@ export function opcionesVentasPorSucursalMock(
     series: [
       {
         name: "Ventas",
+        type: "bar",
+        data: validas.map((v) => v.total),
+        itemStyle: {
+          color: degradadoBarraVertical(),
+          borderRadius: [4, 4, 0, 0],
+        },
+      },
+    ],
+  };
+}
+
+export function opcionesDeliveryPorSucursalMock(
+  datos: VentaSucursalItem[]
+): EChartsOption {
+  const validas = [...datos].sort((a, b) => (b.total || 0) - (a.total || 0));
+  const totalGeneral = validas.reduce((sum, item) => sum + (item.total || 0), 0);
+
+  return {
+    title: tituloGraficoCentrado(
+      "Ventas con Delivery",
+      `${SUBTITULO_VISTA_PREVIA} · ${formatoMonedaPy(totalGeneral)}`
+    ),
+    tooltip: tooltipEjeMoneda("Delivery"),
+    grid: gridGraficoOscuro(),
+    xAxis: ejeCategoriaOscuro(
+      validas.map((v) => v.nombre || `Suc ${v.sucId}`),
+      30
+    ),
+    yAxis: ejeValorOscuro(),
+    series: [
+      {
+        name: "Delivery",
         type: "bar",
         data: validas.map((v) => v.total),
         itemStyle: {
@@ -534,6 +567,9 @@ export function construirVistaDashboardMock(): GraficosDashboardVista {
   return {
     cargando: false,
     ventasPorSucursal: opcionesVentasPorSucursalMock(MOCK_VENTAS_POR_SUCURSAL),
+    deliveryPorSucursal: opcionesDeliveryPorSucursalMock(
+      MOCK_DELIVERY_POR_SUCURSAL
+    ),
     ventasPorCiudad: opcionesVentasPorCiudadMock(MOCK_VENTAS_POR_CIUDAD),
     formasPago: opcionesFormasPagoMock(MOCK_FORMAS_PAGO),
     gastosCategoria: opcionesGastosCategoriaMock(MOCK_GASTOS_CATEGORIA),

--- a/src/app/modules/grafico/graficos/graficos-dashboard-opciones.util.ts
+++ b/src/app/modules/grafico/graficos/graficos-dashboard-opciones.util.ts
@@ -427,6 +427,109 @@ export function opcionesProductosMock(
   };
 }
 
+export function opcionesEvolucionCostoMock(): EChartsOption {
+  const meses = ["Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago"];
+  const promedio = [8500, 8500, 8900, 9200, 9200, 9800, 10100, 10500];
+  const minimo = [8300, 8300, 8600, 8900, 9000, 9400, 9700, 10100];
+  const maximo = [8800, 8800, 9300, 9600, 9500, 10200, 10600, 11000];
+
+  return {
+    title: tituloGraficoCentrado(
+      "Evolución de Costos",
+      `${SUBTITULO_VISTA_PREVIA} · +23.5%`
+    ),
+    tooltip: { trigger: "axis" },
+    grid: gridGraficoOscuro("12%"),
+    xAxis: ejeCategoriaOscuro(meses),
+    yAxis: ejeValorOscuro(),
+    series: [
+      {
+        name: "Costo promedio",
+        type: "line",
+        data: promedio,
+        smooth: true,
+        symbol: "circle",
+        symbolSize: 6,
+        lineStyle: { color: GRAFICO_COLORES.primary, width: 3 },
+        itemStyle: { color: GRAFICO_COLORES.primary },
+        areaStyle: {
+          color: {
+            type: "linear",
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              { offset: 0, color: "rgba(104,159,56,0.35)" },
+              { offset: 1, color: "rgba(104,159,56,0.02)" },
+            ],
+          },
+        },
+      },
+      {
+        name: "Costo mínimo",
+        type: "line",
+        data: minimo,
+        smooth: true,
+        symbol: "none",
+        lineStyle: { color: GRAFICO_COLORES.accent, width: 1, type: "dashed" },
+      },
+      {
+        name: "Costo máximo",
+        type: "line",
+        data: maximo,
+        smooth: true,
+        symbol: "none",
+        lineStyle: { color: GRAFICO_COLORES.warn, width: 1, type: "dashed" },
+      },
+    ],
+  };
+}
+
+export function opcionesRankingInflacionMock(): EChartsOption {
+  const productos = [
+    "Aceite 900ml",
+    "Harina 1kg",
+    "Azúcar 1kg",
+    "Arroz 1kg",
+    "Fideo 500g",
+    "Leche 1L",
+  ];
+  const variaciones = [8, 12, 18, 24, 31, 42];
+
+  return {
+    title: tituloGraficoCentrado(
+      "Inflación de Costos",
+      `${SUBTITULO_VISTA_PREVIA} · Mayor suba`
+    ),
+    tooltip: { trigger: "axis", axisPointer: { type: "shadow" } },
+    grid: { left: "30%", right: "10%", bottom: "5%", top: "18%", containLabel: true },
+    xAxis: {
+      type: "value",
+      axisLabel: {
+        color: GRAFICO_COLORES.textSecondary,
+        formatter: (v: number) => `${v}%`,
+      },
+      splitLine: { lineStyle: { color: GRAFICO_COLORES.splitLine } },
+    },
+    yAxis: {
+      type: "category",
+      data: productos,
+      axisLabel: { color: GRAFICO_COLORES.textSecondary, fontSize: 10 },
+    },
+    series: [
+      {
+        name: "Variación",
+        type: "bar",
+        data: variaciones.map((v) => ({
+          value: v,
+          itemStyle: { color: GRAFICO_COLORES.warn, borderRadius: [0, 4, 4, 0] },
+        })),
+      },
+    ],
+  };
+}
+
 export function construirVistaDashboardMock(): GraficosDashboardVista {
   return {
     cargando: false,
@@ -451,5 +554,7 @@ export function construirVistaDashboardMock(): GraficosDashboardVista {
       GRAFICO_COLORES.warn,
       "Menor rotación del mes"
     ),
+    evolucionCosto: opcionesEvolucionCostoMock(),
+    rankingInflacion: opcionesRankingInflacionMock(),
   };
 }

--- a/src/app/modules/grafico/graficos/graficos.component.html
+++ b/src/app/modules/grafico/graficos/graficos.component.html
@@ -108,6 +108,30 @@
           class="chart"
         ></div>
       </div>
+
+      <div
+        class="chart-card clickable"
+        (click)="onChartClick('evolucion-costo')"
+      >
+        <div
+          *ngIf="vista.evolucionCosto as opciones"
+          echarts
+          [options]="opciones"
+          class="chart"
+        ></div>
+      </div>
+
+      <div
+        class="chart-card clickable"
+        (click)="onChartClick('ranking-inflacion')"
+      >
+        <div
+          *ngIf="vista.rankingInflacion as opciones"
+          echarts
+          [options]="opciones"
+          class="chart"
+        ></div>
+      </div>
     </div>
   </ng-container>
 </div>

--- a/src/app/modules/grafico/graficos/graficos.component.html
+++ b/src/app/modules/grafico/graficos/graficos.component.html
@@ -15,6 +15,18 @@
 
       <div
         class="chart-card clickable"
+        (click)="onChartClick('delivery-sucursal')"
+      >
+        <div
+          *ngIf="vista.deliveryPorSucursal as opciones"
+          echarts
+          [options]="opciones"
+          class="chart"
+        ></div>
+      </div>
+
+      <div
+        class="chart-card clickable"
         (click)="onChartClick('venta-ciudad')"
       >
         <div

--- a/src/app/modules/grafico/graficos/graficos.component.scss
+++ b/src/app/modules/grafico/graficos/graficos.component.scss
@@ -1,6 +1,12 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
 .graficos-dashboard {
   padding: 16px;
-  min-height: 100%;
+  height: 100%;
+  box-sizing: border-box;
   background: #303030;
   overflow-y: auto;
   position: relative;

--- a/src/app/modules/grafico/graficos/graficos.component.ts
+++ b/src/app/modules/grafico/graficos/graficos.component.ts
@@ -11,6 +11,8 @@ import { GastoCategoriaComponent } from "../gasto-categoria/gasto-categoria.comp
 import { IngresoGastoComponent } from "../ingreso-gasto/ingreso-gasto.component";
 import { VentaSucursalComponent } from "../venta-sucursal/venta-sucursal.component";
 import { VentaCiudadComponent } from "../venta-ciudad/venta-ciudad.component";
+import { EvolucionCostoComponent } from "../evolucion-costo/evolucion-costo.component";
+import { RankingInflacionComponent } from "../ranking-inflacion/ranking-inflacion.component";
 import { GraficosDashboardVista } from "./interfaces/graficos-dashboard-vista.model";
 import { construirVistaDashboardMock } from "./graficos-dashboard-opciones.util";
 
@@ -23,7 +25,9 @@ type TipoGraficoDashboard =
   | "hora"
   | "ingreso-gasto"
   | "venta-sucursal"
-  | "venta-ciudad";
+  | "venta-ciudad"
+  | "evolucion-costo"
+  | "ranking-inflacion";
 
 @Component({
   selector: "app-graficos",
@@ -91,6 +95,16 @@ export class GraficosComponent {
       case "venta-ciudad":
         this.tabService.addTab(
           new Tab(VentaCiudadComponent, "Ventas por Ciudad", null, null)
+        );
+        break;
+      case "evolucion-costo":
+        this.tabService.addTab(
+          new Tab(EvolucionCostoComponent, "Evolución de Costos", null, null)
+        );
+        break;
+      case "ranking-inflacion":
+        this.tabService.addTab(
+          new Tab(RankingInflacionComponent, "Inflación de Costos", null, null)
         );
         break;
     }

--- a/src/app/modules/grafico/graficos/graficos.component.ts
+++ b/src/app/modules/grafico/graficos/graficos.component.ts
@@ -10,6 +10,7 @@ import { VentasDiasComponent } from "../ventas-dias/ventas-dias.component";
 import { GastoCategoriaComponent } from "../gasto-categoria/gasto-categoria.component";
 import { IngresoGastoComponent } from "../ingreso-gasto/ingreso-gasto.component";
 import { VentaSucursalComponent } from "../venta-sucursal/venta-sucursal.component";
+import { DeliverySucursalComponent } from "../delivery-sucursal/delivery-sucursal.component";
 import { VentaCiudadComponent } from "../venta-ciudad/venta-ciudad.component";
 import { EvolucionCostoComponent } from "../evolucion-costo/evolucion-costo.component";
 import { RankingInflacionComponent } from "../ranking-inflacion/ranking-inflacion.component";
@@ -25,6 +26,7 @@ type TipoGraficoDashboard =
   | "hora"
   | "ingreso-gasto"
   | "venta-sucursal"
+  | "delivery-sucursal"
   | "venta-ciudad"
   | "evolucion-costo"
   | "ranking-inflacion";
@@ -90,6 +92,11 @@ export class GraficosComponent {
       case "venta-sucursal":
         this.tabService.addTab(
           new Tab(VentaSucursalComponent, "Ventas por Sucursal", null, null)
+        );
+        break;
+      case "delivery-sucursal":
+        this.tabService.addTab(
+          new Tab(DeliverySucursalComponent, "Ventas con Delivery", null, null)
         );
         break;
       case "venta-ciudad":

--- a/src/app/modules/grafico/graficos/interfaces/graficos-dashboard-vista.model.ts
+++ b/src/app/modules/grafico/graficos/interfaces/graficos-dashboard-vista.model.ts
@@ -11,6 +11,8 @@ export interface GraficosDashboardVista {
   ventasFuncionario: EChartsOption | null;
   productosMasVendidos: EChartsOption | null;
   analisisProducto: EChartsOption | null;
+  evolucionCosto: EChartsOption | null;
+  rankingInflacion: EChartsOption | null;
 }
 
 export const GRAFICOS_DASHBOARD_VISTA_INICIAL: GraficosDashboardVista = {
@@ -24,4 +26,6 @@ export const GRAFICOS_DASHBOARD_VISTA_INICIAL: GraficosDashboardVista = {
   ventasFuncionario: null,
   productosMasVendidos: null,
   analisisProducto: null,
+  evolucionCosto: null,
+  rankingInflacion: null,
 };

--- a/src/app/modules/grafico/graficos/interfaces/graficos-dashboard-vista.model.ts
+++ b/src/app/modules/grafico/graficos/interfaces/graficos-dashboard-vista.model.ts
@@ -3,6 +3,7 @@ import { EChartsOption } from "echarts";
 export interface GraficosDashboardVista {
   cargando: boolean;
   ventasPorSucursal: EChartsOption | null;
+  deliveryPorSucursal: EChartsOption | null;
   ventasPorCiudad: EChartsOption | null;
   formasPago: EChartsOption | null;
   gastosCategoria: EChartsOption | null;
@@ -18,6 +19,7 @@ export interface GraficosDashboardVista {
 export const GRAFICOS_DASHBOARD_VISTA_INICIAL: GraficosDashboardVista = {
   cargando: false,
   ventasPorSucursal: null,
+  deliveryPorSucursal: null,
   ventasPorCiudad: null,
   formasPago: null,
   gastosCategoria: null,

--- a/src/app/modules/grafico/graphql/delivery-por-sucursal-multi.gql.ts
+++ b/src/app/modules/grafico/graphql/delivery-por-sucursal-multi.gql.ts
@@ -1,0 +1,19 @@
+import { Injectable } from "@angular/core";
+import { Query } from "apollo-angular";
+import gql from "graphql-tag";
+import { GRAFICO_MULTI_FRAGMENTS } from "./grafico-multi.fragments";
+
+@Injectable({ providedIn: "root" })
+export class DeliveryPorSucursalMultiGQL extends Query<any> {
+  override document = gql`
+    query deliveryPorSucursalMulti($periodos: [PeriodoGraficoInput!]!) {
+      data: deliveryPorSucursalMulti(periodos: $periodos) {
+        sucId
+        nombre
+        total
+        cantidadVentas
+        ${GRAFICO_MULTI_FRAGMENTS.DESGLOSE_PERIODO}
+      }
+    }
+  `;
+}

--- a/src/app/modules/grafico/graphql/evolucion-costo-producto.gql.ts
+++ b/src/app/modules/grafico/graphql/evolucion-costo-producto.gql.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import gql from 'graphql-tag';
+import { EvolucionCostoResponse } from '../evolucion-costo/interfaces/evolucion-costo-response.model';
+
+export interface Response {
+  data: EvolucionCostoResponse;
+}
+
+const evolucionCostoProductoQuery = gql`
+  query evolucionCostoProducto($inicio: String, $fin: String, $productoId: ID!, $sucursalId: ID, $agrupacion: String) {
+    data: evolucionCostoProducto(inicio: $inicio, fin: $fin, productoId: $productoId, sucursalId: $sucursalId, agrupacion: $agrupacion) {
+      periodos {
+        periodo
+        costoPromedio
+        costoMinimo
+        costoMaximo
+        cantidad
+        cantidadCompras
+      }
+      resumen {
+        costoInicial
+        costoFinal
+        variacionPorcentual
+        costoPromedioPonderado
+        periodoConMayorCosto
+        totalCompras
+        hayDatos
+      }
+    }
+  }
+`;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EvolucionCostoProductoGQL extends Query<Response> {
+  document = evolucionCostoProductoQuery;
+}

--- a/src/app/modules/grafico/graphql/ranking-inflacion-costo.gql.ts
+++ b/src/app/modules/grafico/graphql/ranking-inflacion-costo.gql.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import gql from 'graphql-tag';
+import { RankingInflacionItem } from '../ranking-inflacion/interfaces/ranking-inflacion-item.model';
+
+export interface Response {
+  data: RankingInflacionItem[];
+}
+
+const rankingInflacionCostoQuery = gql`
+  query rankingInflacionCosto($inicio: String, $fin: String, $sucursalId: ID, $familiaId: ID, $limit: Int, $orden: String) {
+    data: rankingInflacionCosto(inicio: $inicio, fin: $fin, sucursalId: $sucursalId, familiaId: $familiaId, limit: $limit, orden: $orden) {
+      productoId
+      descripcion
+      costoInicial
+      costoFinal
+      variacionPorcentual
+      periodos
+      totalCompras
+    }
+  }
+`;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RankingInflacionCostoGQL extends Query<Response> {
+  document = rankingInflacionCostoQuery;
+}

--- a/src/app/modules/grafico/ranking-inflacion/interfaces/ranking-inflacion-item.model.ts
+++ b/src/app/modules/grafico/ranking-inflacion/interfaces/ranking-inflacion-item.model.ts
@@ -1,0 +1,9 @@
+export interface RankingInflacionItem {
+  productoId: number;
+  descripcion: string;
+  costoInicial: number;
+  costoFinal: number;
+  variacionPorcentual: number;
+  periodos: number;
+  totalCompras: number;
+}

--- a/src/app/modules/grafico/ranking-inflacion/interfaces/ranking-inflacion-vista.model.ts
+++ b/src/app/modules/grafico/ranking-inflacion/interfaces/ranking-inflacion-vista.model.ts
@@ -1,0 +1,20 @@
+import { EChartsOption } from 'echarts';
+
+export interface RankingInflacionFilaVista {
+  productoId: number;
+  descripcion: string;
+  costoInicial: string;
+  costoFinal: string;
+  variacion: string;
+  /** true = el costo subió (desfavorable). */
+  variacionPositiva: boolean;
+  totalCompras: number;
+  rank: number;
+}
+
+export interface RankingInflacionVista {
+  chartOptions: EChartsOption;
+  filas: RankingInflacionFilaVista[];
+  hayDatos: boolean;
+  titulo: string;
+}

--- a/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.html
+++ b/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.html
@@ -29,22 +29,6 @@
 
     <mat-form-field
       appearance="outline"
-      class="grafico-filtros__campo grafico-filtros__campo--sucursal"
-    >
-      <mat-label>Sucursal</mat-label>
-      <mat-select [formControl]="sucursalControl">
-        <mat-option [value]="null">Todas</mat-option>
-        <mat-option
-          *ngFor="let s of sucursales$ | async"
-          [value]="s.id"
-        >
-          {{ s.nombre }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-
-    <mat-form-field
-      appearance="outline"
       class="grafico-filtros__campo grafico-filtros__campo--familia"
     >
       <mat-label>Familia</mat-label>

--- a/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.html
+++ b/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.html
@@ -1,0 +1,165 @@
+<div class="ranking-inflacion-container grafico-pantalla">
+  <div class="grafico-filtros">
+    <mat-form-field
+      appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--rango"
+    >
+      <mat-label>Período</mat-label>
+      <mat-date-range-input
+        [formGroup]="fechaRangoGroup"
+        [rangePicker]="pickerRango"
+      >
+        <input
+          matStartDate
+          formControlName="inicio"
+          placeholder="Desde"
+        >
+        <input
+          matEndDate
+          formControlName="fin"
+          placeholder="Hasta"
+        >
+      </mat-date-range-input>
+      <mat-datepicker-toggle
+        matSuffix
+        [for]="pickerRango"
+      ></mat-datepicker-toggle>
+      <mat-date-range-picker #pickerRango></mat-date-range-picker>
+    </mat-form-field>
+
+    <mat-form-field
+      appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--sucursal"
+    >
+      <mat-label>Sucursal</mat-label>
+      <mat-select [formControl]="sucursalControl">
+        <mat-option [value]="null">Todas</mat-option>
+        <mat-option
+          *ngFor="let s of sucursales$ | async"
+          [value]="s.id"
+        >
+          {{ s.nombre }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field
+      appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--familia"
+    >
+      <mat-label>Familia</mat-label>
+      <mat-select [formControl]="familiaControl">
+        <mat-option [value]="null">Todas</mat-option>
+        <mat-option
+          *ngFor="let f of familias$ | async"
+          [value]="f.id"
+        >
+          {{ f.nombre | titlecase }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-button-toggle-group
+      [formControl]="ordenControl"
+      class="orden-toggle"
+    >
+      <mat-button-toggle
+        *ngFor="let o of ordenes"
+        [value]="o.valor"
+      >
+        {{ o.label }}
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+
+    <mat-form-field
+      appearance="outline"
+      class="grafico-filtros__campo grafico-filtros__campo--limit"
+    >
+      <mat-label>Top</mat-label>
+      <mat-select [formControl]="limitControl">
+        <mat-option
+          *ngFor="let l of limits"
+          [value]="l"
+        >
+          {{ l }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <div class="grafico-filtros__acciones">
+      <button
+        mat-raised-button
+        color="primary"
+        type="button"
+        (click)="filtrar()"
+      >
+        <mat-icon>filter_alt</mat-icon>
+        Filtrar
+      </button>
+      <button
+        mat-icon-button
+        type="button"
+        (click)="limpiarFiltros()"
+        matTooltip="Limpiar filtros"
+        aria-label="Limpiar filtros"
+      >
+        <mat-icon>filter_alt_off</mat-icon>
+      </button>
+    </div>
+  </div>
+
+  <div
+    class="loading-overlay"
+    *ngIf="cargando"
+  >
+    <mat-spinner diameter="40"></mat-spinner>
+  </div>
+
+  <ng-container *ngIf="datos$ | async as datos">
+    <div
+      class="charts-layout"
+      *ngIf="datos.hayDatos"
+    >
+      <div class="chart-panel">
+        <div
+          echarts
+          [options]="datos.chartOptions"
+          class="chart"
+        ></div>
+      </div>
+
+      <div class="detalle-panel">
+        <h3 class="detalle-title">{{ datos.titulo }}</h3>
+        <div class="detalle-list">
+          <div
+            *ngFor="let fila of datos.filas; trackBy: trackByProductoId"
+            class="detalle-item"
+          >
+            <span class="rank-badge">#{{ fila.rank }}</span>
+            <div class="item-info">
+              <span class="item-name">{{ fila.descripcion }}</span>
+              <span class="item-costos">
+                {{ fila.costoInicial }} → {{ fila.costoFinal }}
+              </span>
+            </div>
+            <span
+              class="variacion-badge"
+              [class.variacion-badge--sube]="fila.variacionPositiva"
+              [class.variacion-badge--baja]="!fila.variacionPositiva"
+            >
+              {{ fila.variacion }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      class="no-data-message"
+      *ngIf="!datos.hayDatos && !cargando"
+    >
+      <mat-icon>trending_up</mat-icon>
+      <span>No hay productos con al menos dos meses de compras en el período seleccionado</span>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.scss
+++ b/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.scss
@@ -29,6 +29,9 @@ $border: #555;
   display: grid;
   grid-template-columns: 1.3fr 1fr;
   gap: 16px;
+  // Ocupa todo el alto restante debajo de la barra de filtros.
+  flex: 1;
+  min-height: 0;
 }
 
 .chart-panel {
@@ -36,11 +39,15 @@ $border: #555;
   border: 1px solid $border;
   border-radius: 12px;
   padding: 8px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .chart {
   width: 100%;
-  height: 560px;
+  flex: 1;
+  min-height: 320px;
 }
 
 .detalle-panel {
@@ -50,6 +57,7 @@ $border: #555;
   padding: 16px;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .detalle-title {
@@ -63,7 +71,8 @@ $border: #555;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  max-height: 520px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding-right: 5px;
 

--- a/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.scss
+++ b/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.scss
@@ -1,0 +1,157 @@
+@import '../styles/grafico-filtros';
+
+$primary: #689F38;
+$warn: #F44336;
+$background: #424242;
+$background-dark: #303030;
+$text: #E0E0E0;
+$text-secondary: #9E9E9E;
+$border: #555;
+
+.ranking-inflacion-container {
+  min-height: 100%;
+  position: relative;
+}
+
+.orden-toggle {
+  flex-shrink: 0;
+}
+
+.loading-overlay {
+  position: absolute;
+  top: 120px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+}
+
+.charts-layout {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 16px;
+}
+
+.chart-panel {
+  background: $background;
+  border: 1px solid $border;
+  border-radius: 12px;
+  padding: 8px;
+}
+
+.chart {
+  width: 100%;
+  height: 560px;
+}
+
+.detalle-panel {
+  background: $background;
+  border: 1px solid $border;
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+}
+
+.detalle-title {
+  font-size: 0.9rem;
+  color: $text-secondary;
+  margin: 0 0 12px;
+  font-weight: 500;
+}
+
+.detalle-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 520px;
+  overflow-y: auto;
+  padding-right: 5px;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba($primary, 0.5);
+    border-radius: 3px;
+  }
+}
+
+.detalle-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: $background-dark;
+  border-radius: 8px;
+  border: 1px solid rgba($border, 0.3);
+}
+
+.rank-badge {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: rgba($text, 0.5);
+  min-width: 28px;
+}
+
+.item-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  gap: 2px;
+}
+
+.item-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: $text;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.item-costos {
+  font-size: 0.8rem;
+  color: $text-secondary;
+}
+
+.variacion-badge {
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 10px;
+  white-space: nowrap;
+
+  &--sube {
+    background: rgba($warn, 0.2);
+    color: #EF5350;
+  }
+
+  &--baja {
+    background: rgba($primary, 0.22);
+    color: #8BC34A;
+  }
+}
+
+.no-data-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px;
+  color: $text-secondary;
+  text-align: center;
+
+  mat-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+  }
+}
+
+@media (max-width: 1100px) {
+  .charts-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.ts
+++ b/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.ts
@@ -3,7 +3,6 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { EChartsOption } from 'echarts';
 import { BehaviorSubject, Observable, catchError, of } from 'rxjs';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { Sucursal } from '../../empresarial/sucursal/sucursal.model';
 import { Familia } from '../../productos/familia/familia.model';
 import { GraficoService } from '../grafico.service';
 import { dateToString } from '../../../commons/core/utils/dateUtils';
@@ -37,15 +36,12 @@ export class RankingInflacionComponent implements OnInit {
   private datosSubject = new BehaviorSubject<RankingInflacionVista | null>(null);
   datos$: Observable<RankingInflacionVista | null> = this.datosSubject.asObservable();
 
-  private sucursalesSubject = new BehaviorSubject<Sucursal[]>([]);
-  sucursales$: Observable<Sucursal[]> = this.sucursalesSubject.asObservable();
-
   private familiasSubject = new BehaviorSubject<Familia[]>([]);
   familias$: Observable<Familia[]> = this.familiasSubject.asObservable();
 
   cargando = false;
 
-  sucursalControl = new FormControl<number | null>(null);
+  // El costo se registra de forma global (no por sucursal), por eso no hay filtro de sucursal.
   familiaControl = new FormControl<number | null>(null);
   limitControl = new FormControl<number>(20);
   ordenControl = new FormControl<OrdenInflacion>('suba');
@@ -81,14 +77,6 @@ export class RankingInflacionComponent implements OnInit {
   }
 
   private cargarMetadata(): void {
-    this.graficoService.obtenerSucursales().pipe(
-      untilDestroyed(this),
-      catchError(() => of([]))
-    ).subscribe(sucs => {
-      const validas = (sucs || []).filter(s => s.activo && s.id > 0 && s.id !== 999);
-      this.sucursalesSubject.next(validas);
-    });
-
     this.graficoService.obtenerFamilias().pipe(
       untilDestroyed(this),
       catchError(() => of([]))
@@ -127,12 +115,11 @@ export class RankingInflacionComponent implements OnInit {
     this.cargando = true;
     this.cdr.markForCheck();
 
-    const sucId = this.sucursalControl.value || undefined;
     const famId = this.familiaControl.value || undefined;
     const limit = this.limitControl.value || 20;
     const orden = this.ordenControl.value || 'suba';
 
-    this.graficoService.obtenerRankingInflacionCosto(rango.inicio, rango.fin, limit, orden, sucId, famId).pipe(
+    this.graficoService.obtenerRankingInflacionCosto(rango.inicio, rango.fin, limit, orden, undefined, famId).pipe(
       catchError(() => of([] as RankingInflacionItem[])),
       untilDestroyed(this)
     ).subscribe(items => {
@@ -239,7 +226,6 @@ export class RankingInflacionComponent implements OnInit {
   }
 
   limpiarFiltros(): void {
-    this.sucursalControl.setValue(null);
     this.familiaControl.setValue(null);
     this.limitControl.setValue(20);
     this.ordenControl.setValue('suba');

--- a/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.ts
+++ b/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.ts
@@ -156,7 +156,7 @@ export class RankingInflacionComponent implements OnInit {
   private construirChart(items: RankingInflacionItem[], titulo: string): EChartsOption {
     // Barras horizontales: el ítem con mayor variación arriba (ECharts dibuja de abajo hacia arriba).
     const invertidos = [...items].reverse();
-    const nombres = invertidos.map(i => this.truncar(i.descripcion, 28));
+    const nombres = invertidos.map(i => this.truncar(i.descripcion, 45));
     const valores = invertidos.map(i => Number(i.variacionPorcentual.toFixed(1)));
 
     return {
@@ -180,7 +180,7 @@ export class RankingInflacionComponent implements OnInit {
             Compras: ${item.totalCompras}`;
         }
       },
-      grid: { left: '30%', right: '10%', bottom: '5%', top: '16%', containLabel: true },
+      grid: { left: 8, right: '10%', bottom: '5%', top: '16%', containLabel: true },
       xAxis: {
         type: 'value',
         axisLabel: {
@@ -192,7 +192,8 @@ export class RankingInflacionComponent implements OnInit {
       yAxis: {
         type: 'category',
         data: nombres,
-        axisLabel: { color: this.colores.textSecondary, fontSize: 10 }
+        // margin: pequeño respiro entre el nombre y la barra (el ancho lo reserva containLabel).
+        axisLabel: { color: this.colores.textSecondary, fontSize: 10, margin: 14 }
       },
       series: [
         {

--- a/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.ts
+++ b/src/app/modules/grafico/ranking-inflacion/ranking-inflacion.component.ts
@@ -1,0 +1,249 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { EChartsOption } from 'echarts';
+import { BehaviorSubject, Observable, catchError, of } from 'rxjs';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Sucursal } from '../../empresarial/sucursal/sucursal.model';
+import { Familia } from '../../productos/familia/familia.model';
+import { GraficoService } from '../grafico.service';
+import { dateToString } from '../../../commons/core/utils/dateUtils';
+import { formatoMonedaPy } from '../../../shared/utils/grafico-echarts.theme';
+import { RankingInflacionItem } from './interfaces/ranking-inflacion-item.model';
+import {
+  RankingInflacionFilaVista,
+  RankingInflacionVista
+} from './interfaces/ranking-inflacion-vista.model';
+
+type OrdenInflacion = 'suba' | 'baja';
+
+interface RangoFechas {
+  inicio: string;
+  fin: string;
+}
+
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'ranking-inflacion',
+  templateUrl: './ranking-inflacion.component.html',
+  styleUrls: ['./ranking-inflacion.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'ranking-inflacion-host' }
+})
+export class RankingInflacionComponent implements OnInit {
+
+  private graficoService = inject(GraficoService);
+  private cdr = inject(ChangeDetectorRef);
+
+  private datosSubject = new BehaviorSubject<RankingInflacionVista | null>(null);
+  datos$: Observable<RankingInflacionVista | null> = this.datosSubject.asObservable();
+
+  private sucursalesSubject = new BehaviorSubject<Sucursal[]>([]);
+  sucursales$: Observable<Sucursal[]> = this.sucursalesSubject.asObservable();
+
+  private familiasSubject = new BehaviorSubject<Familia[]>([]);
+  familias$: Observable<Familia[]> = this.familiasSubject.asObservable();
+
+  cargando = false;
+
+  sucursalControl = new FormControl<number | null>(null);
+  familiaControl = new FormControl<number | null>(null);
+  limitControl = new FormControl<number>(20);
+  ordenControl = new FormControl<OrdenInflacion>('suba');
+
+  fechaRangoGroup = new FormGroup({
+    inicio: new FormControl<Date | null>(null),
+    fin: new FormControl<Date | null>(null)
+  });
+
+  limits = [10, 15, 20, 30, 50];
+  ordenes: { valor: OrdenInflacion; label: string }[] = [
+    { valor: 'suba', label: 'Mayor suba' },
+    { valor: 'baja', label: 'Mayor baja' }
+  ];
+
+  private colores = {
+    text: '#E0E0E0',
+    textSecondary: '#9E9E9E',
+    primary: '#689F38',
+    warn: '#F44336'
+  };
+
+  ngOnInit(): void {
+    this.inicializarRangoPorDefecto();
+    this.cargarMetadata();
+    this.cargarDatos();
+  }
+
+  private inicializarRangoPorDefecto(): void {
+    const hoy = new Date();
+    const inicio = new Date(hoy.getFullYear(), hoy.getMonth() - 11, 1);
+    this.fechaRangoGroup.setValue({ inicio, fin: hoy }, { emitEvent: false });
+  }
+
+  private cargarMetadata(): void {
+    this.graficoService.obtenerSucursales().pipe(
+      untilDestroyed(this),
+      catchError(() => of([]))
+    ).subscribe(sucs => {
+      const validas = (sucs || []).filter(s => s.activo && s.id > 0 && s.id !== 999);
+      this.sucursalesSubject.next(validas);
+    });
+
+    this.graficoService.obtenerFamilias().pipe(
+      untilDestroyed(this),
+      catchError(() => of([]))
+    ).subscribe(fams => this.familiasSubject.next(fams));
+  }
+
+  /** Aplica los filtros manualmente (botón Filtrar). */
+  filtrar(): void {
+    this.cargarDatos();
+  }
+
+  private obtenerRangoFechas(): RangoFechas | null {
+    const inicio = this.fechaRangoGroup.value.inicio;
+    const fin = this.fechaRangoGroup.value.fin;
+    if (!inicio || !fin) return null;
+
+    const inicioDate = new Date(inicio);
+    const finDate = new Date(fin);
+    inicioDate.setHours(0, 0, 0, 0);
+    finDate.setHours(0, 0, 0, 0);
+    if (finDate < inicioDate) return null;
+
+    const finExclusive = new Date(finDate);
+    finExclusive.setDate(finExclusive.getDate() + 1);
+
+    return {
+      inicio: `${dateToString(inicioDate, 'yyyy-MM-dd')} 00:00:00`,
+      fin: `${dateToString(finExclusive, 'yyyy-MM-dd')} 00:00:00`
+    };
+  }
+
+  private cargarDatos(): void {
+    const rango = this.obtenerRangoFechas();
+    if (!rango) return;
+
+    this.cargando = true;
+    this.cdr.markForCheck();
+
+    const sucId = this.sucursalControl.value || undefined;
+    const famId = this.familiaControl.value || undefined;
+    const limit = this.limitControl.value || 20;
+    const orden = this.ordenControl.value || 'suba';
+
+    this.graficoService.obtenerRankingInflacionCosto(rango.inicio, rango.fin, limit, orden, sucId, famId).pipe(
+      catchError(() => of([] as RankingInflacionItem[])),
+      untilDestroyed(this)
+    ).subscribe(items => {
+      this.cargando = false;
+      this.datosSubject.next(this.construirVista(items || [], orden));
+      this.cdr.markForCheck();
+    });
+  }
+
+  private construirVista(items: RankingInflacionItem[], orden: OrdenInflacion): RankingInflacionVista {
+    const filas: RankingInflacionFilaVista[] = items.map((item, i) => ({
+      productoId: item.productoId,
+      descripcion: item.descripcion,
+      costoInicial: formatoMonedaPy(Math.round(item.costoInicial)),
+      costoFinal: formatoMonedaPy(Math.round(item.costoFinal)),
+      variacion: `${item.variacionPorcentual >= 0 ? '+' : ''}${item.variacionPorcentual.toFixed(1)}%`,
+      variacionPositiva: item.variacionPorcentual > 0,
+      totalCompras: item.totalCompras,
+      rank: i + 1
+    }));
+
+    const titulo = orden === 'suba'
+      ? 'Productos con mayor suba de costo'
+      : 'Productos con mayor baja de costo';
+
+    return {
+      chartOptions: this.construirChart(items, titulo),
+      filas,
+      hayDatos: filas.length > 0,
+      titulo
+    };
+  }
+
+  private construirChart(items: RankingInflacionItem[], titulo: string): EChartsOption {
+    // Barras horizontales: el ítem con mayor variación arriba (ECharts dibuja de abajo hacia arriba).
+    const invertidos = [...items].reverse();
+    const nombres = invertidos.map(i => this.truncar(i.descripcion, 28));
+    const valores = invertidos.map(i => Number(i.variacionPorcentual.toFixed(1)));
+
+    return {
+      title: {
+        text: titulo,
+        subtext: 'Variación % entre el primer y último mes con compras',
+        left: 'center',
+        textStyle: { color: this.colores.text, fontSize: 15, fontWeight: 'bold' },
+        subtextStyle: { color: this.colores.textSecondary, fontSize: 11 }
+      },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        formatter: (params: any) => {
+          const idx = params[0]?.dataIndex ?? 0;
+          const item = invertidos[idx];
+          return `<strong>${item.descripcion}</strong><br/>
+            Costo inicial: ${formatoMonedaPy(Math.round(item.costoInicial))}<br/>
+            Costo final: ${formatoMonedaPy(Math.round(item.costoFinal))}<br/>
+            Variación: ${item.variacionPorcentual >= 0 ? '+' : ''}${item.variacionPorcentual.toFixed(1)}%<br/>
+            Compras: ${item.totalCompras}`;
+        }
+      },
+      grid: { left: '30%', right: '10%', bottom: '5%', top: '16%', containLabel: true },
+      xAxis: {
+        type: 'value',
+        axisLabel: {
+          color: this.colores.textSecondary,
+          formatter: (v: number) => `${v}%`
+        },
+        splitLine: { lineStyle: { color: '#444' } }
+      },
+      yAxis: {
+        type: 'category',
+        data: nombres,
+        axisLabel: { color: this.colores.textSecondary, fontSize: 10 }
+      },
+      series: [
+        {
+          name: 'Variación',
+          type: 'bar',
+          data: valores.map(v => ({
+            value: v,
+            itemStyle: {
+              color: v >= 0 ? this.colores.warn : this.colores.primary,
+              borderRadius: v >= 0 ? [0, 4, 4, 0] : [4, 0, 0, 4]
+            }
+          })),
+          label: {
+            show: true,
+            position: 'right',
+            color: this.colores.textSecondary,
+            fontSize: 10,
+            formatter: (p: any) => `${p.value >= 0 ? '+' : ''}${p.value}%`
+          }
+        }
+      ]
+    };
+  }
+
+  private truncar(texto: string, max: number): string {
+    return texto.length > max ? texto.substring(0, max - 2) + '…' : texto;
+  }
+
+  trackByProductoId(_: number, item: RankingInflacionFilaVista): number {
+    return item.productoId;
+  }
+
+  limpiarFiltros(): void {
+    this.sucursalControl.setValue(null);
+    this.familiaControl.setValue(null);
+    this.limitControl.setValue(20);
+    this.ordenControl.setValue('suba');
+    this.inicializarRangoPorDefecto();
+    this.cargarDatos();
+  }
+}

--- a/src/app/modules/grafico/utils/grafico-excel-export.model.ts
+++ b/src/app/modules/grafico/utils/grafico-excel-export.model.ts
@@ -8,7 +8,8 @@ export type GraficoExcelTipo =
   | "GASTO_CATEGORIA"
   | "PRODUCTOS_VENDIDOS"
   | "INGRESO_GASTO"
-  | "VENTAS_HORA";
+  | "VENTAS_HORA"
+  | "DELIVERY_SUCURSAL";
 
 export interface GraficoExcelExportInput {
   periodos?: PeriodoGraficoInput[];

--- a/src/app/modules/operaciones/inventario/list-productos-vencidos/list-productos-vencidos.component.ts
+++ b/src/app/modules/operaciones/inventario/list-productos-vencidos/list-productos-vencidos.component.ts
@@ -203,6 +203,12 @@ export class ListProductosVencidosComponent implements OnInit, OnDestroy {
       fetchPolicy: 'no-cache',
       errorPolicy: 'all',
       context: {
+        // Forzar la consulta al servidor CENTRAL (clientName "servidor").
+        // Sin esto, en modo local (isLocal=true) el split de Apollo la ruteaba
+        // al filial, que no tiene el schema de productosVencidos y devolvía
+        // "Query failed to validate". El central sí lo expone; así se comporta
+        // igual que en modo solo-cloud.
+        clientName: 'servidor',
         fetchOptions: { signal },
       },
     }).pipe(


### PR DESCRIPTION
## Qué resuelve
Nuevos gráficos analíticos en el módulo `grafico` (desktop):
- **Ventas con Delivery por sucursal**: componente `delivery-sucursal` (espejo de `venta-sucursal`) con los mismos filtros de período (Años / Meses / Rango de días), exportación Excel, tooltip y comparativa de años. Nueva tarjeta en el dashboard que abre el tab al hacer click.
- **Evolución de costos** y **ranking de inflación** por producto (pantallas + fixes de la rama).
- Fix de alto/scroll del dashboard de gráficos dentro del tab.
- Fix: rutear `productosVencidos` al servidor central.

## Cómo probarlo
1. Abrir el dashboard de **Gráficos** → click en la tarjeta "Ventas con Delivery".
2. Probar filtros (Años, Meses, Rango de días), comparativa multi-año y el botón **Excel**.
3. Verificar scroll del dashboard cuando el contenido excede el área.

## Riesgo
Bajo. No altera lógica existente; el componente nuevo replica el patrón de `venta-sucursal` y consume un query nuevo del backend.

## Impacto auto-update
Ninguno (no toca `installer.nsh`, `electron-builder.json` ni manifests).

## Dependencia
Requiere el PR backend correspondiente (`deliveryPorSucursalMulti`) mergeado para que el gráfico de delivery traiga datos reales.

## Preflight
`npm run check` (AOT) ✅ pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)