### PR TITLE
feat(maletines): filtrar por sucursal, codigo y abierto

### DIFF
--- a/src/app/modules/financiero/maletin/list-maletin/list-maletin.component.html
+++ b/src/app/modules/financiero/maletin/list-maletin/list-maletin.component.html
@@ -7,7 +7,48 @@
   [isAdicionar]="true"
   (adicionar)="onAdd()"
 >
-  <div filtros></div>
+  <div filtros>
+    <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
+      <div fxFlex="30%">
+        <mat-form-field style="width: 90%">
+          <mat-label>Sucursal</mat-label>
+          <mat-select [formControl]="sucursalControl" name="sucursalControl">
+            <mat-option [value]="null"> Todas </mat-option>
+            <mat-option *ngFor="let sucursal of sucursalList" [value]="sucursal">
+              {{ sucursal?.id }} - {{ sucursal?.nombre | titlecase }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+      <div fxFlex="30%">
+        <mat-form-field style="width: 90%">
+          <mat-label>Código</mat-label>
+          <input
+            matInput
+            type="text"
+            [formControl]="codigoControl"
+            (keyup.enter)="onFiltrar()"
+          />
+        </mat-form-field>
+      </div>
+      <div fxFlex="30%">
+        <mat-label>Abierto</mat-label>
+        <mat-checkbox
+          [checked]="abiertoControl.value == true"
+          [indeterminate]="abiertoControl.value == null"
+          (click)="onCambiarAbierto()"
+        >
+          {{
+            abiertoControl.value == null
+              ? "Todos"
+              : abiertoControl.value == true
+              ? "Si"
+              : "No"
+          }}
+        </mat-checkbox>
+      </div>
+    </div>
+  </div>
   <div table>
     <table
       mat-table

--- a/src/app/modules/financiero/maletin/list-maletin/list-maletin.component.ts
+++ b/src/app/modules/financiero/maletin/list-maletin/list-maletin.component.ts
@@ -1,5 +1,6 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { Component, OnInit, ViewChild } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { updateDataSource } from '../../../../commons/core/utils/numbersUtils';
@@ -16,6 +17,8 @@ import { Tab } from '../../../../layouts/tab/tab.model';
 import { ListVentaComponent } from '../../../operaciones/venta/list-venta/list-venta.component';
 import { PdvCaja } from '../../pdv/caja/caja.model';
 import { ListRetiroComponent } from '../../retiro/list-retiro/list-retiro.component';
+import { Sucursal } from '../../../empresarial/sucursal/sucursal.model';
+import { SucursalService } from '../../../empresarial/sucursal/sucursal.service';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -50,13 +53,21 @@ export class ListMaletinComponent implements OnInit {
   isLastPage = false;
   isSearching = false;
 
+  sucursalList: Sucursal[] = [];
+  maletinList: Maletin[] = [];
+
+  sucursalControl = new FormControl(null);
+  codigoControl = new FormControl(null);
+  // tri-estado: null = todos, true = abiertos, false = cerrados
+  abiertoControl = new FormControl(null);
 
 
   constructor(
     private maletinService: MaletinService,
     public windowInfoService: WindowInfoService,
     private matDialog: MatDialog,
-    private tabService: TabService
+    private tabService: TabService,
+    private sucursalService: SucursalService
   ) {
     this.headerHeight = windowInfoService.innerTabHeight * 0.2;
     this.tableHeight = windowInfoService.innerTabHeight * 0.8;
@@ -64,6 +75,11 @@ export class ListMaletinComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.sucursalService.onGetAllSucursales(true)
+      .pipe(untilDestroyed(this))
+      .subscribe(res => {
+        if (res != null) this.sucursalList = res.filter(s => s.id != 0);
+      })
     this.onFiltrar()
   }
 
@@ -94,14 +110,43 @@ export class ListMaletinComponent implements OnInit {
 
   }
   onFiltrar() {
-    this.maletinService.onGetAll().subscribe(res => {
-      if (res != null) {
-        this.dataSource.data = res;
-      }
-    })
+    this.maletinService.onGetAll()
+      .pipe(untilDestroyed(this))
+      .subscribe(res => {
+        if (res != null) {
+          this.maletinList = res;
+          this.aplicarFiltros();
+        }
+      })
   }
-  resetFiltro() {
 
+  aplicarFiltros() {
+    const sucursalId = this.sucursalControl.value?.id;
+    const codigo = (this.codigoControl.value || '').toString().trim().toLowerCase();
+    const abierto = this.abiertoControl.value;
+
+    this.dataSource.data = (this.maletinList || []).filter(maletin =>
+      (sucursalId == null || maletin?.sucursal?.id == sucursalId) &&
+      (codigo == '' || (maletin?.descripcion || '').toLowerCase().includes(codigo)) &&
+      (abierto == null || (maletin?.abierto == true) == abierto)
+    );
+  }
+
+  onCambiarAbierto() {
+    this.abiertoControl.setValue(
+      this.abiertoControl.value === null
+        ? true
+        : this.abiertoControl.value === true
+          ? false
+          : null
+    );
+  }
+
+  resetFiltro() {
+    this.sucursalControl.setValue(null);
+    this.codigoControl.setValue(null);
+    this.abiertoControl.setValue(null);
+    this.aplicarFiltros();
   }
 
   onIrACaja(cajaSalida: PdvCaja){


### PR DESCRIPTION
## Qué resuelve

La lista de maletines (**Financiero → Maletines**) mostraba los ~70 registros sin ninguna forma de acotarlos: el slot `<div filtros>` estaba vacío y `resetFiltro()` no hacía nada. Se agregan los tres filtros pedidos:

- **Sucursal** — `mat-select` con opción "Todas".
- **Código** — input de texto, coincidencia parcial (case-insensitive) sobre `descripcion`. Enter dispara la búsqueda.
- **Abierto** — `mat-checkbox` tri-estado: **Todos** (indeterminado) → **Si** → **No**. Mismo patrón que el filtro "Verificado" de Lista de Cajas.

Arranca sin filtros aplicados, así que el comportamiento por defecto de la pantalla no cambia. **Limpiar Filtro** resetea los tres controles.

## Decisiones de implementación

- **Filtrado en cliente.** El resolver `maletines(page, size)` ignora ambos argumentos y devuelve `service.findAll2()` (`MaletinGraphQL.java:72-74`), o sea que el frontend ya recibía la lista completa en cada carga. Filtrar sobre esa lista evita tocar el backend y no introduce una paginación que hoy no existe. Si la tabla crece, el paso siguiente natural es mover el filtro al server sobre `searchMaletin(texto, sucId)`.
- **`abierto = null` se trata como "No"**, que es exactamente lo que ya muestra la columna Abierto de la grilla (`abierto == true ? "Si" : "No"`). Así el filtro y la tabla no se contradicen. Hay 1 registro en ese estado.
- **Sucursal 0 (SERVIDOR) excluida del dropdown**, siguiendo la convención del codebase (`filter(s => s.id != 0)`, igual que `list-sector`, `list-retiro`, `list-compra`, `list-gastos`). Esos maletines siguen siendo visibles con "Todas".

## Cómo probarlo

Financiero → Maletines. Aplicar con **Buscar** (o Enter en Código):

| Filtro | Esperado |
|---|---|
| Abierto = **Si** / **No** / **Todos** | 30 / 40 / 70 filas |
| Sucursal `4 - Suc. Industrial` | 2 filas: `0020220401`, `0020220402` |
| Código `00202207` | 2 filas de Suc. Katuete 1 |
| Sucursal `7 - Suc. Katuete 1` + Abierto **Si** | 2 filas |
| **Limpiar Filtro** | vuelve a las 70 filas |

Verificado con `npm run check` (build AOT de producción): 0 errores, solo los warnings preexistentes de CommonJS/SCSS. Probado en el entorno local contra la DB `bodega` (backend en 8081).

## Impacto

- **DB**: ninguno. Sin migraciones.
- **API GraphQL**: ninguno. No se agregan ni modifican queries, campos ni resolvers — `maletinsQuery` ya traía `descripcion`, `activo` y `sucursal { id nombre }`. Sin impacto cross-proyecto (mobile/backend).
- **Rollback**: trivial, revertir el commit. No hay estado persistido ni cambios de schema.
- **Riesgo**: **bajo**. Cambio acotado a un componente, sin backend, aditivo sobre una barra de filtros que estaba vacía.

🤖 Generated with [Claude Code](https://claude.com/claude-code)