### PR TITLE
feat(transferencias): rediseñar diálogo de hoja de ruta con búsquedas paginadas

### DIFF
--- a/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
+++ b/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
@@ -1000,12 +1000,16 @@ export const hojaRutaQuery = gql`
         id
         modelo {
           descripcion
+          marca {
+            descripcion
+          }
         }
         chapa
       }
       chofer {
         id
         nombre
+        documento
       }
       fechaSalida
       fechaLlegada
@@ -1016,6 +1020,7 @@ export const hojaRutaQuery = gql`
       acompanantes {
         id
         nombre
+        documento
       }
     }
   }

--- a/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.ts
@@ -316,7 +316,8 @@ export class ListTransferenciaComponent implements OnInit {
   onAsignarRuta() {
     if (this.selection.selected.length > 0) {
       this.matDialog.open(RutaHojaComponent, {
-        width: '30%',
+        width: '560px',
+        maxWidth: '95vw',
         disableClose: true,
         panelClass: 'custom-dialog-container'
       }).afterClosed().subscribe(async (res) => {

--- a/src/app/modules/operaciones/transferencia/ruta-hoja/ruta-hoja.component.html
+++ b/src/app/modules/operaciones/transferencia/ruta-hoja/ruta-hoja.component.html
@@ -1,82 +1,117 @@
-<h2 mat-dialog-title>Hoja de Ruta</h2>
+<div class="hoja-ruta-dialog">
 
-<mat-dialog-content>
-    <div fxLayout="column" fxLayoutGap="15px">
-        <div fxLayout="row" fxLayoutAlign="start center">
-            <mat-form-field appearance="outline" fxFlex class="dark-outline-input">
-                <mat-label>Vehículo</mat-label>
-                <input matInput
-                    [value]="selectedVehiculo ? (selectedVehiculo.modelo?.marca?.descripcion + ' ' + selectedVehiculo.modelo?.descripcion + ' - ' + selectedVehiculo.chapa) : ''"
-                    readonly (click)="onBuscarVehiculo()" style="cursor: pointer;">
-                <button mat-icon-button matSuffix (click)="onBuscarVehiculo()">
-                    <mat-icon>search</mat-icon>
-                </button>
-                <mat-error *ngIf="vehiculoControl.invalid">El vehículo es obligatorio</mat-error>
-            </mat-form-field>
+    <div class="dialog-header">
+        <div class="header-icon">
+            <mat-icon>route</mat-icon>
+        </div>
+        <div class="header-text">
+            <h2>{{ tituloDialog }}</h2>
+            <span class="header-sub">{{ subtituloDialog }}</span>
+        </div>
+        <button mat-icon-button class="header-close" (click)="onCancel()" matTooltip="Cerrar">
+            <mat-icon>close</mat-icon>
+        </button>
+    </div>
+
+    <mat-dialog-content class="dialog-body">
+
+        <div *ngIf="isLoading" class="cargando-overlay">
+            <mat-spinner diameter="36"></mat-spinner>
+            <span>Cargando hoja de ruta...</span>
         </div>
 
+        <ng-container *ngIf="!isLoading">
 
-        <div fxLayout="row" fxLayoutAlign="start center">
-            <mat-form-field appearance="outline" fxFlex class="dark-outline-input">
-                <mat-label>Chofer</mat-label>
-                <input matInput [formControl]="choferControl" readonly (click)="onBuscarChofer()"
-                    style="cursor: pointer;">
-                <button mat-icon-button matSuffix (click)="onBuscarChofer()">
-                    <mat-icon>search</mat-icon>
-                </button>
-                <mat-error *ngIf="choferControl.hasError('required')">El chofer es obligatorio</mat-error>
-            </mat-form-field>
-        </div>
+            <!-- VEHICULO -->
+            <div class="selector-card" [class.vacio]="!selectedVehiculo" (click)="onBuscarVehiculo()"
+                matTooltip="Click para buscar un vehículo">
+                <div class="selector-avatar vehiculo">
+                    <mat-icon>local_shipping</mat-icon>
+                </div>
+                <div class="selector-info">
+                    <span class="selector-label">Vehículo <span class="requerido">*</span></span>
+                    <ng-container *ngIf="selectedVehiculo; else vehiculoVacio">
+                        <span class="selector-value">{{ vehiculoTitulo }}</span>
+                        <span class="selector-sub" *ngIf="vehiculoSubtitulo">{{ vehiculoSubtitulo }}</span>
+                    </ng-container>
+                    <ng-template #vehiculoVacio>
+                        <span class="selector-placeholder">Seleccionar vehículo</span>
+                    </ng-template>
+                </div>
+                <mat-icon class="selector-action">{{ selectedVehiculo ? 'swap_horiz' : 'search' }}</mat-icon>
+            </div>
 
+            <!-- CHOFER -->
+            <div class="selector-card" [class.vacio]="!selectedChofer" (click)="onBuscarChofer()"
+                matTooltip="Click para buscar un chofer">
+                <div class="selector-avatar chofer" [class.iniciales]="selectedChofer">
+                    <span *ngIf="selectedChofer">{{ choferIniciales }}</span>
+                    <mat-icon *ngIf="!selectedChofer">person</mat-icon>
+                </div>
+                <div class="selector-info">
+                    <span class="selector-label">Chofer <span class="requerido">*</span></span>
+                    <ng-container *ngIf="selectedChofer; else choferVacio">
+                        <span class="selector-value">{{ choferTitulo }}</span>
+                        <span class="selector-sub" *ngIf="choferSubtitulo">{{ choferSubtitulo }}</span>
+                    </ng-container>
+                    <ng-template #choferVacio>
+                        <span class="selector-placeholder">Seleccionar chofer</span>
+                    </ng-template>
+                </div>
+                <mat-icon class="selector-action">{{ selectedChofer ? 'swap_horiz' : 'search' }}</mat-icon>
+            </div>
 
-        <div fxLayout="row" fxLayoutGap="10px">
-            <mat-form-field appearance="outline" fxFlex="50" class="dark-outline-input">
-                <mat-label>Fecha de Salida</mat-label>
-                <input matInput [matDatepicker]="pickerSalida" [formControl]="fechaSalidaControl">
+            <!-- FECHA DE SALIDA -->
+            <mat-form-field appearance="outline" class="dark-outline-input fecha-field">
+                <mat-label>Fecha de salida</mat-label>
+                <input matInput [matDatepicker]="pickerSalida" [formControl]="fechaSalidaControl" readonly
+                    (click)="pickerSalida.open()">
                 <mat-datepicker-toggle matSuffix [for]="pickerSalida"></mat-datepicker-toggle>
                 <mat-datepicker #pickerSalida></mat-datepicker>
             </mat-form-field>
-        </div>
 
+            <!-- ACOMPAÑANTES -->
+            <div class="acompanhantes-section">
+                <div class="section-header">
+                    <div class="section-title">
+                        <mat-icon>groups</mat-icon>
+                        <span>Acompañantes</span>
+                        <span class="contador" *ngIf="cantidadAcompanhantes > 0">{{ cantidadAcompanhantes }}</span>
+                    </div>
+                    <button mat-stroked-button class="btn-agregar" (click)="onAddAcompanhante()">
+                        <mat-icon>person_add</mat-icon>
+                        Agregar
+                    </button>
+                </div>
 
-        <div>
-            <div fxLayout="row" fxLayoutAlign="space-between center">
-                <h3>Acompañantes</h3>
-                <button mat-raised-button color="accent" (click)="onAddAcompanhante()">
-                    <mat-icon>add</mat-icon> Agregar
-                </button>
+                <div class="lista-vacia" *ngIf="cantidadAcompanhantes === 0">
+                    <mat-icon>group_off</mat-icon>
+                    <span>Sin acompañantes asignados</span>
+                    <small>Opcional — agregá a quienes viajan con el chofer</small>
+                </div>
+
+                <div class="acompanhante-item" *ngFor="let a of acompanhantesView; trackBy: trackByAcompanhante">
+                    <div class="selector-avatar iniciales chico">{{ a.iniciales }}</div>
+                    <div class="acompanhante-info">
+                        <span class="acompanhante-nombre">{{ a.nombre }}</span>
+                        <span class="acompanhante-doc" *ngIf="a.documento">Doc. {{ a.documento }}</span>
+                    </div>
+                    <button mat-icon-button class="btn-quitar" (click)="onRemoveAcompanhante(a)"
+                        matTooltip="Quitar acompañante">
+                        <mat-icon>close</mat-icon>
+                    </button>
+                </div>
             </div>
 
-            <table mat-table [dataSource]="dataSource" class="mat-elevation-z8" style="width: 100%; margin-top: 10px;">
-                <ng-container matColumnDef="id">
-                    <th mat-header-cell *matHeaderCellDef> ID </th>
-                    <td mat-cell *matCellDef="let element"> {{element.id}} </td>
-                </ng-container>
-                <ng-container matColumnDef="nombre">
-                    <th mat-header-cell *matHeaderCellDef> Nombre </th>
-                    <td mat-cell *matCellDef="let element"> {{element.nombre | uppercase}} </td>
-                </ng-container>
-                <ng-container matColumnDef="accion">
-                    <th mat-header-cell *matHeaderCellDef> </th>
-                    <td mat-cell *matCellDef="let element">
-                        <button mat-icon-button color="warn" (click)="onRemoveAcompanhante(element)">
-                            <mat-icon>delete</mat-icon>
-                        </button>
-                    </td>
-                </ng-container>
+        </ng-container>
+    </mat-dialog-content>
 
-                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-            </table>
-        </div>
-
-    </div>
-</mat-dialog-content>
-
-<mat-dialog-actions align="end">
-    <button mat-button (click)="onCancel()">Cancelar</button>
-    <button mat-raised-button color="primary" (click)="onSave()"
-        [disabled]="vehiculoControl.invalid || choferControl.invalid">
-        Guardar
-    </button>
-</mat-dialog-actions>
+    <mat-dialog-actions class="dialog-footer">
+        <button mat-button class="btn-cancelar" (click)="onCancel()" [disabled]="isSaving">Cancelar</button>
+        <button mat-flat-button class="btn-guardar" (click)="onSave()" [disabled]="guardarDeshabilitado">
+            <mat-spinner *ngIf="isSaving" diameter="18" class="btn-spinner"></mat-spinner>
+            <mat-icon *ngIf="!isSaving">save</mat-icon>
+            {{ isSaving ? 'Guardando...' : 'Guardar' }}
+        </button>
+    </mat-dialog-actions>
+</div>

--- a/src/app/modules/operaciones/transferencia/ruta-hoja/ruta-hoja.component.scss
+++ b/src/app/modules/operaciones/transferencia/ruta-hoja/ruta-hoja.component.scss
@@ -1,15 +1,226 @@
-.dark-outline-input {
-    width: 100%;
+/* Tonos del sistema (ver src/styles.scss):
+   #f57c00 -> acento / títulos / headers de tabla
+   #43a047 -> success (guardar)
+   #f44336 -> danger
+   #3c3c3c / #464646 -> superficies de header y filas */
+$acento: #f57c00;
+$acento-claro: #ffa726;
+$success: #43a047;
+$success-claro: #66bb6a;
+$danger: #f44336;
 
+$superficie-header: #3c3c3c;
+$superficie-body: #3a3a3a;
+$superficie-card: #464646;
+$superficie-footer: #333333;
+
+$borde: rgba(255, 255, 255, 0.12);
+$texto: #ffffff;
+$texto-sec: #bbbbbb;
+$texto-terciario: rgba(255, 255, 255, 0.45);
+
+:host {
+    display: block;
+}
+
+.hoja-ruta-dialog {
+    display: flex;
+    flex-direction: column;
+    color: $texto;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+/* ---------- HEADER ---------- */
+.dialog-header {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 20px;
+    background-color: $superficie-header;
+    border-bottom: 2px solid $acento;
+
+    .header-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 42px;
+        height: 42px;
+        border-radius: 10px;
+        background-color: rgba(245, 124, 0, 0.18);
+        flex-shrink: 0;
+
+        mat-icon {
+            color: $acento;
+        }
+    }
+
+    .header-text {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0;
+
+        h2 {
+            margin: 0;
+            font-size: 19px;
+            font-weight: 500;
+            color: $acento;
+        }
+
+        .header-sub {
+            font-size: 13px;
+            color: $texto-sec;
+        }
+    }
+
+    .header-close {
+        color: $texto-sec;
+        flex-shrink: 0;
+
+        &:hover {
+            color: $texto;
+        }
+    }
+}
+
+/* ---------- BODY ---------- */
+.dialog-body {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 20px !important;
+    max-height: 65vh;
+    background-color: $superficie-body;
+}
+
+.cargando-overlay {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 40px 0;
+    color: $texto-sec;
+}
+
+/* ---------- SELECTOR CARDS (vehículo / chofer) ---------- */
+.selector-card {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 14px;
+    border-radius: 8px;
+    background-color: $superficie-card;
+    border: 1px solid $borde;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+
+    &:hover {
+        border-color: $acento;
+        background-color: #4f4f4f;
+
+        .selector-action {
+            color: $acento;
+        }
+    }
+
+    &.vacio {
+        background-color: #404040;
+        border-color: $borde;
+    }
+
+    .selector-info {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0;
+    }
+
+    .selector-label {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+        color: $acento;
+
+        .requerido {
+            color: $danger;
+        }
+    }
+
+    .selector-value {
+        font-size: 16px;
+        font-weight: 500;
+        color: $texto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .selector-placeholder {
+        font-size: 15px;
+        color: $texto-terciario;
+        font-style: italic;
+    }
+
+    .selector-sub {
+        font-size: 13px;
+        color: $texto-sec;
+    }
+
+    .selector-action {
+        color: rgba(255, 255, 255, 0.4);
+        flex-shrink: 0;
+        transition: color 0.2s ease;
+    }
+}
+
+.selector-avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background-color: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.55);
+    font-weight: 600;
+    font-size: 15px;
+
+    &.vehiculo mat-icon {
+        color: $acento-claro;
+    }
+
+    &.iniciales {
+        background-color: rgba(245, 124, 0, 0.2);
+        color: $acento-claro;
+    }
+
+    &.chico {
+        width: 34px;
+        height: 34px;
+        font-size: 13px;
+        background-color: rgba(255, 255, 255, 0.1);
+        color: $texto-sec;
+    }
+}
+
+/* ---------- FECHA ---------- */
+.fecha-field {
+    width: 60%;
+}
+
+.dark-outline-input {
     ::ng-deep {
         .mat-mdc-text-field-wrapper {
-            background-color: #2e2e2e !important;
-            border-radius: 4px !important;
+            background-color: rgba(255, 255, 255, 0.04) !important;
+            border-radius: 8px !important;
         }
 
         .mat-mdc-input-element {
             color: white !important;
             caret-color: white !important;
+            cursor: pointer;
         }
 
         .mdc-floating-label,
@@ -20,7 +231,7 @@
         .mdc-notched-outline__leading,
         .mdc-notched-outline__notch,
         .mdc-notched-outline__trailing {
-            border-color: rgba(255, 255, 255, 0.3) !important;
+            border-color: rgba(255, 255, 255, 0.2) !important;
         }
 
         .mat-mdc-form-field.mat-focused {
@@ -28,24 +239,186 @@
             .mdc-notched-outline__leading,
             .mdc-notched-outline__notch,
             .mdc-notched-outline__trailing {
-                border-color: #4caf50 !important;
+                border-color: $acento !important;
             }
 
             .mdc-floating-label {
-                color: #4caf50 !important;
+                color: $acento !important;
             }
         }
 
-        .mat-icon {
-            color: white !important;
-        }
-
-        .mat-mdc-icon-button {
-            color: white !important;
-        }
-
+        .mat-icon,
+        .mat-mdc-icon-button,
         .mat-datepicker-toggle {
             color: white !important;
+        }
+    }
+}
+
+/* ---------- ACOMPAÑANTES ---------- */
+.acompanhantes-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-top: 10px;
+    border-top: 1px solid $borde;
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+
+    .section-title {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 15px;
+        font-weight: 500;
+        color: $acento;
+
+        mat-icon {
+            color: $acento;
+            font-size: 20px;
+            width: 20px;
+            height: 20px;
+        }
+
+        .contador {
+            min-width: 22px;
+            padding: 1px 7px;
+            border-radius: 11px;
+            background-color: rgba(245, 124, 0, 0.25);
+            color: $acento-claro;
+            font-size: 12px;
+            font-weight: 600;
+            text-align: center;
+        }
+    }
+
+    .btn-agregar {
+        color: $success-claro !important;
+        border-color: rgba(67, 160, 71, 0.6) !important;
+        line-height: 32px;
+
+        mat-icon {
+            font-size: 18px;
+            width: 18px;
+            height: 18px;
+            margin-right: 4px;
+        }
+
+        &:hover {
+            background-color: rgba(67, 160, 71, 0.15) !important;
+        }
+    }
+}
+
+.lista-vacia {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 18px;
+    border: 1px dashed rgba(255, 255, 255, 0.15);
+    border-radius: 8px;
+    color: $texto-sec;
+
+    mat-icon {
+        color: rgba(255, 255, 255, 0.25);
+    }
+
+    span {
+        font-size: 14px;
+    }
+
+    small {
+        font-size: 12px;
+        color: $texto-terciario;
+    }
+}
+
+.acompanhante-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background-color: $superficie-card;
+    border: 1px solid transparent;
+    transition: border-color 0.2s ease;
+
+    &:hover {
+        border-color: rgba(255, 255, 255, 0.2);
+    }
+
+    .acompanhante-info {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0;
+    }
+
+    .acompanhante-nombre {
+        font-size: 14px;
+        color: $texto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .acompanhante-doc {
+        font-size: 12px;
+        color: $texto-sec;
+    }
+
+    .btn-quitar {
+        color: rgba(255, 255, 255, 0.45);
+        flex-shrink: 0;
+
+        &:hover {
+            color: $danger;
+        }
+    }
+}
+
+/* ---------- FOOTER ---------- */
+.dialog-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    padding: 12px 20px !important;
+    margin: 0 !important;
+    border-top: 1px solid $borde;
+    background-color: $superficie-footer;
+
+    .btn-cancelar {
+        color: $texto-sec !important;
+    }
+
+    .btn-guardar {
+        min-width: 130px;
+
+        &:not([disabled]) {
+            background-color: $success !important;
+            color: white !important;
+        }
+
+        mat-icon {
+            font-size: 18px;
+            width: 18px;
+            height: 18px;
+            margin-right: 6px;
+        }
+
+        .btn-spinner {
+            display: inline-block;
+            margin-right: 8px;
+
+            ::ng-deep circle {
+                stroke: rgba(255, 255, 255, 0.85);
+            }
         }
     }
 }

--- a/src/app/modules/operaciones/transferencia/ruta-hoja/ruta-hoja.component.ts
+++ b/src/app/modules/operaciones/transferencia/ruta-hoja/ruta-hoja.component.ts
@@ -1,18 +1,29 @@
-import { Component, Inject, OnInit, ViewChild, ElementRef } from '@angular/core';
-import { FormControl, Validators } from '@angular/forms';
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { MatTableDataSource } from '@angular/material/table';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { finalize } from 'rxjs/operators';
 import { TransferenciaService } from '../transferencia.service';
 import { Persona } from '../../../personas/persona/persona.model';
 import { HojaRuta, HojaRutaInput } from '../transferencia.model';
 import { dateToString } from '../../../../commons/core/utils/dateUtils';
 import { NotificacionSnackbarService } from '../../../../notificacion-snackbar.service';
 import { SearchListDialogComponent, SearchListtDialogData, TableData } from '../../../../shared/components/search-list-dialog/search-list-dialog.component';
-import { PersonaSearchGQL } from '../../../personas/persona/graphql/personaSearch';
+import { PersonaSearchPageGQL } from '../../../personas/persona/graphql/personaSearchPage';
 import { Vehiculo } from '../../../activos/vehiculos/vehiculo/models/vehiculo.model';
-import { VehiculoService } from '../../../activos/vehiculos/vehiculo/service/vehiculo.service';
 import { VehiculoSearchPageGQL } from '../../../activos/vehiculos/vehiculo/graphql/vehiculoSearchPage';
+
+/**
+ * Vista precalculada de cada acompañante.
+ * Se arma en el .ts para no llamar funciones/getters desde el template.
+ */
+export interface AcompanhanteView {
+  id: number;
+  nombre: string;
+  documento: string;
+  iniciales: string;
+  persona: Persona;
+}
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -22,58 +33,73 @@ import { VehiculoSearchPageGQL } from '../../../activos/vehiculos/vehiculo/graph
 })
 export class RutaHojaComponent implements OnInit {
 
-  @ViewChild('vehiculoInput', { static: false }) vehiculoInput: ElementRef;
-
-  vehiculoControl = new FormControl(null, Validators.required);
-  choferControl = new FormControl(null, Validators.required);
   fechaSalidaControl = new FormControl(new Date());
 
-  vehiculoList: Vehiculo[] = [];
   selectedVehiculo: Vehiculo;
   selectedChofer: Persona;
   selectedHojaRuta: HojaRuta;
   acompanhantes: Persona[] = [];
 
-  dataSource = new MatTableDataSource<Persona>([]);
-  displayedColumns = ['id', 'nombre', 'accion'];
+  // Estado de vista (precalculado, sin llamadas a funciones desde el HTML)
+  tituloDialog = 'Nueva hoja de ruta';
+  subtituloDialog = 'Asigná el vehículo y la tripulación de la ruta';
+  vehiculoTitulo = '';
+  vehiculoSubtitulo = '';
+  choferTitulo = '';
+  choferSubtitulo = '';
+  choferIniciales = '';
+  acompanhantesView: AcompanhanteView[] = [];
+  cantidadAcompanhantes = 0;
+  guardarDeshabilitado = true;
+  isLoading = false;
+  isSaving = false;
+
+  private readonly personaTableData: TableData[] = [
+    { id: 'id', nombre: 'ID', width: '10%' },
+    { id: 'nombre', nombre: 'Nombre' },
+    { id: 'documento', nombre: 'Documento' }
+  ];
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: any,
     public dialogRef: MatDialogRef<RutaHojaComponent>,
-    private vehiculoService: VehiculoService,
     private transferenciaService: TransferenciaService,
     private matDialog: MatDialog,
     private notificacionService: NotificacionSnackbarService,
     private vehiculoSearchPageGQL: VehiculoSearchPageGQL,
-    private personaSearchGQL: PersonaSearchGQL
+    private personaSearchPageGQL: PersonaSearchPageGQL
   ) { }
 
   ngOnInit(): void {
     if (this.data?.hojaRutaId) {
       this.loadHojaRuta(this.data.hojaRutaId);
+    } else {
+      this.actualizarResumen();
     }
   }
 
-  loadHojaRuta(id: number) {
-    this.transferenciaService.onGetHojaRuta(id).subscribe(res => {
-      if (res) {
-        this.selectedHojaRuta = res;
-        this.selectedVehiculo = res.vehiculo;
-        this.selectedChofer = res.chofer;
-        this.vehiculoControl.setValue(this.selectedVehiculo);
-        this.choferControl.setValue(this.selectedChofer?.nombre);
-        if (res.fechaSalida) {
-          this.fechaSalidaControl.setValue(new Date(res.fechaSalida));
+  loadHojaRuta(id: number): void {
+    this.isLoading = true;
+    this.transferenciaService.onGetHojaRuta(id)
+      .pipe(untilDestroyed(this), finalize(() => this.isLoading = false))
+      .subscribe(res => {
+        if (res) {
+          this.selectedHojaRuta = res;
+          this.selectedVehiculo = res.vehiculo;
+          this.selectedChofer = res.chofer;
+          if (res.fechaSalida) {
+            this.fechaSalidaControl.setValue(new Date(res.fechaSalida));
+          }
+          this.acompanhantes = res.acompanantes || [];
         }
-        this.acompanhantes = res.acompanantes || [];
-        this.dataSource.data = this.acompanhantes;
-      }
-    });
+        this.isLoading = false;
+        this.actualizarResumen();
+      });
   }
 
-  onBuscarVehiculo() {
+  onBuscarVehiculo(): void {
     const tableData: TableData[] = [
-      { id: 'id', nombre: 'Id' },
+      { id: 'id', nombre: 'ID', width: '10%' },
       { id: 'chapa', nombre: 'Chapa' },
       { id: 'modelo.marca.descripcion', nombre: 'Marca' },
       { id: 'modelo.descripcion', nombre: 'Modelo' }
@@ -97,27 +123,21 @@ export class RutaHojaComponent implements OnInit {
     }).afterClosed().pipe(untilDestroyed(this)).subscribe((res: Vehiculo) => {
       if (res) {
         this.selectedVehiculo = res;
-        this.vehiculoControl.setValue(res);
+        this.actualizarResumen();
       }
     });
   }
 
-  onBuscarChofer() {
-    const tableData: TableData[] = [
-      { id: 'id', nombre: 'Id' },
-      { id: 'nombre', nombre: 'Nombre' },
-      { id: 'documento', nombre: 'Documento' }
-    ];
-
+  onBuscarChofer(): void {
     const data: SearchListtDialogData = {
-      query: this.personaSearchGQL,
-      tableData,
+      query: this.personaSearchPageGQL,
+      tableData: this.personaTableData,
       titulo: 'Buscar Chofer',
       search: true,
       inicialSearch: true,
       textHint: 'Buscar por nombre o documento...',
-      paginator: false,
-      queryData: { texto: '' }
+      paginator: true,
+      queryData: { page: 0, size: 15 }
     };
 
     this.matDialog.open(SearchListDialogComponent, {
@@ -127,27 +147,21 @@ export class RutaHojaComponent implements OnInit {
     }).afterClosed().pipe(untilDestroyed(this)).subscribe((res: Persona) => {
       if (res) {
         this.selectedChofer = res;
-        this.choferControl.setValue(res.nombre);
+        this.actualizarResumen();
       }
     });
   }
 
-  onAddAcompanhante() {
-    const tableData: TableData[] = [
-      { id: 'id', nombre: 'Id' },
-      { id: 'nombre', nombre: 'Nombre' },
-      { id: 'documento', nombre: 'Documento' }
-    ];
-
+  onAddAcompanhante(): void {
     const data: SearchListtDialogData = {
-      query: this.personaSearchGQL,
-      tableData,
+      query: this.personaSearchPageGQL,
+      tableData: this.personaTableData,
       titulo: 'Buscar Acompañante',
       search: true,
       inicialSearch: true,
       textHint: 'Buscar por nombre o documento...',
-      paginator: false,
-      queryData: { texto: '' }
+      paginator: true,
+      queryData: { page: 0, size: 15 }
     };
 
     this.matDialog.open(SearchListDialogComponent, {
@@ -156,39 +170,112 @@ export class RutaHojaComponent implements OnInit {
       height: '80%'
     }).afterClosed().pipe(untilDestroyed(this)).subscribe((res: Persona) => {
       if (res) {
-        if (!this.acompanhantes.find(p => p.id === res.id)) {
-          this.acompanhantes.push(res);
-          this.dataSource.data = [...this.acompanhantes];
-        } else {
-          this.notificacionService.openWarn('Esta persona ya esta agregada en la lista');
+        if (this.selectedChofer?.id === res.id) {
+          this.notificacionService.openWarn('Esta persona ya está asignada como chofer');
+          return;
         }
+        if (this.acompanhantes.find(p => p.id === res.id)) {
+          this.notificacionService.openWarn('Esta persona ya esta agregada en la lista');
+          return;
+        }
+        this.acompanhantes = [...this.acompanhantes, res];
+        this.actualizarResumen();
       }
     });
   }
 
-  onRemoveAcompanhante(persona: Persona) {
-    this.acompanhantes = this.acompanhantes.filter(p => p.id !== persona.id);
-    this.dataSource.data = [...this.acompanhantes];
+  onRemoveAcompanhante(item: AcompanhanteView): void {
+    this.acompanhantes = this.acompanhantes.filter(p => p.id !== item.id);
+    this.actualizarResumen();
   }
 
-  onSave() {
-    if (this.vehiculoControl.valid && this.choferControl.valid) {
-      const input = new HojaRutaInput();
-      input.id = this.selectedHojaRuta?.id;
-      input.vehiculoId = this.selectedVehiculo.id;
-      input.choferId = this.selectedChofer.id;
-      input.fechaSalida = dateToString(this.fechaSalidaControl.value);
-      input.acompanantesIds = this.acompanhantes.map(p => p.id);
+  onSave(): void {
+    if (this.guardarDeshabilitado) return;
 
-      this.transferenciaService.onSaveHojaRuta(input).subscribe(res => {
-        if (res) {
-          this.dialogRef.close(res);
+    const input = new HojaRutaInput();
+    input.id = this.selectedHojaRuta?.id;
+    input.vehiculoId = this.selectedVehiculo.id;
+    input.choferId = this.selectedChofer.id;
+    input.fechaSalida = dateToString(this.fechaSalidaControl.value);
+    input.acompanantesIds = this.acompanhantes.map(p => p.id);
+
+    this.isSaving = true;
+    this.guardarDeshabilitado = true;
+    this.transferenciaService.onSaveHojaRuta(input)
+      .pipe(untilDestroyed(this), finalize(() => this.isSaving = false))
+      .subscribe({
+        next: res => {
+          if (res) {
+            this.dialogRef.close(res);
+          } else {
+            this.isSaving = false;
+            this.actualizarResumen();
+          }
+        },
+        error: err => {
+          console.error('Error al guardar la hoja de ruta:', err);
+          this.isSaving = false;
+          this.notificacionService.openWarn('No se pudo guardar la hoja de ruta');
+          this.actualizarResumen();
         }
       });
-    }
   }
 
-  onCancel() {
+  onCancel(): void {
     this.dialogRef.close();
+  }
+
+  trackByAcompanhante(index: number, item: AcompanhanteView): number {
+    return item.id;
+  }
+
+  /**
+   * Recalcula todo lo que consume el template. Se llama solo ante cambios reales
+   * de estado para evitar evaluaciones en cada ciclo de change detection.
+   */
+  private actualizarResumen(): void {
+    this.tituloDialog = this.selectedHojaRuta?.id
+      ? `Hoja de ruta #${this.selectedHojaRuta.id}`
+      : 'Nueva hoja de ruta';
+
+    const marca = this.selectedVehiculo?.modelo?.marca?.descripcion;
+    const modelo = this.selectedVehiculo?.modelo?.descripcion;
+    this.vehiculoTitulo = this.selectedVehiculo
+      ? [marca, modelo].filter(v => !!v).join(' ') || `Vehículo ${this.selectedVehiculo.id}`
+      : '';
+    this.vehiculoSubtitulo = this.selectedVehiculo?.chapa
+      ? `Chapa ${this.selectedVehiculo.chapa}`
+      : '';
+
+    this.choferTitulo = this.selectedChofer?.nombre ? this.selectedChofer.nombre.toUpperCase() : '';
+    this.choferSubtitulo = this.selectedChofer?.documento
+      ? `Doc. ${this.selectedChofer.documento}`
+      : '';
+    this.choferIniciales = this.getIniciales(this.selectedChofer?.nombre);
+
+    this.acompanhantesView = this.acompanhantes.map(p => ({
+      id: p.id,
+      nombre: (p.nombre || '').toUpperCase(),
+      documento: p.documento || '',
+      iniciales: this.getIniciales(p.nombre),
+      persona: p
+    }));
+    this.cantidadAcompanhantes = this.acompanhantesView.length;
+
+    this.guardarDeshabilitado = this.isSaving
+      || this.isLoading
+      || this.selectedVehiculo == null
+      || this.selectedChofer == null;
+  }
+
+  private getIniciales(nombre: string): string {
+    if (!nombre) return '?';
+    return nombre
+      .trim()
+      .split(/\s+/)
+      .slice(0, 2)
+      .map(p => p.charAt(0))
+      .join('')
+      .toUpperCase();
   }
 }


### PR DESCRIPTION
## Qué resuelve

El diálogo de **Hoja de Ruta** (el que se abre desde la lista de transferencias con "Asignar ruta") tenía dos problemas:

1. **Las búsquedas de chofer y acompañante no estaban paginadas.** Usaban `PersonaSearchGQL` (`personaSearch`), que trae **toda** la lista de personas en un solo request y arma la paginación en el cliente.
2. La UI era poco clara: vehículo y chofer eran inputs `readonly` que parecían editables, no se veía qué quedaba seleccionado, y no había estados de carga, guardado ni error.

## Cambios

### Backend-side (consultas)
- `PersonaSearchGQL` → **`PersonaSearchPageGQL`** (`personaSearchPage(texto, page, size)`) en chofer y acompañante, con `paginator: true` y `queryData: { page: 0, size: 15 }`. La query ya existía en el backend y ya se usaba en Gastos y en `asset-common-dialog.service`; no requiere cambios en `central`.
- Vehículo ya usaba `VehiculoSearchPageGQL` paginado; solo se unificó el formato de columnas.
- `hojaRutaQuery` ahora pide `documento` (chofer y acompañantes) y `modelo.marca.descripcion` — campos que ya existen en el schema, adición no rompe nada.

### UI
- Header con ícono, título dinámico (`Nueva hoja de ruta` / `Hoja de ruta #id`) y botón de cerrar.
- Vehículo y chofer pasan a **tarjetas seleccionables** con avatar, valor principal y dato secundario (chapa / documento).
- Acompañantes: lista con iniciales, documento, contador y estado vacío explícito. Valida que el chofer no se agregue como acompañante.
- Estados de carga (modo edición), guardado (spinner en el botón) y manejo de error al guardar, que antes fallaba en silencio.
- Paleta alineada a los tonos del sistema (`src/styles.scss`): acento naranja `#f57c00`, superficies `#3c3c3c` / `#464646`, guardar en verde success `#43a047`, danger `#f44336`.
- Ancho del diálogo `30%` → `560px` (`maxWidth: 95vw`).

### Performance
Todo lo que consume el template se precalcula en el `.ts` (`actualizarResumen()`), sin llamadas a funciones ni getters desde el HTML.

## Cómo probarlo

1. Operaciones → Transferencias → seleccionar una o más transferencias sin hoja de ruta → **Asignar ruta**.
2. Click en la tarjeta de **Vehículo** → verificar paginador con total de elementos y que la búsqueda por chapa/marca/modelo pagine contra el servidor.
3. Click en **Chofer** → mismo chequeo (antes traía todas las personas de una).
4. **Agregar** acompañantes → verificar paginación, que no permita duplicados ni agregar al chofer.
5. Guardar → las transferencias seleccionadas quedan asignadas a la hoja de ruta creada.
6. Abrir el diálogo en modo edición (`hojaRutaId`) → verificar que precarga vehículo, chofer, fecha y acompañantes.

`npm run check` (AOT producción) corrido localmente: pasa sin errores.

## Riesgo

**Bajo.** Cambios acotados al diálogo `ruta-hoja` y a la query `hojaRutaQuery`. No toca el schema del backend ni el flujo de guardado (`saveHojaRuta` recibe el mismo `HojaRutaInput`).

## Impacto en auto-update

Ninguno. No se tocaron `installer.nsh`, `electron-builder.json`, manifests YAML ni nombres de artefactos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)