### PR TITLE
fix(compras): abrir lista de proveedores desde el dashboard

### DIFF
--- a/src/app/modules/operaciones/compra/compra-dashboard/compra-dashboard.component.ts
+++ b/src/app/modules/operaciones/compra/compra-dashboard/compra-dashboard.component.ts
@@ -5,6 +5,7 @@ import { MainService } from '../../../../main.service';
 import { NotificacionSnackbarService } from '../../../../notificacion-snackbar.service';
 import { ListCompraComponent } from '../list-compra/list-compra.component';
 import { ListSolicitudPagoComponent } from '../../solicitud-pago/list-solicitud-pago/list-solicitud-pago.component';
+import { ListProveedorComponent } from '../../../personas/proveedor/list-proveedor/list-proveedor.component';
 
 @Component({
   selector: 'compra-dashboard',
@@ -26,8 +27,9 @@ export class CompraDashboardComponent {
   }
 
   onListProveedores() {
-    // TODO: Implementar cuando se cree el componente de lista de proveedores
-    this.notificacionService.openWarn('Funcionalidad en desarrollo. ')
+    this.tabService.addTab(
+      new Tab(ListProveedorComponent, 'Lista de proveedores', null, CompraDashboardComponent)
+    );
   }
 
   onListVendedores() {


### PR DESCRIPTION
## Qué resuelve

El botón **"Lista de Proveedores"** del dashboard de compras no hacía nada útil: `onListProveedores()` tenía un `TODO` y solo mostraba un snackbar *"Funcionalidad en desarrollo"*.

El componente `ListProveedorComponent` ya existía y ya está declarado en `PersonasModule` — se abre hoy desde el menú lateral (`side-mini-variant`) y desde el dashboard de personas. Solo faltaba engancharlo acá.

## Cambio

`compra-dashboard.component.ts`: `onListProveedores()` ahora abre `ListProveedorComponent` en un tab vía `tabService.addTab(...)`, pasando `CompraDashboardComponent` como parent para que el botón de volver funcione — mismo patrón que `onListCompras()` y `onListSolicitudesPago()`.

Un archivo, +4/-2. Sin cambios de backend ni de schema GraphQL.

Fuera de alcance: `onListVendedores()` sigue con su `TODO`.

## Cómo probarlo

1. Operaciones → Compras
2. Tocar **"Lista de Proveedores"**
3. Debe abrirse el tab "Lista de proveedores" con la tabla cargada, y el botón de volver debe regresar al dashboard de compras

Probado en la app (`npm start`) contra el central en 8081.

## Riesgo

**Bajo.** Reutiliza un componente ya en producción, sin tocar su código. Sin impacto en DB ni en auto-update. Rollback = revertir el commit.

## Verificación

`npm run check` (build AOT de producción) OK — chunks emitidos, cero errores; solo los warnings preexistentes de dependencias CommonJS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)