### PR TITLE
feat(financiero): confirmar antes de emitir una factura duplicada

### DIFF
--- a/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
+++ b/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
@@ -15,7 +15,10 @@ import {
 import { MatSelect } from "@angular/material/select";
 import { MatTableDataSource } from "@angular/material/table";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import { Subject } from "rxjs";
+import { Observable, Subject, of } from "rxjs";
+import { map, switchMap } from "rxjs/operators";
+import { MainService } from "../../../../main.service";
+import { FacturaSimilar } from "../factura-similar.model";
 import { updateDataSource } from "../../../../commons/core/utils/numbersUtils";
 import { getDigitoVerificadorString } from "../../../../commons/core/utils/rucUtils";
 import { NotificacionSnackbarService } from "../../../../notificacion-snackbar.service";
@@ -136,7 +139,8 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
     private sucursalService: SucursalService,
     private timbradoService: TimbradoService,
     private monedaService: MonedaService,
-    private cambioService: CambioService
+    private cambioService: CambioService,
+    private mainService: MainService
   ) {}
   ngAfterViewInit(): void {
     setTimeout(() => {
@@ -685,6 +689,79 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
       return;
     }
     this.guardando = true;
+    // Antes de emitir, avisar si ya se generó una factura casi idéntica en este turno
+    // de caja. Va acá y no después de guardar porque emitir imprime y consume un
+    // número de timbrado: una vez emitida, ya no se puede deshacer.
+    this.verificarFacturaDuplicada().subscribe((emitirIgual) => {
+      if (!emitirIgual) {
+        this.guardando = false;
+        return;
+      }
+      this.continuarGuardado();
+    });
+  }
+
+  /**
+   * @return observable que emite true si se debe emitir la factura (no hay duplicado,
+   * o el cajero confirmó que quiere emitirla igual) y false si decidió cancelar.
+   */
+  private verificarFacturaDuplicada(): Observable<boolean> {
+    const items: FacturaLegalItemInput[] = this.dataSource.data.map((f) =>
+      f.toInput()
+    );
+    this.calcularTotal();
+    const totalFinal =
+      this.totalFinalControl.value - (this.data?.descuento || 0);
+
+    return this.facturaService
+      .onVerificarFacturaSimilar(
+        this.mainService?.usuarioActual?.id,
+        this.selectedCliente?.id,
+        totalFinal,
+        items
+      )
+      .pipe(
+        switchMap((facturaSimilar) => {
+          if (facturaSimilar == null) {
+            return of(true);
+          }
+          return this.dialogoService.confirm(
+            "Atención!!",
+            "Ya se emitió hoy una factura muy parecida a este cliente",
+            "¿Seguro que desea generar otra factura?",
+            this.detalleFacturaSimilar(facturaSimilar),
+            true,
+            "Sí, generar igual",
+            "Cancelar"
+          ).pipe(map((confirmado) => confirmado === true));
+        })
+      );
+  }
+
+  /**
+   * Líneas de detalle de la factura previa que se muestran en el aviso. Se arma acá y
+   * no en el template para no llamar funciones desde el HTML.
+   */
+  private detalleFacturaSimilar(facturaSimilar: FacturaSimilar): string[] {
+    const hora = facturaSimilar.fecha
+      ? new Date(facturaSimilar.fecha).toLocaleTimeString("es-PY", {
+          hour: "2-digit",
+          minute: "2-digit",
+        })
+      : "-";
+    const total =
+      facturaSimilar.totalFinal != null
+        ? facturaSimilar.totalFinal.toLocaleString("es-PY") + " Gs."
+        : "-";
+    return [
+      "Factura: " + (facturaSimilar.numeroFactura ?? "sin número"),
+      "Cliente: " + (facturaSimilar.clienteNombre ?? "-"),
+      "Hora: " + hora,
+      "Total: " + total,
+    ];
+  }
+
+  private continuarGuardado() {
     // Si es modo filial, preguntar si desea imprimir (pero el guardado siempre ocurre)
     if (this.isServidor) {
       this.dialogoService

--- a/src/app/modules/financiero/factura-legal/factura-legal.service.ts
+++ b/src/app/modules/financiero/factura-legal/factura-legal.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
-import { Observable } from "rxjs";
+import { Observable, of } from "rxjs";
+import { catchError, timeout } from "rxjs/operators";
 import { GenericCrudService } from "../../../generics/generic-crud.service";
 import { NotificacionSnackbarService } from "../../../notificacion-snackbar.service";
 import {
@@ -33,11 +34,16 @@ import { DescargarPdfFacturaElectronicaGQL } from "./graphql/descargarPdfFactura
 import { ImprimirTicketFacturaEnImpresoraGQL } from "./graphql/imprimirTicketFacturaEnImpresora";
 import { ImprimirPdfFacturaEnImpresoraGQL } from "./graphql/imprimirPdfFacturaEnImpresora";
 import { VincularFacturaLegalAVentaGQL } from "./graphql/vincularFacturaLegalAVenta";
+import { FacturaSimilarRecienteGQL } from "./graphql/facturaSimilarReciente";
+import { FacturaSimilar } from "./factura-similar.model";
 
 @Injectable({
   providedIn: "root",
 })
 export class FacturaLegalService {
+  /** El aviso de duplicado no puede demorar la emisión: si no responde a tiempo, se ignora */
+  private readonly TIMEOUT_VERIFICACION_MS = 5000;
+
   constructor(
     private saveFactura: SaveFacturaLegalGQL,
     private genericService: GenericCrudService,
@@ -61,8 +67,51 @@ export class FacturaLegalService {
     private descargarPdfFacturaElectronicaGQL: DescargarPdfFacturaElectronicaGQL,
     private imprimirTicketFacturaEnImpresoraGQL: ImprimirTicketFacturaEnImpresoraGQL,
     private imprimirPdfFacturaEnImpresoraGQL: ImprimirPdfFacturaEnImpresoraGQL,
-    private vincularFacturaLegalAVentaGQL: VincularFacturaLegalAVentaGQL
+    private vincularFacturaLegalAVentaGQL: VincularFacturaLegalAVentaGQL,
+    private facturaSimilarRecienteGQL: FacturaSimilarRecienteGQL
   ) {}
+
+  /**
+   * Busca una factura de hoy, del mismo cajero y con el mismo cliente, total e items,
+   * para avisar al cajero ANTES de emitir un duplicado (emitir imprime y consume un
+   * número de timbrado, así que después no hay vuelta atrás).
+   *
+   * Solo aplica con cliente identificado: sin cliente, o con un cliente nuevo todavía
+   * sin id, no hay contra qué comparar.
+   *
+   * Nunca bloquea la emisión: si la consulta falla o tarda, resuelve en null.
+   */
+  onVerificarFacturaSimilar(
+    usuarioId: number,
+    clienteId: number,
+    totalFinal: number,
+    items: FacturaLegalItemInput[],
+    servidor: boolean = false
+  ): Observable<FacturaSimilar> {
+    if (
+      usuarioId == null ||
+      clienteId == null ||
+      clienteId <= 0 ||
+      totalFinal == null ||
+      items == null ||
+      items.length === 0
+    ) {
+      return of(null);
+    }
+
+    return this.genericService
+      .onCustomQuery(
+        this.facturaSimilarRecienteGQL,
+        { usuarioId, clienteId, totalFinal, items },
+        servidor,
+        null,
+        true
+      )
+      .pipe(
+        timeout(this.TIMEOUT_VERIFICACION_MS),
+        catchError(() => of(null))
+      );
+  }
 
   onVincularFacturaAVenta(
     facturaLegalId: number,

--- a/src/app/modules/financiero/factura-legal/factura-similar.model.ts
+++ b/src/app/modules/financiero/factura-legal/factura-similar.model.ts
@@ -1,0 +1,12 @@
+/**
+ * Factura ya emitida en el turno de caja que se parece a la que se está por generar.
+ * Solo se usa para mostrar el aviso de posible duplicado antes de emitirla.
+ */
+export class FacturaSimilar {
+  facturaLegalId: number;
+  /** Formato EEE-PPP-NNNNNNN */
+  numeroFactura: string;
+  fecha: Date;
+  totalFinal: number;
+  clienteNombre: string;
+}

--- a/src/app/modules/financiero/factura-legal/graphql/facturaSimilarReciente.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/facturaSimilarReciente.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { FacturaSimilar } from '../factura-similar.model';
+import { facturaSimilarRecienteQuery } from './graphql-query';
+
+class Response {
+  data: FacturaSimilar;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FacturaSimilarRecienteGQL extends Query<Response> {
+  document = facturaSimilarRecienteQuery;
+}

--- a/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
@@ -261,6 +261,28 @@ export const facturaLegalQuery = gql`
     }
   }
 `;
+export const facturaSimilarRecienteQuery = gql`
+  query facturaSimilarReciente(
+    $usuarioId: ID!
+    $clienteId: ID
+    $totalFinal: Float!
+    $items: [FacturaLegalItemInput]
+  ) {
+    data: facturaSimilarReciente(
+      usuarioId: $usuarioId
+      clienteId: $clienteId
+      totalFinal: $totalFinal
+      items: $items
+    ) {
+      facturaLegalId
+      numeroFactura
+      fecha
+      totalFinal
+      clienteNombre
+    }
+  }
+`;
+
 // this returns TimbradoDetalle
 export const saveFacturaLegal = gql`
   mutation saveFacturaLegal(


### PR DESCRIPTION
## Qué resuelve

Un cajero podía emitir dos veces la misma factura sin darse cuenta. Ahora, al guardar, se consulta si hoy ya se emitió otra al mismo cliente con el mismo total y las mismas líneas; si la hay, se muestra el diálogo de confirmación con el número, cliente, hora y total de la anterior.

Requiere el PR del filial: `GabFrank/franco-system-backend-filial#89` (query `facturaSimilarReciente`).

## Dónde va el chequeo

Al principio de `onGuardar()` en `add-factura-legal-dialog.component.ts`, **antes** de las tres ramas que guardan e imprimen. Ese método es el embudo común de la factura suelta y de "Finalizar con Factura", así que la pregunta siempre precede a la impresión.

Esto importa: la impresión la dispara `onSaveFactura()`, que se ejecuta antes de que exista la venta. Un chequeo puesto en el guardado de la venta llegaba tarde — la factura ya estaba impresa y numerada.

## Cómo probarlo

Con las dos configuraciones de "Factura con Venta" (activada y desactivada):

1. Emitir una factura a un cliente elegido con el buscador.
2. Repetirla con los mismos productos, cantidades y montos → debe aparecer el diálogo **antes** de imprimir.
3. Confirmar → se emite normalmente. Cancelar → no se emite ni se imprime nada, y el formulario queda cargado.
4. Cambiar cliente, monto o cantidad → no debe avisar.
5. Consumidor final → no debe avisar.

## Riesgo

Bajo. Nunca bloquea la emisión: si la consulta falla o pasa de 5s, resuelve en `null` y el guardado sigue su curso normal. La query va al filial (`servidor = false`), igual que el guardado de la factura.

## Limitación conocida

Solo funciona con clientes que tengan id, o sea los que salen del buscador. Si se teclea el RUC de alguien que todavía no existe, el diálogo arma un cliente temporal sin id y el chequeo no corre.

## Impacto en auto-update

Ninguno. No toca `installer.nsh`, `electron-builder.json` ni los manifests.