### PR TITLE
feat(financiero): ABM de proveedores de servicios y vínculo con terminal POS

### DIFF
--- a/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.html
+++ b/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.html
@@ -52,6 +52,39 @@
       </div>
     </div>
 
+    <!-- Proveedor de servicio -->
+    <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
+      <div fxFlex>
+        <mat-form-field appearance="outline" style="width: 100%">
+          <mat-label>Proveedor de servicio</mat-label>
+          <input
+            matInput
+            [formControl]="proveedorServicioControl"
+            readonly
+            placeholder="Sin proveedor asignado"
+          />
+        </mat-form-field>
+      </div>
+      <button
+        mat-icon-button
+        color="primary"
+        type="button"
+        [disabled]="!isEditting"
+        (click)="onBuscarProveedorServicio()"
+      >
+        <mat-icon>search</mat-icon>
+      </button>
+      <button
+        mat-icon-button
+        color="warn"
+        type="button"
+        [disabled]="!isEditting || !selectedProveedorServicio"
+        (click)="onLimpiarProveedorServicio()"
+      >
+        <mat-icon>clear</mat-icon>
+      </button>
+    </div>
+
     <!-- Checkbox -->
     <div fxLayout="column" fxLayoutGap="10px">
       <div fxLayout="row" fxLayoutGap="20px">

--- a/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.ts
+++ b/src/app/modules/financiero/terminal-pos/add-terminal-pos-dialog/add-terminal-pos-dialog.component.ts
@@ -2,6 +2,8 @@ import { Component, Inject, OnInit } from "@angular/core";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { ProveedorServicio } from "../../../personas/proveedor-servicio/proveedor-servicio.model";
+import { ProveedorServicioService } from "../../../personas/proveedor-servicio/proveedor-servicio.service";
 import { Moneda } from "../../moneda/moneda.model";
 import { MonedaService } from "../../moneda/moneda.service";
 import { TerminalPos } from "../terminal-pos.model";
