### PR TITLE
feat(compras): columna monto total en la lista de pedidos

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/graphql/graphql-query.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/graphql/graphql-query.ts
@@ -67,6 +67,7 @@ export const pedidoQuery = gql`
         }
         creadoEn
       }
+      montoTotal
     }
   }
 `;
@@ -1479,6 +1480,7 @@ export const pedidosWithFiltersQuery = gql`
           }
           creadoEn
         }
+        montoTotal
       }
     }
   }

--- a/src/app/modules/operaciones/compra/gestion-compras/pedido.model.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/pedido.model.ts
@@ -28,6 +28,7 @@ export class Pedido {
   sucursalEntregaList: PedidoSucursalEntrega[];
   sucursalInfluenciaList: PedidoSucursalInfluencia[];
   procesoEtapas: ProcesoEtapa[];
+  montoTotal?: number;
 
   toInput(): PedidoInput {
     let input = new PedidoInput();

--- a/src/app/modules/operaciones/compra/gestion-compras/solicitud-pago-compra/solicitud-pago-compra.component.scss
+++ b/src/app/modules/operaciones/compra/gestion-compras/solicitud-pago-compra/solicitud-pago-compra.component.scss
@@ -327,7 +327,8 @@
     padding: 60px 20px;
     color: #ccc;
 
-    mat-icon {
+    // Solo el ícono ilustrativo del estado vacío, no los que van dentro de botones
+    > mat-icon {
       font-size: 4rem;
       width: 4rem;
       height: 4rem;

--- a/src/app/modules/operaciones/compra/list-compra/list-compra.component.html
+++ b/src/app/modules/operaciones/compra/list-compra/list-compra.component.html
@@ -167,14 +167,14 @@
         <th
           mat-header-cell
           *matHeaderCellDef
-          style="text-align: center; width: 25%"
+          style="text-align: center; width: 20%"
         >
           Proveedor
         </th>
         <td
           mat-cell
           *matCellDef="let pedido"
-          style="text-align: center; width: 25%"
+          style="text-align: center; width: 20%"
         >
           {{ pedido?.proveedor?.persona?.nombre | uppercase }}
         </td>
@@ -184,14 +184,14 @@
         <th
           mat-header-cell
           *matHeaderCellDef
-          style="text-align: center; width: 25%"
+          style="text-align: center; width: 20%"
         >
           Vendedor
         </th>
         <td
           mat-cell
           *matCellDef="let pedido"
-          style="text-align: center; width: 25%"
+          style="text-align: center; width: 20%"
         >
           {{ pedido?.vendedor?.persona?.nombre | uppercase }}
         </td>
@@ -201,16 +201,34 @@
         <th
           mat-header-cell
           *matHeaderCellDef
-          style="text-align: center; width: 25%"
+          style="text-align: center; width: 20%"
         >
           Responsable
         </th>
         <td
           mat-cell
           *matCellDef="let pedido"
-          style="text-align: center; width: 25%"
+          style="text-align: center; width: 20%"
         >
           {{ pedido?.usuario?.persona?.nombre | uppercase }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="montoTotal">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          style="text-align: center; width: 15%"
+        >
+          Monto Total
+        </th>
+        <td
+          mat-cell
+          *matCellDef="let pedido"
+          style="text-align: center; width: 15%"
+        >
+          {{ pedido?.moneda?.simbolo }}
+          {{ pedido?.montoTotal | number : "1.0-2" }}
         </td>
       </ng-container>
 

--- a/src/app/modules/operaciones/compra/list-compra/list-compra.component.ts
+++ b/src/app/modules/operaciones/compra/list-compra/list-compra.component.ts
@@ -94,6 +94,7 @@ export class ListCompraComponent implements OnInit {
     "proveedor",
     "vendedor",
     "responsable",
+    "montoTotal",
     "fecha",
     "etapa",
     "acciones",


### PR DESCRIPTION
## Qué resuelve

Dos pedidos del módulo de compras:

**1. Columna Monto Total** — la lista de pedidos mostraba solo id, proveedor, vendedor, responsable, fecha y etapa actual. Se agrega **Monto Total** entre Responsable y Fecha, con el símbolo de la moneda del pedido.

Se pide el campo `montoTotal` tanto en `pedidosWithFiltersQuery` como en `pedidoQuery`: el filtro por Id de la lista va por un camino distinto (`onGetPedidoById`), y sin esto la columna quedaba vacía al buscar por número de pedido. Para hacerle lugar a la columna nueva (15%), proveedor/vendedor/responsable bajan de 25% a 20%.

**2. Ícono de "Crear Primera Solicitud"** (etapa 5, Solicitud de Pago) — el botón se veía distinto de "Nueva Solicitud de Pago" aunque ambos ya usaban `<mat-icon>add</mat-icon>`. La causa era el SCSS: la regla `.empty-state mat-icon`, pensada para el ícono grande ilustrativo del estado vacío, también alcanzaba al ícono de adentro del botón y lo dejaba en 4rem y `#666`. Se limita a `> mat-icon` (hijo directo).

**Requiere el PR compañero del backend**: GabFrank/franco-system-backend-servidor#179 agrega `montoTotal` al tipo `Pedido`. Sin él, la columna sale vacía y la query falla por campo desconocido.

## Cómo probarlo

1. Levantar el central en 8081 (con la rama del PR del backend) y `npm start`.
2. Compras → Lista de Compras: la columna **Monto Total** entre Responsable y Fecha, con el total de cada pedido.
3. Filtrar por Id de un pedido: la columna debe seguir mostrando el monto.
4. Abrir un pedido → etapa 5 Solicitud de Pago, sin solicitudes cargadas: el botón "Crear Primera Solicitud" debe verse igual que "Nueva Solicitud de Pago".

Verificado localmente: `npm run check` (build AOT) OK, y los montos en la UI coinciden con la suma de ítems en la DB.

## Riesgo

**Bajo.** Cambios acotados a la lista de compras y al SCSS de solicitud de pago. La única dependencia es el PR del backend, que tiene que desplegarse antes o junto con este.

## Impacto en auto-update

Ninguno — no toca `installer.nsh`, `electron-builder.json` ni los manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)