### PR TITLE
feat(transferencias): filtro de estado multiple en la lista

### DIFF
--- a/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
+++ b/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
@@ -319,7 +319,7 @@ export const transferenciaWithFiltersQuery = gql`
   query (
     $sucursalOrigenId: Int
     $sucursalDestinoId: Int
-    $estado: TransferenciaEstado
+    $estados: [TransferenciaEstado]
     $tipo: TipoTransferencia
     $etapa: EtapaTransferencia
     $isOrigen: Boolean
@@ -332,7 +332,7 @@ export const transferenciaWithFiltersQuery = gql`
     data: transferenciasWithFilters(
       sucursalOrigenId: $sucursalOrigenId
       sucursalDestinoId: $sucursalDestinoId
-      estado: $estado
+      estados: $estados
       tipo: $tipo
       etapa: $etapa
       isOrigen: $isOrigen

--- a/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.html
+++ b/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.html
@@ -27,7 +27,9 @@
 
       <mat-form-field fxFlex="25">
         <mat-label>Estado</mat-label>
-        <mat-select [formControl]="estadoControl">
+        <mat-select [formControl]="estadoControl" multiple
+          (selectionChange)="onEstadoSelectionChange()">
+          <mat-select-trigger>{{ estadoTriggerLabel }}</mat-select-trigger>
           <mat-option *ngFor="let estado of estadoList" [value]="estado">
             {{ estado | enumToString }}
           </mat-option>

--- a/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.ts
@@ -66,7 +66,7 @@ export class ListTransferenciaComponent implements OnInit {
   idControl = new FormControl();
   sucOrigenControl = new FormControl();
   sucDestinoControl = new FormControl();
-  estadoControl = new FormControl();
+  estadoControl = new FormControl<TransferenciaEstado[]>([]);
   etapaControl = new FormControl();
   fechaInicioControl = new FormControl();
   fechaFinControl = new FormControl();
@@ -75,6 +75,7 @@ export class ListTransferenciaComponent implements OnInit {
   sucursalIdlist: Number[];
   estadoList = Object.values(TransferenciaEstado);
   etapaList = Object.values(EtapaTransferencia);
+  estadoTriggerLabel = "";
   today = new Date();
 
   displayedColumns = [
@@ -191,12 +192,22 @@ export class ListTransferenciaComponent implements OnInit {
     this.idControl.setValue(null);
     this.sucOrigenControl.setValue(null);
     this.sucDestinoControl.setValue(null);
-    this.estadoControl.setValue(null);
+    this.estadoControl.setValue([]);
+    this.onEstadoSelectionChange();
     this.etapaControl.setValue(null);
     let unaSemanaAtras = new Date();
     unaSemanaAtras.setDate(this.today.getDate() - 7);
     this.fechaInicioControl.setValue(unaSemanaAtras);
     this.fechaFinControl.setValue(this.today);
+  }
+
+  // Se recalcula solo al cambiar la seleccion (no en cada change detection cycle,
+  // por eso no se llama desde el HTML).
+  onEstadoSelectionChange() {
+    const estados = this.estadoControl.value ?? [];
+    this.estadoTriggerLabel = estados
+      .map((e) => e.replace(/_/g, " "))
+      .join(", ");
   }
 
   onRowClick(transferencia: Transferencia, index) {

--- a/src/app/modules/operaciones/transferencia/transferencia.service.ts
+++ b/src/app/modules/operaciones/transferencia/transferencia.service.ts
@@ -222,7 +222,7 @@ export class TransferenciaService {
   onGetTransferenciasWithFilters(
     sucursalOrigenId?: number,
     sucursalDestinoId?: number,
-    estado?: TransferenciaEstado,
+    estados?: TransferenciaEstado[],
     tipo?: TipoTransferencia,
     etapa?: EtapaTransferencia,
     isOrigen?: boolean,
@@ -235,7 +235,7 @@ export class TransferenciaService {
     return this.genericCrudService.onCustomQuery(this.getTransferenciasWithFiler, {
       sucursalOrigenId,
       sucursalDestinoId,
-      estado,
+      estados,
       tipo,
       etapa,
       isOrigen,


### PR DESCRIPTION
## Qué resuelve

En **Operaciones → Transferencias** el filtro de Estado permitía elegir un solo valor. Ahora es un `mat-select multiple`: se pueden seleccionar varios estados y el listado los filtra todos a la vez.

## Cambios

| Archivo | Cambio |
|---|---|
| `graphql/graphql-query.ts` | La query pasa de `$estado: TransferenciaEstado` a `$estados: [TransferenciaEstado]` |
| `transferencia.service.ts` | El 3er parámetro de `onGetTransferenciasWithFilters` pasa a `estados?: TransferenciaEstado[]` |
| `list-transferencia.component.ts` | `estadoControl` tipado `FormControl<TransferenciaEstado[]>([])`; reset a `[]`; nuevo `onEstadoSelectionChange()` |
| `list-transferencia.component.html` | `multiple` + `mat-select-trigger` con el label precalculado |

El filtrado sigue siendo **server-side**, así que el total del paginador refleja la selección (no es un filtro visual sobre la página actual).

### Nota de performance

El label del select se precalcula en `onEstadoSelectionChange()`, disparado solo por `(selectionChange)`. No se llama ninguna función desde el HTML, respetando la regla del CLAUDE.md.

## Dependencia — orden de despliegue

⚠️ **Requiere el central con el argumento `estados`**: GabFrank/franco-system-backend-servidor#170.

Ese PR va **primero**. Si este desktop sale antes, la query falla en runtime con "Unknown argument `estados`" (Apollo no valida el schema en compile time, así que el build pasa igual). El PR del backend es retrocompatible, así que puede desplegarse solo sin esperar a este.

## Cómo probarlo

1. Levantar el central del PR #170 en 8081 y `npm start`.
2. Ir a **Operaciones → Transferencias**.
3. Poner el rango de fecha sobre datos existentes y abrir el select de Estado — ahora tiene checkboxes.
4. Elegir 2 estados → el listado y el **total del paginador** deben ser la suma de ambos.
5. Sumar un 3ro → el total crece en consecuencia.
6. Deseleccionar todo, o "Resetear filtro" → vuelve a traer todo el rango sin filtro de estado.
7. El trigger del select debe mostrar los estados elegidos separados por coma, con guiones bajos reemplazados por espacios (ej. `EN TRANSITO, ABIERTA`).

Verificado localmente contra `bodega@localhost:5551` en el rango 20/04/2026–23/04/2026: `EN_TRANSITO + ABIERTA` → 57, sumando `EN_ORIGEN` → 85, sin filtro → 203.

## Riesgo

**Bajo**, acotado a la pantalla de lista de transferencias. Sin impacto en auto-update (no toca `installer.nsh`, `electron-builder.json` ni los manifests). El único riesgo real es de orden de despliegue, descrito arriba.

## Verificación

- [x] `npm run check` (build AOT producción) completo, 0 errores
- [x] Probado end-to-end en la app contra el central del PR #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)