### PR TITLE
fix(compras): enfocar boton Salir al crear nota de recepcion

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.html
@@ -367,6 +367,7 @@
       type="button"
       (click)="onSalir()"
       class="exit-button"
+      #salirButton
       [disabled]="deletingNota || savingNota"
     >
       {{ textoBotonSalir }}

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-nota-recepcion-dialog/add-edit-nota-recepcion-dialog.component.ts
@@ -57,6 +57,7 @@ export interface AddEditNotaRecepcionDialogResult {
 export class AddEditNotaRecepcionDialogComponent implements OnInit, AfterViewInit {
   @ViewChild('guardarButton', { static: false }) guardarButton!: MatButton;
   @ViewChild('cancelButton', { static: false }) cancelButton!: MatButton;
+  @ViewChild('salirButton', { static: false }) salirButton!: MatButton;
   @ViewChild(MatPaginator, { static: false }) paginator!: MatPaginator;
   
   // ViewChild para los campos del formulario
@@ -1427,7 +1428,7 @@ export class AddEditNotaRecepcionDialogComponent implements OnInit, AfterViewIni
 
               this.loadItemsAfterCreation();
 
-              this.focusCancelButton();
+              this.focusSalirButton();
               
               this.notificacionService.openSucess('Nota de recepción creada exitosamente');
             },
@@ -1542,11 +1543,11 @@ export class AddEditNotaRecepcionDialogComponent implements OnInit, AfterViewIni
     }
   }
 
-  private focusCancelButton(): void {
-    // Dar foco al botón Cancelar después de crear
+  private focusSalirButton(): void {
+    // Dar foco al botón Salir después de crear
     setTimeout(() => {
-      if (this.cancelButton) {
-        this.cancelButton._elementRef.nativeElement.focus();
+      if (this.salirButton) {
+        this.salirButton._elementRef.nativeElement.focus();
       }
     }, 100);
   }


### PR DESCRIPTION
## Qué resuelve

En el diálogo **Editar Nota de Recepción**, después de crear la nota el foco se daba automáticamente al botón **Cancelar**. La acción esperada por defecto es **Salir**, así que un Enter accidental disparaba la cancelación en lugar de cerrar el diálogo.

Ahora el foco post-creación va al botón **Salir**.

## Cambios

- `add-edit-nota-recepcion-dialog.component.html` — se agrega la referencia de template `#salirButton` al botón de salida.
- `add-edit-nota-recepcion-dialog.component.ts` — nuevo `@ViewChild('salirButton')`; `focusCancelButton()` pasa a `focusSalirButton()` y apunta al botón de salida. Se actualiza la llamada en el `next` de `onSaveNotaRecepcion`.

## Cómo probarlo

1. Compras → Gestión de Compras → seleccionar un pedido → **+ Crear Nota**.
2. Completar los datos requeridos y presionar **Crear**.
3. Verificar que, tras el mensaje "Nota de recepción creada exitosamente", el botón enfocado (borde de foco visible) sea **Salir** y no **Cancelar**.
4. Presionar Enter y confirmar que ejecuta el flujo de salida.

## Riesgo

**Bajo.** Cambio acotado al foco de un botón dentro de un único diálogo. No toca lógica de negocio, GraphQL ni persistencia.

## Impacto en auto-update

Ninguno. No se tocan `installer.nsh`, `electron-builder.json` ni manifests YAML.

## Notas

- `npm run check` (build AOT) corrido localmente: exit 0, sin errores.
- El `@ViewChild('cancelButton')` queda declarado pero sin uso; se dejó por si se necesita enfocarlo en otro flujo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)