@@ -26,14 +28,17 @@ export class AddTerminalPosDialogComponent implements OnInit {
   codigoControl = new FormControl(null, Validators.required);
   monedaControl = new FormControl(null, Validators.required);
   activoControl = new FormControl(true);
+  proveedorServicioControl = new FormControl(null);
   selectedTerminalPos: TerminalPos;
+  selectedProveedorServicio: ProveedorServicio = null;
   monedas: Moneda[] = [];
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: AddTerminalPosData,
     private matDialogRef: MatDialogRef<AddTerminalPosDialogComponent>,
     private terminalPosService: TerminalPosService,
-    private monedaService: MonedaService
+    private monedaService: MonedaService,
+    private proveedorServicioService: ProveedorServicioService
   ) {
     if (data?.terminalPos != null) {
       this.selectedTerminalPos = data.terminalPos;
@@ -45,6 +50,7 @@ export class AddTerminalPosDialogComponent implements OnInit {
       descripcion: this.descripcionControl,
       codigo: this.codigoControl,
       moneda: this.monedaControl,
+      proveedorServicio: this.proveedorServicioControl,
       activo: this.activoControl,
     });
 
@@ -67,6 +73,30 @@ export class AddTerminalPosDialogComponent implements OnInit {
     this.codigoControl.setValue(this.selectedTerminalPos.codigo);
     this.monedaControl.setValue(this.selectedTerminalPos.moneda?.id ?? null);
     this.activoControl.setValue(this.selectedTerminalPos.activo);
+    this.selectedProveedorServicio =
+      this.selectedTerminalPos.proveedorServicio ?? null;
+    this.proveedorServicioControl.setValue(
+      this.selectedProveedorServicio?.persona?.nombre ?? null
+    );
+  }
+
+  onBuscarProveedorServicio() {
+    if (!this.isEditting) return;
+    this.proveedorServicioService
+      .onSearchProveedorServicioPorTexto(null)
+      .pipe(untilDestroyed(this))
+      .subscribe((res) => {
+        if (res?.id != null) {
+          this.selectedProveedorServicio = res;
+          this.proveedorServicioControl.setValue(res.persona?.nombre ?? null);
+        }
+      });
+  }
+
+  onLimpiarProveedorServicio() {
+    if (!this.isEditting) return;
+    this.selectedProveedorServicio = null;
+    this.proveedorServicioControl.setValue(null);
   }
 
   onSave() {
@@ -85,6 +115,7 @@ export class AddTerminalPosDialogComponent implements OnInit {
 
     const input = terminalPos.toInput();
     input.monedaId = this.monedaControl.value ?? undefined;
+    input.proveedorServicioId = this.selectedProveedorServicio?.id ?? null;
 
     this.terminalPosService
       .onSave(input)

--- a/src/app/modules/financiero/terminal-pos/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/terminal-pos/graphql/graphql-query.ts
@@ -5,6 +5,12 @@ const terminalPosFields = `
   descripcion
   codigo
   moneda { id denominacion simbolo }
+  proveedorServicio {
+    id
+    nombreContacto
+    numeroContacto
+    persona { id nombre documento }
+  }
   activo
   creadoEn
   usuario {

--- a/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.html
+++ b/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.html
@@ -90,6 +90,15 @@
           <span *ngIf="!terminalPos.moneda" style="color: gray">-</span>
         </td>
       </ng-container>
+      <ng-container matColumnDef="proveedorServicio" style="width: 15%">
+        <th mat-header-cell *matHeaderCellDef style="width: 15%">Proveedor de servicio</th>
+        <td mat-cell *matCellDef="let terminalPos" style="width: 15%">
+          <span *ngIf="terminalPos.proveedorServicio">
+            {{ terminalPos.proveedorServicio.persona?.nombre }}
+          </span>
+          <span *ngIf="!terminalPos.proveedorServicio" style="color: gray">-</span>
+        </td>
+      </ng-container>
       <ng-container matColumnDef="creadoEn" style="width: 10%">
         <th mat-header-cell *matHeaderCellDef style="width: 10%;">Creado En</th>
         <td mat-cell *matCellDef="let terminalPos" style="width: 10%;"> 

--- a/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.ts
+++ b/src/app/modules/financiero/terminal-pos/list-terminal-pos/list-terminal-pos.component.ts
@@ -44,6 +44,7 @@ export class ListTerminalPosComponent implements OnInit, GenericList<TerminalPos
       'descripcion',
       'codigo',
       'moneda',
+      'proveedorServicio',
       'creadoEn',
       'creadoPor',
       'activo',

--- a/src/app/modules/financiero/terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component.html
+++ b/src/app/modules/financiero/terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component.html
@@ -7,6 +7,9 @@
       <div fxFlex="30%" style="height: 250px">
         <app-boton nombre="Ventas con tarjeta" icon="tune" [iconSize]="4" (clickEvent)="onListVentaTarjeta()"></app-boton>
       </div>
+      <div fxFlex="30%" style="height: 250px">
+        <app-boton nombre="Proveedores de servicios" icon="support_agent" [iconSize]="4" (clickEvent)="onListProveedorServicio()"></app-boton>
+      </div>
       <div fxFlex="30%" style="height: 250px" *ngIf="
                 mainService.usuarioActual?.roles.includes(
                   ROLES.ADMIN

--- a/src/app/modules/financiero/terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component.ts
+++ b/src/app/modules/financiero/terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component.ts
@@ -7,6 +7,7 @@ import { ListVentaTarjetaComponent } from "../../venta-tarjeta/list-venta-tarjet
 import { ROLES } from "../../../personas/roles/roles.enum";
 import { ConfiguracionVentaTarjetaDialogComponent } from "../../venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta-dialog.component";
 import { MatDialog } from "@angular/material/dialog";
+import { ListProveedorServicioComponent } from "../../../personas/proveedor-servicio/list-proveedor-servicio/list-proveedor-servicio.component";
 
 @Component({
   selector: 'app-terminal-pos-dashboard',
@@ -32,6 +33,10 @@ export class TerminalPosDashboard  implements OnInit{
 
   onListVentaTarjeta() {
     this.tabService.addTab(new Tab(ListVentaTarjetaComponent, 'Lista de ventas con tarjeta', null, TerminalPosDashboard));
+  }
+
+  onListProveedorServicio() {
+    this.tabService.addTab(new Tab(ListProveedorServicioComponent, 'Proveedores de servicios', null, TerminalPosDashboard));
   }
 
   onAbrirConfiguracion() {

--- a/src/app/modules/financiero/terminal-pos/terminal-pos.model.ts
+++ b/src/app/modules/financiero/terminal-pos/terminal-pos.model.ts
@@ -1,4 +1,5 @@
 import { dateToString } from "../../../commons/core/utils/dateUtils";
+import { ProveedorServicio } from "../../personas/proveedor-servicio/proveedor-servicio.model";
 import { Usuario } from "../../personas/usuarios/usuario.model";
 import { Moneda } from "../moneda/moneda.model";
 
@@ -8,6 +9,7 @@ export class TerminalPos {
   codigo: string;
   cuentaBancariaId: number;
   moneda: Moneda;
+  proveedorServicio: ProveedorServicio;
   activo: boolean;
   creadoEn: Date;
   usuario: Usuario;
@@ -19,6 +21,7 @@ export class TerminalPos {
     input.codigo = this?.codigo;
     input.cuentaBancariaId = this?.cuentaBancariaId;
     input.monedaId = this?.moneda?.id;
+    input.proveedorServicioId = this?.proveedorServicio?.id;
     input.activo = this?.activo;
     input.creadoEn = dateToString(this?.creadoEn);
     input.usuarioId = this?.usuario?.id;
@@ -32,6 +35,7 @@ export class TerminalPosInput {
   codigo?: string;
   cuentaBancariaId?: number;
   monedaId?: number;
+  proveedorServicioId?: number;
   activo?: boolean;
   creadoEn?: string;
   usuarioId?: number;

--- a/src/app/modules/personas/personas.module.ts
+++ b/src/app/modules/personas/personas.module.ts
@@ -26,6 +26,8 @@ import { AdicionarProveedorDialogComponent } from './proveedor/adicionar-proveed
 import { ClienteDashboardComponent } from './clientes/cliente-dashboard/cliente-dashboard.component';
 import { ListClientesComponent } from './clientes/list-clientes/list-clientes.component';
 import { ProductoModule } from '../productos/productos.module';
+import { EditProveedorServicioComponent } from './proveedor-servicio/edit-proveedor-servicio/edit-proveedor-servicio.component';
+import { ListProveedorServicioComponent } from './proveedor-servicio/list-proveedor-servicio/list-proveedor-servicio.component';
 
 
 @NgModule({
@@ -48,7 +50,9 @@ import { ProductoModule } from '../productos/productos.module';
     AddClienteDialogComponent,
     AdicionarProveedorDialogComponent,
     ClienteDashboardComponent,
-    ListClientesComponent
+    ListClientesComponent,
+    EditProveedorServicioComponent,
+    ListProveedorServicioComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/personas/proveedor-servicio/edit-proveedor-servicio/edit-proveedor-servicio.component.html
+++ b/src/app/modules/personas/proveedor-servicio/edit-proveedor-servicio/edit-proveedor-servicio.component.html
@@ -1,0 +1,244 @@
+<div class="dialog-container">
+  <div class="dialog-header background-gradient">
+    <div class="dialog-title titulo-center">
+      {{ dialogTitleComputed }}
+    </div>
+  </div>
+
+  <div class="dialog-content">
+    <div class="search-section" *ngIf="!isEditingModeComputed">
+      <div class="section-header">
+        <span>Buscar Persona Existente</span>
+      </div>
+      <div class="search-content">
+        <div class="search-field-wrapper">
+          <frc-searchable-select
+            titulo="Buscar por nombre o documento"
+            [list]="personaList"
+            [compareFields]="['nombre', 'documento']"
+            [currentData]="selectedPersona"
+            (selectionChanged)="onPersonaSelectionChange($event)"
+            (inputChanged)="onPersonaInputChange($event)"
+            [isFilter]="false"
+            [initialValue]="false"
+          >
+            <ng-template let-item>
+              {{ item.id }} - {{ item.nombre }} - {{ item.documento }}
+            </ng-template>
+          </frc-searchable-select>
+        </div>
+        <button
+          mat-icon-button
+          color="primary"
+          [disabled]="!hasPersonaSelectedComputed"
+          (click)="onClearPersonaSelection()"
+          class="clear-button"
+        >
+          <mat-icon>clear</mat-icon>
+        </button>
+      </div>
+      <div class="search-loading" *ngIf="isSearching">
+        <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+        <span>Buscando personas...</span>
+      </div>
+    </div>
+
+    <div class="form-section">
+      <div class="section-header">
+        <span>{{
+          hasPersonaSelectedComputed
+            ? "Datos de la Persona"
+            : "Datos de Nueva Persona"
+        }}</span>
+      </div>
+
+      <form [formGroup]="proveedorServicioFormGroup" class="proveedor-form">
+        <div class="form-row">
+          <mat-form-field appearance="outline" class="form-field full-width">
+            <mat-label>Nombre Completo / Razón Social *</mat-label>
+            <input
+              matInput
+              #nombreInput
+              formControlName="nombre"
+              placeholder="Ingrese el nombre completo"
+              (keydown)="onNombreEnter($event)"
+              [readonly]="hasPersonaSelectedComputed && !isEditingModeComputed"
+            />
+            <mat-icon
+              matSuffix
+              [ngClass]="{
+                'field-valid-icon': nombreValidComputed,
+                'field-invalid-icon': nombreInvalidComputed
+              }"
+            >
+              {{ nombreIconComputed }}
+            </mat-icon>
+            <mat-error *ngIf="nombreInvalidComputed">
+              {{ nombreErrorMessageComputed }}
+            </mat-error>
+          </mat-form-field>
+        </div>
+
+        <div class="form-row">
+          <mat-form-field appearance="outline" class="form-field full-width">
+            <mat-label>Nombre Comercial / Apodo</mat-label>
+            <input
+              matInput
+              #apodoInput
+              formControlName="apodo"
+              placeholder="Ingrese el apodo (opcional)"
+              (keydown)="onApodoEnter($event)"
+              [readonly]="hasPersonaSelectedComputed && !isEditingModeComputed"
+            />
+            <mat-icon matSuffix>person_outline</mat-icon>
+            <mat-error *ngIf="apodoInvalidComputed">
+              {{ apodoErrorMessageComputed }}
+            </mat-error>
+          </mat-form-field>
+        </div>
+
+        <div class="form-row">
+          <mat-form-field appearance="outline" class="form-field full-width">
+            <mat-label>CI/RUC (Sin dígito verificador) *</mat-label>
+            <input
+              matInput
+              #documentoInput
+              formControlName="documento"
+              placeholder="Ingrese CI o RUC sin dígito verificador"
+              (keydown)="onDocumentoEnter($event)"
+              [readonly]="hasPersonaSelectedComputed && !isEditingModeComputed"
+            />
+            <mat-icon
+              matSuffix
+              [ngClass]="{
+                'field-valid-icon': documentoValidComputed,
+                'field-invalid-icon': documentoInvalidComputed
+              }"
+            >
+              {{ documentoIconComputed }}
+            </mat-icon>
+            <mat-error *ngIf="documentoInvalidComputed">
+              {{ documentoErrorMessageComputed }}
+            </mat-error>
+          </mat-form-field>
+        </div>
+
+        <div
+          class="verification-status"
+          *ngIf="documentVerificationState !== 'none'"
+        >
+          <div
+            class="status-content"
+            [ngClass]="{
+              'status-checking': documentVerificationState === 'checking',
+              'status-found': documentVerificationState === 'found',
+              'status-available': documentVerificationState === 'available',
+              'status-warning': showDocumentWarning
+            }"
+          >
+            <mat-icon>
+              {{
+                documentVerificationState === "checking"
+                  ? "search"
+                  : documentVerificationState === "found"
+                    ? "person"
+                    : documentVerificationState === "available"
+                      ? "check_circle"
+                      : "info"
+              }}
+            </mat-icon>
+            <span>{{ documentVerificationMessage }}</span>
+          </div>
+          <mat-progress-bar
+            *ngIf="documentVerificationState === 'checking'"
+            mode="indeterminate"
+          ></mat-progress-bar>
+        </div>
+
+        <div class="form-row">
+          <mat-form-field appearance="outline" class="form-field full-width">
+            <mat-label>Teléfono</mat-label>
+            <input
+              matInput
+              #telefonoInput
+              formControlName="telefono"
+              placeholder="Ingrese número de teléfono"
+              (keydown)="onTelefonoEnter($event)"
+            />
+            <mat-icon matSuffix>phone</mat-icon>
+            <mat-error *ngIf="telefonoInvalidComputed">
+              {{ telefonoErrorMessageComputed }}
+            </mat-error>
+          </mat-form-field>
+        </div>
+
+        <div class="section-divider"></div>
+        <div class="section-header">
+          <span>Contacto de Soporte</span>
+        </div>
+
+        <div class="form-row">
+          <mat-form-field appearance="outline" class="form-field full-width">
+            <mat-label>Nombre del contacto</mat-label>
+            <input
+              matInput
+              #nombreContactoInput
+              formControlName="nombreContacto"
+              placeholder="A quién reclamar cuando falla una terminal"
+              (keydown)="onNombreContactoEnter($event)"
+            />
+            <mat-icon matSuffix>support_agent</mat-icon>
+          </mat-form-field>
+        </div>
+
+        <div class="form-row">
+          <mat-form-field appearance="outline" class="form-field full-width">
+            <mat-label>Número del contacto</mat-label>
+            <input
+              matInput
+              #numeroContactoInput
+              formControlName="numeroContacto"
+              placeholder="Teléfono de soporte"
+              (keydown)="onNumeroContactoEnter($event)"
+            />
+            <mat-icon matSuffix>call</mat-icon>
+          </mat-form-field>
+        </div>
+      </form>
+    </div>
+
+    <div class="loading-overlay" *ngIf="isSaving">
+      <mat-progress-spinner
+        diameter="60"
+        mode="indeterminate"
+      ></mat-progress-spinner>
+      <span>{{
+        isEditingModeComputed
+          ? "Actualizando proveedor de servicio..."
+          : "Creando proveedor de servicio..."
+      }}</span>
+    </div>
+  </div>
+
+  <div class="dialog-actions">
+    <button
+      mat-stroked-button
+      color="primary"
+      (click)="onCancelar()"
+      [disabled]="isSaving"
+    >
+      <mat-icon>close</mat-icon>
+      Cancelar
+    </button>
+    <button
+      mat-raised-button
+      #guardarButton
+      color="accent"
+      [disabled]="!canSaveComputed"
+      (click)="onGuardar()"
+      (keydown)="onGuardarButtonEnter($event)"
+    >
+      {{ isEditingModeComputed ? "Actualizar" : "Crear" }}
+    </button>
+  </div>
+</div>

--- a/src/app/modules/personas/proveedor-servicio/edit-proveedor-servicio/edit-proveedor-servicio.component.scss
+++ b/src/app/modules/personas/proveedor-servicio/edit-proveedor-servicio/edit-proveedor-servicio.component.scss
@@ -1,0 +1,389 @@
+// Dialog Container
+.dialog-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+.titulo-center {
+  text-align: center;
+  font-weight: 500;
+}
+
+// Dialog Header
+.dialog-header {
+  padding: 24px 32px 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+
+  .dialog-title {
+    font-size: 1.8rem;
+    font-weight: 500;
+    color: #ffffff;
+    margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+}
+
+// Dialog Content
+.dialog-content {
+  flex: 1;
+  padding: 10px;
+  overflow-y: auto;
+  position: relative;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 4px;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.5);
+    }
+  }
+}
+
+// Search Section
+.search-section {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+    color: rgba(255, 255, 255, 0.9);
+    font-weight: 500;
+    font-size: 1.5rem !important;
+
+    mat-icon {
+      color: #2196F3;
+      font-size: 1.3rem;
+    }
+  }
+
+  .search-content {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: nowrap;
+
+    .search-field-wrapper {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .clear-button {
+      flex-shrink: 0;
+      height: 56px;
+      width: 56px;
+      white-space: nowrap;
+      margin-top: 0;
+    }
+  }
+
+  .search-loading {
+    margin-top: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.9rem;
+  }
+}
+
+// Form Section
+.form-section {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 20px;
+    color: rgba(255, 255, 255, 0.9);
+    font-weight: 500;
+    font-size: 1.5rem;
+
+    mat-icon {
+      color: #4CAF50;
+      font-size: 1.3rem;
+    }
+  }
+}
+
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.2) 50%, transparent 100%);
+  margin: 24px 0 20px;
+}
+
+.proveedor-form {
+  .form-row {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 16px;
+    align-items: flex-start;
+
+    &.credit-row {
+      align-items: center;
+      padding: 16px;
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .form-field {
+      &.full-width {
+        width: 100%;
+      }
+    }
+  }
+
+  .credit-toggle {
+    display: flex;
+    align-items: center;
+    margin-right: 24px;
+
+    .toggle-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 500;
+      color: rgba(255, 255, 255, 0.9);
+
+      mat-icon {
+        font-size: 1.2rem;
+        transform: scale(1.7);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+  }
+
+  .credit-terms {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.field-valid-icon {
+  color: #4CAF50 !important;
+}
+
+.field-invalid-icon {
+  color: #f44336 !important;
+}
+
+.verification-status {
+  margin: 8px 0 16px;
+  border-radius: 8px;
+  overflow: hidden;
+
+  .status-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    font-size: 1.1rem;
+    font-weight: 500;
+    align-self: flex-end;
+
+    mat-icon {
+      font-size: 1.8rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    &.status-checking {
+      background: rgba(33, 150, 243, 0.15);
+      color: #2196F3;
+      border: 1px solid rgba(33, 150, 243, 0.3);
+    }
+
+    &.status-found {
+      background: rgba(76, 175, 80, 0.15);
+      color: #4CAF50;
+      border: 1px solid rgba(76, 175, 80, 0.3);
+    }
+
+    &.status-available {
+      background: rgba(76, 175, 80, 0.15);
+      color: #4CAF50;
+      border: 1px solid rgba(76, 175, 80, 0.3);
+    }
+
+    &.status-warning {
+      background: rgba(255, 193, 7, 0.15);
+      color: #FFC107;
+      border: 1px solid rgba(255, 193, 7, 0.3);
+    }
+
+    span {
+      align-self: flex-end;
+    }
+  }
+
+  mat-progress-bar {
+    height: 3px;
+  }
+}
+
+.loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 500;
+  z-index: 1000;
+  backdrop-filter: blur(2px);
+}
+
+.dialog-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  padding: 20px 32px 24px;
+  background: rgba(255, 255, 255, 0.02);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+
+  button {
+    min-width: 120px;
+    height: 44px;
+    font-weight: 500;
+    border-radius: 8px;
+    text-transform: none;
+
+    &:disabled {
+      opacity: 0.5;
+    }
+
+    mat-icon {
+      margin-right: 8px;
+      font-size: 1.5rem;
+      height: 12px;
+      width: 12px;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .dialog-header {
+    padding: 20px 24px 16px;
+
+    .dialog-title {
+      font-size: 1.5rem;
+    }
+  }
+
+  .dialog-content {
+    padding: 20px 24px;
+  }
+
+  .search-section,
+  .form-section {
+    padding: 16px;
+  }
+
+  .search-content {
+    flex-direction: column;
+    align-items: stretch;
+
+    button {
+      height: 48px;
+    }
+  }
+
+  .form-row {
+    &.credit-row {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 16px;
+
+      .credit-toggle {
+        margin-right: 0;
+      }
+    }
+  }
+
+  .dialog-actions {
+    padding: 16px 24px 20px;
+    flex-direction: column-reverse;
+
+    button {
+      width: 100%;
+    }
+  }
+}
+
+::ng-deep {
+  .mat-mdc-form-field {
+    .mat-mdc-text-field-wrapper {
+      background-color: rgba(255, 255, 255, 0.08);
+
+      .mat-mdc-form-field-flex .mat-mdc-floating-label {
+        color: rgba(255, 255, 255, 0.7);
+      }
+    }
+
+    &.mat-focused .mat-mdc-text-field-wrapper {
+      background-color: rgba(255, 255, 255, 0.12);
+    }
+
+    .mat-mdc-form-field-input-control {
+      color: rgba(255, 255, 255, 0.9);
+    }
+  }
+
+  .mat-mdc-slide-toggle {
+    .mat-mdc-slide-toggle-track {
+      background-color: rgba(255, 255, 255, 0.3);
+    }
+
+    &.mat-checked .mat-mdc-slide-toggle-track {
+      background-color: rgba(76, 175, 80, 0.5);
+    }
+
+    .mdc-switch {
+      margin-right: 3px;
+    }
+  }
+
+  .mat-mdc-progress-bar .mdc-linear-progress__buffer-bar {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
+  .mat-mdc-progress-spinner circle {
+    stroke: #4CAF50;
+  }
+}

--- a/src/app/modules/personas/proveedor-servicio/edit-proveedor-servicio/edit-proveedor-servicio.component.ts
+++ b/src/app/modules/personas/proveedor-servicio/edit-proveedor-servicio/edit-proveedor-servicio.component.ts
@@ -1,0 +1,599 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Inject,
+  OnInit,
+  Optional,
+  ViewChild,
+} from "@angular/core";
+import { FormControl, FormGroup, Validators } from "@angular/forms";
+import { MatButton } from "@angular/material/button";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { debounceTime, distinctUntilChanged } from "rxjs/operators";
+
+import { MainService } from "../../../../main.service";
+import { NotificacionSnackbarService } from "../../../../notificacion-snackbar.service";
+import { DialogosService } from "../../../../shared/components/dialogos/dialogos.service";
+import { PersonaInput } from "../../persona/persona/persona-input.model";
+import { Persona } from "../../persona/persona.model";
+import { PersonaService } from "../../persona/persona.service";
+import {
+  ProveedorServicio,
+  ProveedorServicioInput,
+} from "../proveedor-servicio.model";
+import { ProveedorServicioService } from "../proveedor-servicio.service";
+
+export interface EditProveedorServicioData {
+  proveedorServicio?: ProveedorServicio;
+  isEditing?: boolean;
+}
+
+export interface EditProveedorServicioResult {
+  saved?: boolean;
+  proveedorServicio?: ProveedorServicio;
+}
+
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: "app-edit-proveedor-servicio",
+  templateUrl: "./edit-proveedor-servicio.component.html",
+  styleUrls: ["./edit-proveedor-servicio.component.scss"],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EditProveedorServicioComponent implements OnInit {
+  @ViewChild("nombreInput") nombreInput: ElementRef<HTMLInputElement>;
+  @ViewChild("apodoInput") apodoInput: ElementRef<HTMLInputElement>;
+  @ViewChild("documentoInput") documentoInput: ElementRef<HTMLInputElement>;
+  @ViewChild("telefonoInput") telefonoInput: ElementRef<HTMLInputElement>;
+  @ViewChild("nombreContactoInput")
+  nombreContactoInput: ElementRef<HTMLInputElement>;
+  @ViewChild("numeroContactoInput")
+  numeroContactoInput: ElementRef<HTMLInputElement>;
+  @ViewChild("guardarButton") guardarButton: MatButton;
+
+  proveedorServicioFormGroup = new FormGroup({
+    nombre: new FormControl("", [Validators.required, Validators.minLength(2)]),
+    apodo: new FormControl(""),
+    documento: new FormControl("", [
+      Validators.required,
+      Validators.minLength(6),
+    ]),
+    telefono: new FormControl("", [Validators.minLength(9)]),
+    nombreContacto: new FormControl(""),
+    numeroContacto: new FormControl(""),
+  });
+
+  personaList: Persona[] = [];
+  selectedPersona: Persona | null = null;
+  selectedProveedorServicio: ProveedorServicio | null = null;
+
+  isLoading = false;
+  isSearching = false;
+  isSaving = false;
+
+  dialogTitleComputed = "";
+  isEditingModeComputed = false;
+  canSaveComputed = false;
+  isFormValidComputed = false;
+  hasPersonaSelectedComputed = false;
+  personaDisplayNameComputed = "";
+
+  nombreValidComputed = false;
+  nombreInvalidComputed = false;
+  nombreErrorMessageComputed = "";
+  nombreIconComputed = "person";
+
+  apodoInvalidComputed = false;
+  apodoErrorMessageComputed = "";
+
+  documentoValidComputed = false;
+  documentoInvalidComputed = false;
+  documentoErrorMessageComputed = "";
+  documentoIconComputed = "badge";
+
+  telefonoInvalidComputed = false;
+  telefonoErrorMessageComputed = "";
+
+  documentVerificationState: "none" | "checking" | "found" | "available" =
+    "none";
+  documentVerificationMessage = "";
+  showDocumentWarning = false;
+  foundPersona: Persona | null = null;
+
+  constructor(
+    @Optional()
+    @Inject(MAT_DIALOG_DATA)
+    public data: EditProveedorServicioData | null,
+    @Optional()
+    private matDialogRef: MatDialogRef<EditProveedorServicioComponent>,
+    private personaService: PersonaService,
+    private proveedorServicioService: ProveedorServicioService,
+    private dialogosService: DialogosService,
+    private notificacionService: NotificacionSnackbarService,
+    private mainService: MainService,
+    private cdr: ChangeDetectorRef
+  ) {
+    if (data?.proveedorServicio) {
+      this.selectedProveedorServicio = data.proveedorServicio;
+      this.selectedPersona = data.proveedorServicio.persona;
+    }
+  }
+
+  ngOnInit(): void {
+    this.setupFormSubscriptions();
+    this.updateComputedProperties();
+    if (this.data?.isEditing && this.selectedProveedorServicio?.id) {
+      this.proveedorServicioService
+        .onGetPorId(this.selectedProveedorServicio.id)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: (full) => {
+            if (full) {
+              this.selectedProveedorServicio = full;
+              this.selectedPersona = full.persona ?? this.selectedPersona;
+            }
+            this.loadExistingData();
+          },
+          error: () => this.loadExistingData(),
+        });
+    } else {
+      this.loadExistingData();
+    }
+  }
+
+  private setupFormSubscriptions(): void {
+    this.proveedorServicioFormGroup
+      .get("documento")
+      ?.valueChanges.pipe(
+        debounceTime(500),
+        distinctUntilChanged(),
+        untilDestroyed(this)
+      )
+      .subscribe((documento: string) => {
+        if (
+          documento &&
+          typeof documento === "string" &&
+          documento.trim().length >= 6
+        ) {
+          this.onDocumentVerification(documento.trim());
+        } else {
+          this.clearDocumentVerification();
+        }
+      });
+
+    this.proveedorServicioFormGroup.valueChanges
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.updateComputedProperties();
+      });
+  }
+
+  private loadExistingData(): void {
+    if (!this.selectedProveedorServicio || !this.selectedPersona) return;
+    this.proveedorServicioFormGroup.patchValue({
+      nombre: this.selectedPersona.nombre,
+      apodo: this.selectedPersona.apodo || "",
+      documento: this.selectedPersona.documento,
+      telefono: this.selectedPersona.telefono || "",
+      nombreContacto: this.selectedProveedorServicio.nombreContacto || "",
+      numeroContacto: this.selectedProveedorServicio.numeroContacto || "",
+    });
+    this.updateComputedProperties();
+  }
+
+  onPersonaInputChange(searchText: string): void {
+    if (!searchText || searchText.trim().length < 2) {
+      this.personaList = [];
+      return;
+    }
+    this.isSearching = true;
+    this.cdr.markForCheck();
+    this.personaService
+      .onSearchSilent(searchText.trim(), true)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (personas) => {
+          this.personaList = personas || [];
+          this.isSearching = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.personaList = [];
+          this.isSearching = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  onPersonaSelectionChange(persona: Persona): void {
+    if (persona?.id) {
+      this.onSelectPersona(persona);
+    }
+  }
+
+  onSelectPersona(persona: Persona): void {
+    this.selectedPersona = persona;
+    this.proveedorServicioFormGroup.patchValue({
+      nombre: persona.nombre,
+      apodo: persona.apodo || "",
+      documento: persona.documento,
+      telefono: persona.telefono || "",
+    });
+    this.checkExistingProveedorServicio(persona.id);
+    this.clearDocumentVerification();
+    this.updateComputedProperties();
+    this.notificacionService.openSucess("Persona seleccionada exitosamente");
+  }
+
+  private checkExistingProveedorServicio(personaId: number): void {
+    this.proveedorServicioService
+      .onGetPorPersona(personaId)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (proveedorServicio) => {
+          if (proveedorServicio?.id) {
+            this.dialogosService
+              .confirm(
+                "Proveedor de servicio existente",
+                "Esta persona ya está registrada como proveedor de servicio. ¿Desea cargar los datos existentes?"
+              )
+              .subscribe((confirmed) => {
+                if (confirmed) {
+                  this.selectedProveedorServicio = proveedorServicio;
+                  this.proveedorServicioFormGroup.patchValue({
+                    nombreContacto: proveedorServicio.nombreContacto || "",
+                    numeroContacto: proveedorServicio.numeroContacto || "",
+                  });
+                  this.updateComputedProperties();
+                }
+              });
+          }
+        },
+        error: () => {},
+      });
+  }
+
+  onClearPersonaSelection(): void {
+    this.selectedPersona = null;
+    this.selectedProveedorServicio = null;
+    this.personaList = [];
+    this.proveedorServicioFormGroup.patchValue({
+      nombre: "",
+      apodo: "",
+      documento: "",
+      telefono: "",
+    });
+    this.clearDocumentVerification();
+    this.updateComputedProperties();
+  }
+
+  private onDocumentVerification(documento: string): void {
+    if (!documento || documento.length < 6) {
+      this.clearDocumentVerification();
+      return;
+    }
+    this.documentVerificationState = "checking";
+    this.documentVerificationMessage = "Verificando documento...";
+    this.cdr.markForCheck();
+    this.personaService
+      .onGetPorDocumento(documento.trim())
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (persona) => {
+          if (persona?.id) {
+            this.foundPersona = persona;
+            this.documentVerificationState = "found";
+            this.documentVerificationMessage =
+              "Persona encontrada. ¿Desea usar los datos existentes?";
+            this.showDocumentWarning = false;
+            this.showUseExistingPersonaDialog(persona);
+          } else {
+            this.foundPersona = null;
+            this.documentVerificationState = "available";
+            this.documentVerificationMessage =
+              "Documento disponible para nuevo registro";
+            this.showDocumentWarning = false;
+          }
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.foundPersona = null;
+          this.documentVerificationState = "available";
+          this.documentVerificationMessage =
+            "Documento disponible para nuevo registro";
+          this.showDocumentWarning = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  private showUseExistingPersonaDialog(persona: Persona): void {
+    this.dialogosService
+      .confirm(
+        "Persona Existente",
+        `Ya existe una persona registrada con este documento: ${persona.nombre}. ¿Desea usar los datos existentes?`
+      )
+      .subscribe((confirmed) => {
+        if (confirmed) {
+          this.onSelectPersona(persona);
+        } else {
+          this.proveedorServicioFormGroup.patchValue({ documento: "" });
+          this.clearDocumentVerification();
+        }
+      });
+  }
+
+  private clearDocumentVerification(): void {
+    this.documentVerificationState = "none";
+    this.documentVerificationMessage = "";
+    this.showDocumentWarning = false;
+    this.foundPersona = null;
+  }
+
+  onGuardar(): void {
+    if (!this.canSaveComputed || this.isSaving) return;
+    const formValue = this.proveedorServicioFormGroup.value;
+    if (!formValue.nombre?.trim() || !formValue.documento?.trim()) {
+      this.notificacionService.openWarn("Complete todos los campos requeridos");
+      return;
+    }
+    this.isSaving = true;
+    this.updateComputedProperties();
+    if (this.selectedPersona) {
+      this.updatePersonaThenProveedorServicio(this.selectedPersona, formValue);
+    } else {
+      this.createPersonaThenProveedorServicio(formValue);
+    }
+  }
+
+  private updatePersonaThenProveedorServicio(
+    persona: Persona,
+    formValue: any
+  ): void {
+    const personaModel = Object.assign(new Persona(), persona);
+    const personaInput = personaModel.toInput();
+
+    personaInput.nombre = formValue.nombre?.trim().toUpperCase();
+    personaInput.apodo = formValue.apodo?.trim().toUpperCase() || "";
+    personaInput.documento = formValue.documento?.trim();
+    personaInput.telefono = formValue.telefono?.trim() || "";
+
+    this.personaService
+      .onSavePersona(personaInput)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (updatedPersona) => {
+          if (updatedPersona?.id) {
+            this.selectedPersona = updatedPersona;
+            this.createOrUpdateProveedorServicio(updatedPersona);
+          } else {
+            this.onSaveError("Error al actualizar la persona");
+          }
+        },
+        error: () => this.onSaveError("Error al actualizar la persona"),
+      });
+  }
+
+  private createPersonaThenProveedorServicio(formValue: any): void {
+    const personaInput = new PersonaInput();
+    personaInput.nombre = formValue.nombre.trim().toUpperCase();
+    personaInput.apodo = formValue.apodo?.trim().toUpperCase() || "";
+    personaInput.documento = formValue.documento.trim();
+    personaInput.telefono = formValue.telefono?.trim() || "";
+    this.personaService
+      .onSavePersona(personaInput)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (persona) => {
+          if (persona?.id) {
+            this.selectedPersona = persona;
+            this.createOrUpdateProveedorServicio(persona);
+          } else {
+            this.onSaveError("Error al crear la persona");
+          }
+        },
+        error: () => this.onSaveError("Error al crear la persona"),
+      });
+  }
+
+  private createOrUpdateProveedorServicio(persona: Persona): void {
+    const formValue = this.proveedorServicioFormGroup.value;
+    const input = new ProveedorServicioInput();
+    if (this.selectedProveedorServicio?.id) {
+      input.id = this.selectedProveedorServicio.id;
+      input.usuarioId = this.selectedProveedorServicio.usuario?.id;
+    } else {
+      input.usuarioId = this.mainService.usuarioActual?.id;
+    }
+    input.personaId = persona.id;
+    input.nombreContacto =
+      formValue.nombreContacto?.trim().toUpperCase() || null;
+    input.numeroContacto = formValue.numeroContacto?.trim() || null;
+
+    this.proveedorServicioService
+      .onSave(input)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (proveedorServicio) => {
+          if (proveedorServicio?.id) {
+            const isUpdate = !!this.selectedProveedorServicio?.id;
+            this.notificacionService.openSucess(
+              isUpdate
+                ? "Proveedor de servicio actualizado exitosamente"
+                : "Proveedor de servicio creado exitosamente"
+            );
+            const result: EditProveedorServicioResult = {
+              saved: true,
+              proveedorServicio,
+            };
+            if (this.matDialogRef) {
+              this.matDialogRef.close(result);
+            }
+          } else {
+            this.onSaveError("Error al guardar el proveedor de servicio");
+          }
+        },
+        error: () =>
+          this.onSaveError("Error al guardar el proveedor de servicio"),
+      });
+  }
+
+  private onSaveError(mensaje: string): void {
+    this.isSaving = false;
+    this.updateComputedProperties();
+    this.notificacionService.openWarn(mensaje);
+  }
+
+  onCancelar(): void {
+    const result: EditProveedorServicioResult = { saved: false };
+    if (this.matDialogRef) {
+      this.matDialogRef.close(result);
+    }
+  }
+
+  focusApodo(): void {
+    this.apodoInput?.nativeElement?.focus();
+  }
+  focusDocumento(): void {
+    this.documentoInput?.nativeElement?.focus();
+  }
+  focusTelefono(): void {
+    this.telefonoInput?.nativeElement?.focus();
+  }
+  focusNombreContacto(): void {
+    this.nombreContactoInput?.nativeElement?.focus();
+  }
+  focusNumeroContacto(): void {
+    this.numeroContactoInput?.nativeElement?.focus();
+  }
+  focusGuardarButton(): void {
+    this.guardarButton?._elementRef?.nativeElement?.focus();
+  }
+
+  onNombreEnter(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (this.proveedorServicioFormGroup.get("nombre")?.valid) {
+        this.focusApodo();
+      } else {
+        this.proveedorServicioFormGroup.get("nombre")?.markAsTouched();
+        this.updateComputedProperties();
+      }
+    }
+  }
+  onApodoEnter(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      this.focusDocumento();
+    }
+  }
+  onDocumentoEnter(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (this.proveedorServicioFormGroup.get("documento")?.valid) {
+        this.focusTelefono();
+      } else {
+        this.proveedorServicioFormGroup.get("documento")?.markAsTouched();
+        this.updateComputedProperties();
+      }
+    }
+  }
+  onTelefonoEnter(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      this.focusNombreContacto();
+    }
+  }
+  onNombreContactoEnter(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      this.focusNumeroContacto();
+    }
+  }
+  onNumeroContactoEnter(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (this.canSaveComputed) {
+        this.onGuardar();
+      } else {
+        this.focusGuardarButton();
+      }
+    }
+  }
+  onGuardarButtonEnter(event: KeyboardEvent): void {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      this.onGuardar();
+    }
+  }
+
+  private updateComputedProperties(): void {
+    this.dialogTitleComputed = this.selectedProveedorServicio?.id
+      ? "Editar Proveedor de Servicio"
+      : "Nuevo Proveedor de Servicio";
+    this.isEditingModeComputed =
+      !!this.data?.isEditing && !!this.selectedProveedorServicio?.id;
+    this.isFormValidComputed = this.proveedorServicioFormGroup.valid;
+    this.canSaveComputed =
+      this.isFormValidComputed && !this.isSaving && !this.isLoading;
+    this.hasPersonaSelectedComputed = !!this.selectedPersona;
+    this.personaDisplayNameComputed = this.selectedPersona
+      ? `${this.selectedPersona.nombre} - ${this.selectedPersona.documento}`
+      : "";
+    this.updateFieldComputedProperties("nombre");
+    this.updateFieldComputedProperties("apodo");
+    this.updateFieldComputedProperties("documento");
+    this.updateFieldComputedProperties("telefono");
+    this.cdr.markForCheck();
+  }
+
+  private updateFieldComputedProperties(fieldName: string): void {
+    const control = this.proveedorServicioFormGroup.get(fieldName);
+    const isValid = !!(control && control.valid && control.touched);
+    const isInvalid = !!(control && control.invalid && control.touched);
+    const errorMessage = this.getFieldErrorMessage(fieldName);
+    switch (fieldName) {
+      case "nombre":
+        this.nombreValidComputed = isValid;
+        this.nombreInvalidComputed = isInvalid;
+        this.nombreErrorMessageComputed = errorMessage;
+        this.nombreIconComputed = isValid
+          ? "check_circle"
+          : isInvalid
+            ? "error"
+            : "person";
+        break;
+      case "apodo":
+        this.apodoInvalidComputed = isInvalid;
+        this.apodoErrorMessageComputed = errorMessage;
+        break;
+      case "documento":
+        this.documentoValidComputed = isValid;
+        this.documentoInvalidComputed = isInvalid;
+        this.documentoErrorMessageComputed = errorMessage;
+        this.documentoIconComputed = isValid
+          ? "check_circle"
+          : isInvalid
+            ? "error"
+            : "badge";
+        break;
+      case "telefono":
+        this.telefonoInvalidComputed = isInvalid;
+        this.telefonoErrorMessageComputed = errorMessage;
+        break;
+    }
+  }
+
+  getFieldErrorMessage(fieldName: string): string {
+    const control = this.proveedorServicioFormGroup.get(fieldName);
+    if (!control?.errors || !control.touched) return "";
+    const errors = control.errors;
+    if (errors["required"]) return `${fieldName} es requerido`;
+    if (errors["minlength"])
+      return `${fieldName} debe tener al menos ${errors["minlength"].requiredLength} caracteres`;
+    return "Campo inválido";
+  }
+}

--- a/src/app/modules/personas/proveedor-servicio/graphql/deleteProveedorServicio.ts
+++ b/src/app/modules/personas/proveedor-servicio/graphql/deleteProveedorServicio.ts
@@ -1,0 +1,14 @@
+import { Injectable } from "@angular/core";
+import { Mutation } from "apollo-angular";
+import { deleteProveedorServicioQuery } from "./graphql-query";
+
+export interface Response {
+  deleteProveedorServicio: boolean;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class DeleteProveedorServicioGQL extends Mutation<Response> {
+  document = deleteProveedorServicioQuery;
+}

--- a/src/app/modules/personas/proveedor-servicio/graphql/graphql-query.ts
+++ b/src/app/modules/personas/proveedor-servicio/graphql/graphql-query.ts
@@ -1,0 +1,93 @@
+import gql from "graphql-tag";
+
+export const proveedorServicioQuery = gql`
+  query ($id: ID!) {
+    data: proveedorServicio(id: $id) {
+      id
+      nombreContacto
+      numeroContacto
+      creadoEn
+      persona {
+        id
+        nombre
+        documento
+        apodo
+        telefono
+      }
+      usuario {
+        id
+      }
+    }
+  }
+`;
+
+export const proveedorServicioPorPersona = gql`
+  query ($personaId: ID!) {
+    data: proveedorServicioPorPersona(personaId: $personaId) {
+      id
+      nombreContacto
+      numeroContacto
+      creadoEn
+      persona {
+        id
+        nombre
+        documento
+        apodo
+        telefono
+      }
+      usuario {
+        id
+      }
+    }
+  }
+`;
+
+export const proveedorServicioSearchPage = gql`
+  query ($texto: String, $page: Int, $size: Int) {
+    data: proveedorServicioSearchPage(texto: $texto, page: $page, size: $size) {
+      getTotalPages
+      getTotalElements
+      getNumberOfElements
+      isFirst
+      isLast
+      hasNext
+      hasPrevious
+      getContent {
+        id
+        nombreContacto
+        numeroContacto
+        creadoEn
+        persona {
+          id
+          nombre
+          documento
+          apodo
+        }
+      }
+    }
+  }
+`;
+
+export const saveProveedorServicio = gql`
+  mutation saveProveedorServicio($entity: ProveedorServicioInput!) {
+    data: saveProveedorServicio(proveedorServicio: $entity) {
+      id
+      nombreContacto
+      numeroContacto
+      creadoEn
+      persona {
+        id
+        nombre
+        documento
+        apodo
+        telefono
+      }
+    }
+  }
+`;
+
+export const deleteProveedorServicioQuery = gql`
+  mutation deleteProveedorServicio($id: ID!) {
+    deleteProveedorServicio(id: $id)
+  }
+`;

--- a/src/app/modules/personas/proveedor-servicio/graphql/proveedorServicioById.ts
+++ b/src/app/modules/personas/proveedor-servicio/graphql/proveedorServicioById.ts
@@ -1,0 +1,15 @@
+import { Injectable } from "@angular/core";
+import { Query } from "apollo-angular";
+import { ProveedorServicio } from "../proveedor-servicio.model";
+import { proveedorServicioQuery } from "./graphql-query";
+
+export interface Response {
+  data: ProveedorServicio;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class ProveedorServicioByIdGQL extends Query<Response> {
+  document = proveedorServicioQuery;
+}

--- a/src/app/modules/personas/proveedor-servicio/graphql/proveedorServicioPorPersona.ts
+++ b/src/app/modules/personas/proveedor-servicio/graphql/proveedorServicioPorPersona.ts
@@ -1,0 +1,15 @@
+import { Injectable } from "@angular/core";
+import { Query } from "apollo-angular";
+import { ProveedorServicio } from "../proveedor-servicio.model";
+import { proveedorServicioPorPersona } from "./graphql-query";
+
+export interface Response {
+  data: ProveedorServicio;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class ProveedorServicioPorPersonaGQL extends Query<Response> {
+  document = proveedorServicioPorPersona;
+}

--- a/src/app/modules/personas/proveedor-servicio/graphql/proveedorServicioSearchPage.ts
+++ b/src/app/modules/personas/proveedor-servicio/graphql/proveedorServicioSearchPage.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@angular/core";
+import { Query } from "apollo-angular";
+import { PageInfo } from "../../../../app.component";
+import { ProveedorServicio } from "../proveedor-servicio.model";
+import { proveedorServicioSearchPage } from "./graphql-query";
+
+export interface Response {
+  data: PageInfo<ProveedorServicio>;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class ProveedorServicioSearchPageGQL extends Query<Response> {
+  document = proveedorServicioSearchPage;
+}

--- a/src/app/modules/personas/proveedor-servicio/graphql/saveProveedorServicio.ts
+++ b/src/app/modules/personas/proveedor-servicio/graphql/saveProveedorServicio.ts
@@ -1,0 +1,15 @@
+import { Injectable } from "@angular/core";
+import { Mutation } from "apollo-angular";
+import { ProveedorServicio } from "../proveedor-servicio.model";
+import { saveProveedorServicio } from "./graphql-query";
+
+export interface Response {
+  data: ProveedorServicio;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class SaveProveedorServicioGQL extends Mutation<Response> {
+  document = saveProveedorServicio;
+}

--- a/src/app/modules/personas/proveedor-servicio/list-proveedor-servicio/list-proveedor-servicio.component.html
+++ b/src/app/modules/personas/proveedor-servicio/list-proveedor-servicio/list-proveedor-servicio.component.html
@@ -1,0 +1,118 @@
+<app-generic-list
+  [titulo]="titulo"
+  (adicionar)="onAdd()"
+  (filtrar)="onFilter()"
+  (resetFiltro)="onResetFiltro()"
+  [isAdicionar]="true"
+>
+  <div filtros fxLayout="column" style="width: 100%; height: 100%">
+    <div fxLayout="row wrap" fxLayoutGap="10px">
+      <mat-form-field fxFlex="40">
+        <mat-label>Nombre, documento o apodo</mat-label>
+        <input
+          matInput
+          [formControl]="textoControl"
+          placeholder="Buscar..."
+          (keyup.enter)="onFilter()"
+        />
+        <mat-icon matSuffix>search</mat-icon>
+      </mat-form-field>
+    </div>
+  </div>
+
+  <div
+    table
+    style="height: 100%; background-color: rgb(70, 70, 70)"
+    fxLayout="column"
+    fxLayoutAlign="space-between start"
+  >
+    <table
+      mat-table
+      [dataSource]="dataSource"
+      class="mat-elevation-z8"
+      style="width: 100%"
+    >
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef class="titulo-center">Id</th>
+        <td mat-cell *matCellDef="let row" style="text-align: center">
+          {{ row.id }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="nombre">
+        <th mat-header-cell *matHeaderCellDef class="titulo-center">Nombre</th>
+        <td mat-cell *matCellDef="let row" style="text-align: center">
+          {{ row.persona?.nombre }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="documento">
+        <th mat-header-cell *matHeaderCellDef class="titulo-center">
+          Documento
+        </th>
+        <td mat-cell *matCellDef="let row" style="text-align: center">
+          {{ row.persona?.documento }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="nombreContacto">
+        <th mat-header-cell *matHeaderCellDef class="titulo-center">
+          Contacto
+        </th>
+        <td mat-cell *matCellDef="let row" style="text-align: center">
+          {{ row.nombreContacto }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="numeroContacto">
+        <th mat-header-cell *matHeaderCellDef class="titulo-center">
+          Nro. contacto
+        </th>
+        <td mat-cell *matCellDef="let row" style="text-align: center">
+          {{ row.numeroContacto }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="creadoEn">
+        <th mat-header-cell *matHeaderCellDef class="titulo-center">Creado en</th>
+        <td mat-cell *matCellDef="let row" style="text-align: center">
+          {{ row.creadoEn | date : "dd/MM/yyyy HH:mm" }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef class="titulo-center">...</th>
+        <td mat-cell *matCellDef="let row" style="text-align: center">
+          <button
+            mat-icon-button
+            [matMenuTriggerFor]="menu"
+            (click)="$event.stopPropagation()"
+          >
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #menu="matMenu">
+            <button mat-menu-item (click)="onEditar(row)">
+              <mat-icon>edit</mat-icon>
+              Editar
+            </button>
+            <button mat-menu-item (click)="onEliminar(row)">
+              <mat-icon>delete</mat-icon>
+              Eliminar
+            </button>
+          </mat-menu>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+    <mat-paginator
+      itemsPerPageLabel="Items por página"
+      [pageSizeOptions]="[15, 25, 50, 100]"
+      (page)="handlePageEvent($event)"
+      [length]="length"
+      style="width: 100%"
+      showFirstLastButtons
+    ></mat-paginator>
+  </div>
+</app-generic-list>

--- a/src/app/modules/personas/proveedor-servicio/list-proveedor-servicio/list-proveedor-servicio.component.scss
+++ b/src/app/modules/personas/proveedor-servicio/list-proveedor-servicio/list-proveedor-servicio.component.scss
@@ -1,0 +1,8 @@
+table {
+  width: 100%;
+}
+
+.titulo-center {
+  text-align: center;
+  font-weight: 500;
+}

--- a/src/app/modules/personas/proveedor-servicio/list-proveedor-servicio/list-proveedor-servicio.component.ts
+++ b/src/app/modules/personas/proveedor-servicio/list-proveedor-servicio/list-proveedor-servicio.component.ts
@@ -1,0 +1,123 @@
+import { Component, OnInit, ViewChild } from "@angular/core";
+import { FormControl } from "@angular/forms";
+import { MatDialog } from "@angular/material/dialog";
+import { MatPaginator, PageEvent } from "@angular/material/paginator";
+import { MatTableDataSource } from "@angular/material/table";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { MainService } from "../../../../main.service";
+import { NotificacionSnackbarService } from "../../../../notificacion-snackbar.service";
+import { EditProveedorServicioComponent } from "../edit-proveedor-servicio/edit-proveedor-servicio.component";
+import { ProveedorServicio } from "../proveedor-servicio.model";
+import { ProveedorServicioService } from "../proveedor-servicio.service";
+
+@UntilDestroy()
+@Component({
+  selector: "app-list-proveedor-servicio",
+  templateUrl: "./list-proveedor-servicio.component.html",
+  styleUrls: ["./list-proveedor-servicio.component.scss"],
+})
+export class ListProveedorServicioComponent implements OnInit {
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  titulo = "Lista de proveedores de servicios";
+
+  dataSource = new MatTableDataSource<ProveedorServicio>([]);
+  textoControl = new FormControl();
+
+  displayedColumns = [
+    "id",
+    "nombre",
+    "documento",
+    "nombreContacto",
+    "numeroContacto",
+    "creadoEn",
+    "acciones",
+  ];
+
+  length = 0;
+  pageSize = 25;
+  pageIndex = 0;
+
+  constructor(
+    private proveedorServicioService: ProveedorServicioService,
+    public mainService: MainService,
+    private notificacionService: NotificacionSnackbarService,
+    private dialog: MatDialog
+  ) {}
+
+  ngOnInit(): void {
+    this.loadPage();
+  }
+
+  loadPage(): void {
+    const texto = this.textoControl.value?.trim() || undefined;
+    this.proveedorServicioService
+      .onGetPaginated(this.pageIndex, this.pageSize, texto)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (pageResult) => {
+          this.dataSource.data = pageResult?.getContent ?? [];
+          this.length = pageResult?.getTotalElements ?? 0;
+        },
+        error: () => {
+          this.notificacionService.openAlgoSalioMal(
+            "Error al cargar proveedores de servicios"
+          );
+        },
+      });
+  }
+
+  onFilter(): void {
+    this.pageIndex = 0;
+    this.loadPage();
+  }
+
+  onResetFiltro(): void {
+    this.textoControl.setValue(null);
+    this.pageIndex = 0;
+    this.loadPage();
+  }
+
+  onAdd(): void {
+    const dialogRef = this.dialog.open(EditProveedorServicioComponent, {
+      width: "600px",
+      data: {},
+    });
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result?.saved) {
+        this.loadPage();
+      }
+    });
+  }
+
+  onEditar(row: ProveedorServicio): void {
+    if (!row?.id) return;
+    const dialogRef = this.dialog.open(EditProveedorServicioComponent, {
+      width: "600px",
+      data: { proveedorServicio: row, isEditing: true },
+    });
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result?.saved) {
+        this.loadPage();
+      }
+    });
+  }
+
+  onEliminar(row: ProveedorServicio): void {
+    if (!row?.id) return;
+    this.proveedorServicioService
+      .onDelete(row.id)
+      .pipe(untilDestroyed(this))
+      .subscribe((ok) => {
+        if (ok) {
+          this.loadPage();
+        }
+      });
+  }
+
+  handlePageEvent(e: PageEvent): void {
+    this.pageIndex = e.pageIndex;
+    this.pageSize = e.pageSize;
+    this.loadPage();
+  }
+}

--- a/src/app/modules/personas/proveedor-servicio/proveedor-servicio.model.ts
+++ b/src/app/modules/personas/proveedor-servicio/proveedor-servicio.model.ts
@@ -1,0 +1,37 @@
+import { CuentaBancaria } from "../../financiero/cuenta-bancaria/cuenta-bancaria.model";
+import { Persona } from "../persona/persona.model";
+import { Usuario } from "../usuarios/usuario.model";
+
+/**
+ * Proveedor de servicios: la empresa que provee las terminales POS y su soporte.
+ * Independiente de Proveedor (mercaderia) — ambos son roles de una Persona.
+ */
+export class ProveedorServicio {
+  id: number;
+  persona: Persona;
+  cuentaBancaria: CuentaBancaria;
+  nombreContacto: string;
+  numeroContacto: string;
+  creadoEn: string;
+  usuario: Usuario;
+
+  toInput(): ProveedorServicioInput {
+    let input = new ProveedorServicioInput();
+    input.id = this.id;
+    input.personaId = this.persona?.id;
+    input.cuentaBancariaId = this.cuentaBancaria?.id;
+    input.nombreContacto = this.nombreContacto;
+    input.numeroContacto = this.numeroContacto;
+    input.usuarioId = this.usuario?.id;
+    return input;
+  }
+}
+
+export class ProveedorServicioInput {
+  id: number;
+  personaId: number;
+  cuentaBancariaId: number;
+  nombreContacto: string;
+  numeroContacto: string;
+  usuarioId: number = null;
+}

--- a/src/app/modules/personas/proveedor-servicio/proveedor-servicio.service.ts
+++ b/src/app/modules/personas/proveedor-servicio/proveedor-servicio.service.ts
@@ -1,0 +1,182 @@
+import { Injectable } from "@angular/core";
+import { MatDialog } from "@angular/material/dialog";
+import { UntilDestroy } from "@ngneat/until-destroy";
+import { Observable, switchMap } from "rxjs";
+import { map } from "rxjs/operators";
+import { GenericCrudService } from "../../../generics/generic-crud.service";
+import {
+  SearchListDialogComponent,
+  SearchListtDialogData,
+  TableData,
+} from "../../../shared/components/search-list-dialog/search-list-dialog.component";
+import { EditProveedorServicioComponent } from "./edit-proveedor-servicio/edit-proveedor-servicio.component";
+import { DeleteProveedorServicioGQL } from "./graphql/deleteProveedorServicio";
+import { ProveedorServicioByIdGQL } from "./graphql/proveedorServicioById";
+import { ProveedorServicioPorPersonaGQL } from "./graphql/proveedorServicioPorPersona";
+import { ProveedorServicioSearchPageGQL } from "./graphql/proveedorServicioSearchPage";
+import { SaveProveedorServicioGQL } from "./graphql/saveProveedorServicio";
+import { ProveedorServicio } from "./proveedor-servicio.model";
+
+export interface ProveedorServicioPageResult {
+  getContent?: ProveedorServicio[];
+  getTotalElements?: number;
+}
+
+@UntilDestroy({ checkProperties: true })
+@Injectable({
+  providedIn: "root",
+})
+export class ProveedorServicioService {
+  constructor(
+    private genericService: GenericCrudService,
+    private proveedorServicioSearchPage: ProveedorServicioSearchPageGQL,
+    private proveedorServicioPorId: ProveedorServicioByIdGQL,
+    private proveedorServicioPorPersona: ProveedorServicioPorPersonaGQL,
+    private saveProveedorServicio: SaveProveedorServicioGQL,
+    private deleteProveedorServicio: DeleteProveedorServicioGQL,
+    private dialog: MatDialog
+  ) {}
+
+  onGetPaginated(
+    page: number,
+    size: number,
+    texto?: string
+  ): Observable<ProveedorServicioPageResult> {
+    return this.genericService
+      .onCustomQuery(
+        this.proveedorServicioSearchPage,
+        { texto: texto?.trim() || null, page, size },
+        true,
+        null,
+        true
+      )
+      .pipe(
+        map((pageResult: ProveedorServicioPageResult) => ({
+          getContent: pageResult?.getContent ?? [],
+          getTotalElements: pageResult?.getTotalElements ?? 0,
+        }))
+      );
+  }
+
+  onGetPorId(id: number): Observable<ProveedorServicio> {
+    return this.genericService.onGetById(this.proveedorServicioPorId, id);
+  }
+
+  onGetPorPersona(id: number): Observable<ProveedorServicio> {
+    return this.genericService.onCustomQuery(this.proveedorServicioPorPersona, {
+      personaId: id,
+    });
+  }
+
+  onSave(input): Observable<ProveedorServicio> {
+    return this.genericService.onSave(this.saveProveedorServicio, input);
+  }
+
+  onDelete(id: number): Observable<boolean> {
+    return this.genericService.onDelete(
+      this.deleteProveedorServicio,
+      id,
+      "Eliminar proveedor de servicio",
+      null,
+      true,
+      true,
+      "¿Realmente desea eliminar este proveedor de servicio?"
+    );
+  }
+
+  /**
+   * Selector reutilizable (lupa) para elegir un proveedor de servicio.
+   * Lo usa el diálogo de terminal POS.
+   */
+  onSearchProveedorServicioPorTexto(
+    texto: string
+  ): Observable<ProveedorServicio> {
+    let tableData: TableData[] = [
+      {
+        id: "id",
+        nombre: "Id",
+      },
+      {
+        id: "persona.nombre",
+        nombre: "Razon Social",
+      },
+      {
+        id: "persona.documento",
+        nombre: "RUC/CI",
+      },
+      {
+        id: "nombreContacto",
+        nombre: "Contacto",
+      },
+      {
+        id: "numeroContacto",
+        nombre: "Nro. contacto",
+      },
+    ];
+
+    let data: SearchListtDialogData = {
+      query: this.proveedorServicioSearchPage,
+      tableData: tableData,
+      titulo: "Buscar proveedor de servicio",
+      search: true,
+      texto: texto,
+      inicialSearch: texto != null && texto.trim() !== "",
+      isAdicionar: true,
+      paginator: true,
+      queryData: {
+        texto: texto,
+        page: 0,
+        size: 10,
+      },
+    };
+
+    return new Observable<ProveedorServicio>((observer) => {
+      this.dialog
+        .open(SearchListDialogComponent, {
+          data: data,
+          width: "60%",
+          height: "80%",
+        })
+        .afterClosed()
+        .pipe(
+          switchMap((res) => {
+            if (res != null) {
+              if (res["adicionar"] === true) {
+                return this.dialog
+                  .open(EditProveedorServicioComponent, {
+                    width: "600px",
+                    data: {},
+                  })
+                  .afterClosed();
+              } else if (res?.id != null) {
+                return new Observable<ProveedorServicio>((obs) => {
+                  obs.next(res);
+                  obs.complete();
+                });
+              }
+            }
+            return new Observable<ProveedorServicio>((obs) => {
+              obs.complete();
+            });
+          })
+        )
+        .subscribe({
+          next: (result) => {
+            if (result) {
+              const proveedorServicio =
+                result?.proveedorServicio ?? result;
+              if (proveedorServicio?.id) {
+                observer.next(proveedorServicio);
+              }
+            }
+          },
+          error: (err) => {
+            observer.error(err);
+          },
+          complete: () => {
+            observer.complete();
+          },
+        });
+    });
+  }
+}


### PR DESCRIPTION
## Qué resuelve

Interfaz para el feature de **proveedores de servicios**: las empresas que proveen las terminales POS y su soporte técnico. Un botón nuevo en el dashboard de terminales POS abre la lista con alta/edición/borrado, y el diálogo de terminal suma un selector para elegir a quién reclamar cuando esa terminal falla.

## Qué cambia

**Módulo nuevo** bajo `src/app/modules/personas/proveedor-servicio/`, clonando la estructura de `proveedor/`: model con `toInput()`, un `gql` por operación, service, `list-proveedor-servicio` y `edit-proveedor-servicio`. Los dos componentes se declaran en `PersonasModule` — no se crea un módulo Angular nuevo.

**Dashboard de terminales POS**: cuarto botón "Proveedores de servicios", mismo patrón de `TabService` que los otros.

**Vínculo con terminal POS**: `proveedorServicio` en el model y `proveedorServicioId` en el input; campo readonly con lupa y botón de limpiar en `add-terminal-pos-dialog`; columna nueva en `list-terminal-pos`.

El campo se agrega al fragmento **`terminalPosFields`**, compartido por todas las queries y la mutation, así que un solo cambio lo propaga a todo.

## Detalles que valen el review

- **`creadoEn` es `string` en el model**, no `Date` (regla de CLAUDE.md). `proveedor.model.ts` la incumple; no copié ese detalle.
- **No cloné `adicionar-proveedor-dialog`**: es un duplicado muerto del flujo de edición.
- `edit-proveedor-servicio` sigue el patrón de `edit-proveedor`: `OnPush`, propiedades `*Computed` precalculadas (nada de funciones ni getters en el template), verificación de documento con `debounceTime(500)`, guardado en 2 pasos (persona → proveedor_servicio), strings en MAYÚSCULAS.
- El borrado usa el diálogo de confirmación de `GenericCrudService`. Si el proveedor tiene terminales vinculadas, el backend responde con un error legible en vez de un falso "eliminado con éxito" — ver el PR del central.

## Cómo probarlo

1. Terminal POS → dashboard → **"Proveedores de servicios"** → la lista abre vacía
2. **+ Adicionar** → crear uno buscando o creando la persona, con contacto y número → aparece en la lista, con su fecha en "Creado en"
3. Editarlo y confirmar que persisten los cambios
4. Menú ⋮ → **Eliminar** en uno sin terminales vinculadas → confirma y desaparece
5. Terminal POS → editar una terminal → elegir el proveedor con la lupa → guardar → **reabrir** y confirmar que quedó vinculado, y que se ve en la columna nueva de la lista
6. Guardar una terminal **sin** proveedor: debe funcionar igual (la relación es nullable)
7. Regresión: la lista de proveedores normal (`personas.proveedor`) sigue funcionando

`npm run check` (AOT producción) pasa sin errores.

## Dependencias

Necesita el backend central mergeado y desplegado: **GabFrank/franco-system-backend-servidor#174**, que a su vez va después de **GabFrank/franco-system-backend-filial#86**. Sin el central, las queries nuevas fallan en runtime.

## Riesgo

**Bajo**. Casi todo es código nuevo y aislado. Lo único compartido que se toca es el fragmento `terminalPosFields`, que suma un campo — si el central todavía no está desplegado, las queries de terminal POS fallan por campo desconocido, así que el orden de despliegue importa.

## Impacto en auto-update

Ninguno: no se tocan `installer.nsh`, `electron-builder.json` ni los manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)