### PR TITLE
fix(graphql): evitar crash ante respuesta vacia del servidor

### DIFF
--- a/src/app/generics/generic-crud.service.ts
+++ b/src/app/generics/generic-crud.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Injector } from "@angular/core";
 import { Mutation, Query, Subscription } from "apollo-angular";
-import { Observable, timeout } from "rxjs";
+import { Observable, OperatorFunction, timeout } from "rxjs";
+import { map } from "rxjs/operators";
 import { MainService } from "../main.service";
 import {
   NotificacionColor,
@@ -25,6 +26,13 @@ export interface QueryError {
   };
 }
 
+// Resultado sintético usado cuando el link de Apollo emite una respuesta vacía
+// (servidor que responde con cuerpo vacío, operación cortada, etc.).
+const RESPUESTA_VACIA = {
+  data: null,
+  errors: [{ message: "Respuesta vacía del servidor" }],
+};
+
 @UntilDestroy({ checkProperties: true })
 @Injectable({
   providedIn: "root",
@@ -43,6 +51,24 @@ export class GenericCrudService {
     private apollo: Apollo
   ) {
     setTimeout(() => (this.mainService = injector.get(MainService)));
+  }
+
+  /**
+   * Apollo puede emitir `null`/`undefined` cuando el servidor responde con
+   * cuerpo vacío o la operación se corta antes de tiempo. Todos los handlers de
+   * abajo asumen un objeto con `errors`/`data`, así que se normaliza acá: el
+   * flujo entra por la rama de error ya existente (cierra el diálogo, avisa)
+   * en vez de romper con "Cannot read properties of null (reading 'errors')".
+   */
+  private sinRespuestaVacia(): OperatorFunction<any, any> {
+    return map((res: any) => {
+      if (res != null) return res;
+      // Si esto aparece SIN el warning "[GraphQL] Respuesta vacía del servidor"
+      // de graphql-connection.service, la operación terminó sin emitir ningún
+      // resultado (link terminal ausente), no por un cuerpo HTTP vacío.
+      console.warn("[GraphQL] Resultado nulo en GenericCrudService");
+      return RESPUESTA_VACIA;
+    });
   }
 
   onGetAll(gql: Query, page?, size?, servidor: boolean = true): Observable<any> {
@@ -64,7 +90,7 @@ export class GenericCrudService {
             },
           }
         )
-        .pipe(untilDestroyed(this))
+        .pipe(untilDestroyed(this), this.sinRespuestaVacia())
         .subscribe({
           next: (res) => {
             this.cargandoService.closeDialog(requestId);
@@ -74,7 +100,7 @@ export class GenericCrudService {
               obs.complete();
             } else {
               this.notificacionSnackBar.notification$.next({
-                texto: "Ups! Algo salió mal: " + res.errors[0].message + res,
+                texto: "Ups! Algo salió mal: " + res.errors[0].message,
                 color: NotificacionColor.danger,
                 duracion: 3,
               });
@@ -116,7 +142,8 @@ export class GenericCrudService {
       })
         .pipe(
           untilDestroyed(this),
-          timeout(300000) // Adjust as per your needs
+          timeout(300000), // Adjust as per your needs
+          this.sinRespuestaVacia()
         )
         .subscribe({
           next: (res) => {
@@ -129,7 +156,7 @@ export class GenericCrudService {
               obs.complete();
             } else {
               this.notificacionSnackBar.notification$.next({
-                texto: "Ups! Algo salió mal: " + res.errors[0].message + res,
+                texto: "Ups! Algo salió mal: " + res.errors[0].message,
                 color: NotificacionColor.danger,
                 duracion: 3,
               });
@@ -180,7 +207,7 @@ export class GenericCrudService {
             fetchOptions: { signal },
           },
         })
-        .pipe(untilDestroyed(this))
+        .pipe(untilDestroyed(this), this.sinRespuestaVacia())
         .subscribe({
           next: (res) => {
             if (silentLoad !== true) {
@@ -193,7 +220,7 @@ export class GenericCrudService {
             } else {
               if (silentLoad !== true) {
                 this.notificacionSnackBar.notification$.next({
-                  texto: "Ups! Algo salió mal: " + res.errors[0].message + res,
+                  texto: "Ups! Algo salió mal: " + res.errors[0].message,
                   color: NotificacionColor.danger,
                   duracion: 3,
                 });
@@ -238,7 +265,7 @@ export class GenericCrudService {
             fetchOptions: { signal },
           },
         })
-        .pipe(untilDestroyed(this))
+        .pipe(untilDestroyed(this), this.sinRespuestaVacia())
         .subscribe({
           next: (res) => {
             if (cargando == true) {
@@ -250,7 +277,7 @@ export class GenericCrudService {
               obs.complete();
             } else {
               this.notificacionSnackBar.notification$.next({
-                texto: "Ups! Algo salió mal: " + res.errors[0].message + res,
+                texto: "Ups! Algo salió mal: " + res.errors[0].message,
                 color: NotificacionColor.danger,
                 duracion: 3,
               });
@@ -297,7 +324,7 @@ export class GenericCrudService {
             },
           }
         )
-        .pipe(untilDestroyed(this))
+        .pipe(untilDestroyed(this), this.sinRespuestaVacia())
         .subscribe(
           (res) => {
             silentLoad != true
@@ -358,7 +385,7 @@ export class GenericCrudService {
             },
           }
         )
-        .pipe(untilDestroyed(this))
+        .pipe(untilDestroyed(this), this.sinRespuestaVacia())
         .subscribe({
           next: (res) => {
             this.cargandoService.closeDialog(requestId);
@@ -433,7 +460,7 @@ export class GenericCrudService {
             },
           }
         )
-        .pipe(untilDestroyed(this))
+        .pipe(untilDestroyed(this), this.sinRespuestaVacia())
         .subscribe({
           next: (res) => {
             this.isLoading = false;
@@ -495,7 +522,7 @@ export class GenericCrudService {
             fetchOptions: { signal },
           },
         })
-        .pipe(untilDestroyed(this))
+        .pipe(untilDestroyed(this), this.sinRespuestaVacia())
         .subscribe({
           next: (res) => {
             this.isLoading = false;
@@ -556,7 +583,7 @@ export class GenericCrudService {
               },
             }
           )
-          .pipe(untilDestroyed(this))
+          .pipe(untilDestroyed(this), this.sinRespuestaVacia())
           .subscribe({
             next: (res) => {
               this.cargandoService.closeDialog(requestId);
@@ -609,6 +636,7 @@ export class GenericCrudService {
                     },
                   }
                 )
+                .pipe(this.sinRespuestaVacia())
                 .subscribe({
                   next: (res) => {
                     this.cargandoService.closeDialog(requestId);
@@ -676,7 +704,7 @@ export class GenericCrudService {
               },
             }
           )
-          .pipe(untilDestroyed(this))
+          .pipe(untilDestroyed(this), this.sinRespuestaVacia())
           .subscribe({
             next: (res) => {
               this.cargandoService.closeDialog(requestId);
@@ -729,6 +757,7 @@ export class GenericCrudService {
                     },
                   }
                 )
+                .pipe(this.sinRespuestaVacia())
                 .subscribe({
                   next: (res) => {
                     this.cargandoService.closeDialog(requestId);
@@ -813,7 +842,7 @@ export class GenericCrudService {
             },
           }
         )
-        .pipe(untilDestroyed(this))
+        .pipe(untilDestroyed(this), this.sinRespuestaVacia())
         .subscribe({
           next: (res) => {
             this.cargandoService.closeDialog(requestId);
@@ -866,7 +895,7 @@ export class GenericCrudService {
             },
           }
         )
-        .pipe(untilDestroyed(this))
+        .pipe(untilDestroyed(this), this.sinRespuestaVacia())
         .subscribe({
           next: (res) => {
             this.cargandoService.closeDialog(requestId);

--- a/src/app/shared/services/graphql-connection.service.ts
+++ b/src/app/shared/services/graphql-connection.service.ts
@@ -212,6 +212,7 @@ export class GraphqlConnectionService {
       http = ApolloLink.from([
         basic,
         auth,
+        this.createEmptyResultGuardLink(),
         httpLink.create({
           uri: url,
           useGETForQueries: false // Force all requests to use POST
@@ -227,6 +228,7 @@ export class GraphqlConnectionService {
       this.createCentralTimeoutLink(),
       basic,
       auth,
+      this.createEmptyResultGuardLink(),
       httpLink.create({
         uri: url2,
         useGETForQueries: false // Force all requests to use POST
@@ -289,6 +291,53 @@ export class GraphqlConnectionService {
         )
       );
     }
+  }
+
+  /**
+   * Normaliza respuestas vacías del transporte HTTP.
+   *
+   * `apollo-angular` emite `response.body` tal cual: si el servidor contesta
+   * 200 con cuerpo vacío (o el proxy corta la respuesta), lo que baja por la
+   * cadena de links es `null`. El link `onError` de Apollo lee `result.errors`
+   * sin protección y lanza "Cannot read properties of null (reading 'errors')";
+   * al romperse ese `next`, la operación jamás entrega valor: el spinner queda
+   * abierto y la promesa de `ApolloClient.query` resuelve `undefined`, que es
+   * el segundo error que se ve en GenericCrudService.
+   *
+   * Este link va pegado al link terminal HTTP (por debajo de `errorLink`) para
+   * que la respuesta vacía se convierta en un resultado GraphQL válido con
+   * `errors`, formato que el resto de la app ya sabe manejar.
+   */
+  private createEmptyResultGuardLink(): ApolloLink {
+    return new ApolloLink((operation, forward) => {
+      return new Observable((observer) => {
+        const subscription = forward(operation).subscribe({
+          next: (result) => {
+            if (result) {
+              observer.next(result);
+            } else {
+              // `apollo-angular` guarda la respuesta HTTP cruda en el contexto:
+              // sirve para saber qué operación y qué servidor devolvió vacío.
+              const { response } = operation.getContext();
+              console.warn("[GraphQL] Respuesta vacía del servidor", {
+                operacion: operation.operationName,
+                url: response?.url,
+                status: response?.status,
+                body: response?.body,
+              });
+              observer.next({
+                data: null,
+                errors: [{ message: "Respuesta vacía del servidor" }] as any,
+              });
+            }
+          },
+          error: (error) => observer.error(error),
+          complete: () => observer.complete(),
+        });
+
+        return () => subscription.unsubscribe();
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
## Que resuelve

Dos errores encadenados en el arranque de la app:

```
ERROR TypeError: Cannot read properties of null (reading 'errors')      (link onError de Apollo)
ERROR TypeError: Cannot read properties of undefined (reading 'errors') (generic-crud.service.ts)
```

Cuando el servidor responde HTTP 200 con cuerpo vacio, `apollo-angular` emite `null` por la cadena de links (`observer.next(response.body)`). El link `onError` de Apollo hace `if (result.errors)` sin guard y explota. Al romperse ese `next`, la operacion nunca entrega valor: el spinner "Buscando..." queda abierto y la promesa de `ApolloClient.query` resuelve `undefined`, provocando el segundo crash.

Ya existia un guard en `createAbortableLink`, pero mal ubicado: la cadena es `abortableLink.concat(errorLink.concat(...))`, o sea el guard queda **por encima** del `errorLink` y el `null` revienta antes de llegar.

> La causa raiz del 200 vacio esta en los backends (el filtro JWT cortaba la respuesta sin escribir nada cuando falta el token). Se arregla en PRs paralelos de `franco-system-backend-filial` y `franco-system-backend-servidor`. Este PR hace que el cliente no se rompa ante un cuerpo vacio venga de donde venga.

## Cambios

- **`graphql-connection.service.ts`**: nuevo `createEmptyResultGuardLink()`, insertado en los dos chains HTTP (`http` local y `http2` central) pegado al link terminal, **por debajo** del `errorLink`. Convierte la respuesta vacia en un resultado GraphQL valido con `errors`, que es el formato que el resto de la app ya sabe manejar. No toca WebSockets ni el `centralTimeoutLink`. Loguea operacion, url y status para diagnostico.
- **`generic-crud.service.ts`**: operador `sinRespuestaVacia()` en los 13 pipes de Apollo. Si llega `null`/`undefined`, se normaliza y el flujo entra por la **rama de error que ya existia** (cierra el dialogo, muestra el snackbar) en vez de romper.
- **`generic-crud.service.ts`**: eliminada la concatenacion `+ res` en 4 mensajes de notificacion, que imprimia `[object Object]` al usuario.

## Como probarlo

1. Levantar la app apuntando a un servidor que devuelva 200 con cuerpo vacio (p.ej. backend sin el fix del filtro JWT, consultando antes del login).
2. Antes: dos `TypeError` en consola y el dialogo de carga colgado.
3. Ahora: sin excepciones, snackbar "Ups! Algo salio mal: Respuesta vacia del servidor" (sin `[object Object]`) y el dialogo se cierra.
4. Camino feliz sin cambios: `sinRespuestaVacia()` solo actua cuando `res == null`.

## Riesgo

**Bajo.** El unico camino que cambia es uno que hoy es un crash garantizado. Los pipes de `dialogoService.confirm` quedaron **sin tocar** a proposito: ahi el stream emite un boolean y normalizar un `null` a un objeto truthy habria hecho que un confirm nulo dispare el borrado.

`npm run check` (AOT) en verde.

## Impacto en auto-update

Ninguno. No se tocan `installer.nsh`, `electron-builder.json` ni manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)