### PR TITLE
fix(productos): buscador de lista de productos + foco en compras

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
@@ -709,6 +709,7 @@
                             <tr
                               mat-row
                               *matRowDef="let row; columns: ['id', 'descripcion', 'precioPrincipal', 'stock', 'acciones']"
+                              tabindex="-1"
                               (click)="onProductoProveedorClick(row)"
                               [class.selected-row]="row.isSelectedComputed"
                               [class.producto-ya-en-pedido]="row.yaEnPedidoComputed"

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.scss
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.scss
@@ -1273,6 +1273,13 @@
 
         .productos-proveedor-table {
           ::ng-deep .mat-mdc-row {
+            // La fila recibe foco de teclado (tabindex="-1") tras seleccionarla;
+            // el resaltado de .selected-row ya indica la selección, por lo que
+            // se evita el outline por defecto del navegador.
+            &:focus {
+              outline: none;
+            }
+
             &.selected-row {
               background-color: rgba(255, 167, 38, 0.2) !important;
 

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -392,6 +392,10 @@ export class GestionComprasComponent
   selectedProductoProveedorIndex: number = -1; // Índice del producto seleccionado para navegación con teclado
   private isNavigatingWithKeyboard = false; // Flag para indicar que estamos navegando con teclado entre páginas
   private keyboardNavigationDirection: 'next' | 'previous' | null = null; // Dirección de navegación con teclado
+  // Flag one-shot: cuando se acaba de agregar un producto desde la tabla de "Productos del proveedor"
+  // se auto-selecciona y enfoca la siguiente fila. Evita que la recarga del resumen del pedido
+  // vuelva a robar el foco hacia el input "Código de barra" (ver loadPedidoResumen).
+  private mantenerFocoEnProductoProveedor = false;
   productosProveedorLoading = false;
   ultimasComprasLoading = false;
   productosProveedorPageSize = 10;
@@ -766,8 +770,12 @@ export class GestionComprasComponent
           this.updateStep3ComputedProperties();
         }
         
-        // Si estamos en el tab de Items y el estado es EN PLANIFICACION, hacer focus en el buscador de ítems
-        if (this.selectedTabIndex === 1 && this.isEstadoEnPlanificacion()) {
+        // Si estamos en el tab de Items y el estado es EN PLANIFICACION, hacer focus en el buscador de ítems.
+        // Excepción: si se acaba de agregar un producto desde la tabla de proveedor, el foco debe quedar
+        // en la siguiente fila auto-seleccionada (no robarlo hacia el buscador). Flag one-shot.
+        if (this.mantenerFocoEnProductoProveedor) {
+          this.mantenerFocoEnProductoProveedor = false;
+        } else if (this.selectedTabIndex === 1 && this.isEstadoEnPlanificacion()) {
           setTimeout(() => {
             this.focusAddItemInput();
           }, 100);
@@ -2341,6 +2349,8 @@ export class GestionComprasComponent
   }
 
   onCodigoFocus(): void {
+    // El usuario volvió manualmente al buscador: cancelar el "mantener foco en la fila".
+    this.mantenerFocoEnProductoProveedor = false;
     const text = this.codigoControl.value?.trim();
     if (text && text.length >= 2) {
       this.buscadorComprasService
@@ -4457,6 +4467,9 @@ export class GestionComprasComponent
             }
 
             if (this.isEditMode) {
+              // Evitar que la recarga del resumen re-enfoque el buscador: el foco debe
+              // quedar en la siguiente fila auto-seleccionada para poder abrirla con Enter.
+              this.mantenerFocoEnProductoProveedor = true;
               this.loadPedidoResumen();
             }
 
@@ -4768,10 +4781,38 @@ export class GestionComprasComponent
       this.loadUltimasCompras(producto.producto.id);
     }
 
-    // Hacer scroll al elemento seleccionado
+    // Hacer scroll al elemento seleccionado y darle foco de teclado.
+    // El foco en la fila es clave: mueve el foco fuera del input "Código de barra"
+    // para que el listener global de Enter (onProductosProveedorKeydown) abra el
+    // diálogo del producto seleccionado en lugar de que el buscador capture el Enter.
     setTimeout(() => {
       this.scrollToSelectedProducto(index);
+      this.focusProductoProveedorRow(index);
     }, 0);
+  }
+
+  /**
+   * Da foco de teclado a la fila del producto del proveedor indicada.
+   * Se usa tras seleccionar una fila (navegación con flechas o auto-selección
+   * del siguiente producto luego de agregar uno) para que el input "Código de barra"
+   * no retenga el foco y el Enter abra directamente el siguiente producto.
+   */
+  private focusProductoProveedorRow(index: number): void {
+    const tableContainer = document.querySelector('.productos-proveedor-section .table-content-wrapper');
+
+    if (!tableContainer) {
+      return;
+    }
+
+    const rows = tableContainer.querySelectorAll('tr[mat-row]');
+
+    if (index < 0 || index >= rows.length) {
+      return;
+    }
+
+    const targetRow = rows[index] as HTMLElement;
+    // preventScroll: el scroll a la vista ya lo maneja scrollToSelectedProducto
+    targetRow?.focus({ preventScroll: true });
   }
 
   /**

--- a/src/app/modules/productos/producto/list-producto/list-producto.component.ts
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.ts
@@ -65,7 +65,7 @@ import { NotificacionSnackbarService } from "../../../../notificacion-snackbar.s
 import { GestionProveedoresProductoDialogComponent } from "../gestion-proveedores-producto-dialog/gestion-proveedores-producto-dialog.component";
 import { Familia } from "../../familia/familia.model";
 import { FamiliasSearchGQL } from "../../familia/graphql/familiasSearch";
-import { distinctUntilChanged, filter } from "rxjs/operators";
+import { debounceTime, distinctUntilChanged, filter } from "rxjs/operators";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -110,6 +110,9 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
   selectedRowIndex;
   menuState: string = "out";
   isSearching = false;
+  // secuencia para descartar respuestas viejas que llegan despues de una busqueda
+  // mas nueva y pisarian la grilla con resultados de un texto ya reemplazado
+  private busquedaSeq = 0;
   imagenPrincipal = null;
   displayedColumns: string[] = [
     "id",
@@ -181,6 +184,7 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
 
     this.filtroProductoControl.valueChanges
       .pipe(
+        debounceTime(250),
         distinctUntilChanged(),
         filter(() => this.filtroCodigoControl.value !== true),
         untilDestroyed(this)
@@ -203,6 +207,7 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
     this.isSearching = true;
     this.expandedProducto = null;
     this.selectedProducto = new Producto();
+    const seq = ++this.busquedaSeq;
 
     this.service
       .onSearchWithFilters(
@@ -227,6 +232,9 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
         silentLoad
       )
       .subscribe((res) => {
+        // llego tarde: ya hay una busqueda mas nueva en curso o resuelta
+        if (seq !== this.busquedaSeq) return;
+
         this.selectedPageInfo = res;
         this.dataSource.data = res.getContent;
         this.isSearching = false;


### PR DESCRIPTION
Dos cambios independientes, un commit cada uno.

---

## 1. `fix(compras)`: foco en la fila del producto tras agregar item

Al agregar un producto desde la tabla de "Productos del proveedor" se auto-selecciona el siguiente, pero la recarga del resumen del pedido robaba el foco hacia el input "Código de barra". El Enter quedaba capturado por el buscador en vez de abrir el producto seleccionado.

- `tabindex="-1"` en la fila y `focusProductoProveedorRow()` para dar foco de teclado a la fila seleccionada.
- Flag one-shot `mantenerFocoEnProductoProveedor` para que `loadPedidoResumen()` no re-enfoque el buscador en ese paso. Se cancela si el usuario vuelve manualmente al buscador (`onCodigoFocus`).
- Se suprime el outline por defecto del navegador en la fila enfocada; la selección ya se indica con `.selected-row`.

**Cómo probarlo:** Gestión de compras → tab Items en estado EN PLANIFICACIÓN → agregar un producto desde la tabla de productos del proveedor → el foco debe quedar en la siguiente fila y Enter debe abrirla directamente, sin volver al input de código de barra.

---

## 2. `fix(productos)`: debounce y descarte de respuestas viejas

Acompaña a franco-system-backend-servidor#167, que arregla el buscador inteligente (escribir `ONTI` no encontraba los productos CONTI).

El buscador de la lista de productos disparaba una query GraphQL con `fetchPolicy: 'no-cache'` **por cada tecla**, sin debounce. Además no había `switchMap` ni guard, así que la respuesta de una tecla anterior podía llegar tarde y pisar la grilla con resultados de un texto ya reemplazado.

- `debounceTime(250)` en el `valueChanges` del filtro.
- Secuencia por búsqueda que descarta las respuestas que llegan fuera de orden.

Importa más ahora: el backend pasó a expandir wildcards, así que la consulta es más pesada.

**Cómo probarlo:** Lista de productos → escribir rápido `CONTI` → una sola query en vez de cinco, y la grilla queda con el resultado del texto final. Con el backend del PR asociado, escribir `ONTI` debe traer los productos CONTI.

---

## Riesgo

**Bajo.** Ambos cambios están acotados a su componente, sin cambios de API ni de modelo. `npm run check` (AOT) pasa sin errores.

Sin impacto en auto-update: no se tocan `installer.nsh`, `electron-builder.json` ni manifests.

Rollback: revertir cualquiera de los dos commits de forma independiente.

## Nota

El cambio del buscador **necesita el backend desplegado** para que `ONTI` funcione. El debounce y el guard de orden son útiles igual por sí solos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)