### PR TITLE
fix(login): cerrar sesion en el mismo servidor donde se abrio

### DIFF
--- a/src/app/modules/login/login.service.ts
+++ b/src/app/modules/login/login.service.ts
@@ -97,7 +97,12 @@ export class LoginService {
       });
   }
 
-  cerrarSesionActiva(servidor: boolean = true): void {
+  /**
+   * Cierra la sesion activa. Sin `servidor` explicito el destino lo resuelve
+   * `onSaveInicioSesion` desde la configuracion, para que el cierre vaya al
+   * mismo lado que la apertura (ver `registrarSesionActiva`).
+   */
+  cerrarSesionActiva(servidor?: boolean): void {
     const sesionActual = this.mainService.usuarioActual?.inicioSesion;
     if (!sesionActual?.id || !sesionActual?.sucursal) {
       return;

--- a/src/app/modules/personas/usuarios/usuario.service.ts
+++ b/src/app/modules/personas/usuarios/usuario.service.ts
@@ -27,6 +27,7 @@ import { IncorporarEmbeddingMarcacionGQL } from "./graphql/incorporarEmbeddingMa
 import { IncorporarEmbeddingMarcacionResult } from '../../administrativo/marcacion/models/incorporar-embedding-result.model';
 import { UsuariosSearchPaginatedGQL } from "./graphql/usuarioSearchPaginated";
 import { PageInfo } from "../../../app.component";
+import { ConfiguracionService } from "../../../shared/services/configuracion.service";
 
 @UntilDestroy({ checkProperties: true })
 @Injectable({
@@ -96,8 +97,19 @@ export class UsuarioService {
     return this.genericService.onGetByTexto(this.verificarUsuario, texto, servidor)
   }
 
-  onSaveInicioSesion(entity: InicioSesionInput, servidor: boolean = true): Observable<InicioSesion> {
-    return this.genericService.onSave(this.saveInicioSesion, entity, null, null, servidor);
+  /**
+   * Guarda el inicio de sesion. Cuando no se indica `servidor` el destino se
+   * resuelve desde la configuracion: en una filial (`isLocal`) se escribe local
+   * y la replica logica lo sube al central.
+   *
+   * Es importante que apertura y cierre de sesion vayan al mismo destino: la
+   * fila usa PK compuesta (id, sucursal_id) y el id lo asigna la filial, asi
+   * que si el cierre escribe directo en el central se adelanta al INSERT que
+   * viaja por replica y la suscripcion se cae por duplicate key.
+   */
+  onSaveInicioSesion(entity: InicioSesionInput, servidor?: boolean): Observable<InicioSesion> {
+    const destino = servidor ?? !this.injector.get(ConfiguracionService).getConfig()?.isLocal;
+    return this.genericService.onSave(this.saveInicioSesion, entity, null, null, destino);
   }
 
   onGetUsuarioImages(id: number, type: string, servidor: boolean = true, errorConf?: any): Observable<string[]> {


### PR DESCRIPTION
## Que resuelve

La suscripcion de replica logica `bodega_filial14_sub` se cae repetidamente con
`duplicate key value violates unique constraint "inicio_sesion_pk"`. Paso tres
veces entre el 24 y el 28 de julio, dejando hasta 2 dias de ventas sin subir al
central.

**Causa:** apertura y cierre de sesion escriben en servidores distintos.

- Apertura (`login.service.ts:155`): `registrarSesionActiva(res, !config.isLocal)`.
  En una filial `isLocal = true`, asi que la sesion se crea **en la filial**, que
  le asigna el id desde su secuencia.
- Cierre (`cerrarSesionActiva`, y los tres componentes que llaman a
  `onSaveInicioSesion` sin flag): tomaban el default `servidor = true` y escribian
  **en el central**, mandando el id que genero la filial.

Como `configuraciones.inicio_sesion` tiene PK compuesta `(id, sucursal_id)` y el
resolver del central (`InicioSesionGraphQL.saveInicioSesion`) mapea `id` y
`sucursalId` del input directo a la PK, el cierre inserta esa fila en el central.
Si le gana la carrera al INSERT que viaja por replica, la suscripcion muere.

Se rompia sobre todo despues de reiniciar la filial, porque ahi se cierran las
sesiones abiertas antes de que la replica alcance a subirlas.

## Como se arregla

El destino se resuelve desde la configuracion cuando no se indica explicitamente.
En una filial todo se escribe local y la replica logica queda como unico camino al
central. Se corrige en `onSaveInicioSesion`, que es el default que heredan los
cuatro puntos de cierre (`login.service`, `header`, `side`, `side-mini-variant`).

Las llamadas que ya pasaban el flag explicito no cambian de comportamiento.

## Como probarlo

1. En una filial (`isLocal = true`), iniciar sesion y cerrarla.
2. La fila debe aparecer **solo** en la base de la filial en el momento del cierre,
   y llegar al central por replica.
3. Verificar que la suscripcion sigue viva:
   `select pid from pg_stat_subscription where subname = 'bodega_filialN_sub';`
   con `pid` no nulo, y `apply_error_count` sin crecer.
4. En un cliente contra el central (`isLocal = false`), abrir y cerrar sesion
   sigue escribiendo en el central igual que antes.

## Impacto en DB

Ninguno: no hay migraciones ni cambios de esquema.

## Impacto en rollback

Ninguno. Revertir el commit restaura el comportamiento anterior, que vuelve a
exponer la carrera.

## Riesgo

Bajo. El cambio es el default de un parametro y no altera las llamadas que ya
pasaban el flag. `tsc --noEmit --skipLibCheck` pasa con 0 errores en `src/`.

## Pendiente aparte

Las filiales ya replicadas quedaron destrabadas a mano borrando las filas
duplicadas en el central. Hasta que este fix se despliegue, la carrera sigue
existiendo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
