### PR TITLE
fix(productos): busqueda en vivo por codigo y tipo de coincidencia parcial

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/buscador-compras.service.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/buscador-compras.service.ts
@@ -16,6 +16,7 @@ import {
 export type TipoCoincidenciaBuscador =
   | 'CODIGO_EXACTO'
   | 'CODIGO_PREFIJO'
+  | 'CODIGO_PARCIAL'
   | 'TEXTO'
   | 'ID';
 
@@ -240,7 +241,7 @@ export class BuscadorComprasService {
           resultado.getContent = (pageInfo.getContent ?? []).map((producto) => ({
             producto,
             codigoCoincidente: producto.codigoPrincipal,
-            tipoCoincidencia: esCodigo ? 'CODIGO_PREFIJO' : 'TEXTO',
+            tipoCoincidencia: esCodigo ? 'CODIGO_PARCIAL' : 'TEXTO',
           }));
           return resultado;
         })

--- a/src/app/modules/productos/producto/list-producto/list-producto.component.ts
+++ b/src/app/modules/productos/producto/list-producto/list-producto.component.ts
@@ -65,7 +65,7 @@ import { NotificacionSnackbarService } from "../../../../notificacion-snackbar.s
 import { GestionProveedoresProductoDialogComponent } from "../gestion-proveedores-producto-dialog/gestion-proveedores-producto-dialog.component";
 import { Familia } from "../../familia/familia.model";
 import { FamiliasSearchGQL } from "../../familia/graphql/familiasSearch";
-import { debounceTime, distinctUntilChanged, filter } from "rxjs/operators";
+import { debounceTime, distinctUntilChanged } from "rxjs/operators";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -186,7 +186,6 @@ export class ListProductoComponent implements OnInit, AfterViewInit {
       .pipe(
         debounceTime(250),
         distinctUntilChanged(),
-        filter(() => this.filtroCodigoControl.value !== true),
         untilDestroyed(this)
       )
       .subscribe(() => this.onFiltrar(false, true));


### PR DESCRIPTION
## Qué resuelve

Acompaña a [franco-system-backend-servidor#171](https://github.com/GabFrank/franco-system-backend-servidor/pull/171), que hace que la búsqueda por código de barras matchee por **coincidencia parcial** (tramo interno, terminación, o con/sin el cero inicial) en lista de productos, transferencias y gestión de compras.

El fix de fondo es de backend; acá van los dos ajustes que necesita el desktop.

## Cambios

**`list-producto.component.ts`** — se quita el `filter()` sobre `valueChanges` que desactivaba el debounce cuando el check "Buscar por código" estaba marcado. Ya no hace falta apretar Enter: busca mientras se escribe, igual que el modo texto. También alinea con la regla del repo de no filtrar en `valueChanges`.

**`buscador-compras.service.ts`** — se agrega `CODIGO_PARCIAL` al type `TipoCoincidenciaBuscador`, reflejando el nuevo valor del enum del backend, y se usa en el mapeo del fallback.

## Cómo probarlo

Requiere el backend del PR gemelo. Con el código real `070847033233`:

| Se escribe | Debe encontrar |
|---|---|
| `070847033233` (completo) | el producto |
| `70847033233` (sin el cero inicial) | el producto |
| `33233` (terminación) | el producto, primero |
| `0847033` (tramo interno) | el producto, primero |

En **Lista de productos**, verificar además que con el check "Buscar por código" marcado la búsqueda se dispara sola al escribir (antes exigía Enter). Probar también en el diálogo de **transferencias** y en el buscador de **gestión de compras**.

## Riesgo

**Bajo.** `npm run check` (AOT) pasa sin errores. Sin cambios de UI ni de contrato; el type nuevo es aditivo.

## Impacto en auto-update

Ninguno: no se tocan `installer.nsh`, `electron-builder.json` ni manifests.

## Dependencia

Mergear **después** de [franco-system-backend-servidor#171](https://github.com/GabFrank/franco-system-backend-servidor/pull/171). Por sí solo este PR no rompe nada (el type nuevo simplemente no llega hasta que el backend lo emita), pero la búsqueda parcial no funciona sin el backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)