### PR TITLE
feat(financiero): agregar accion de cancelar gasto en la lista

### DIFF
--- a/src/app/modules/financiero/gastos/graphql/cancelarGasto.ts
+++ b/src/app/modules/financiero/gastos/graphql/cancelarGasto.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { cancelarGasto } from './graphql-query';
+
+export interface Response {
+  data: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CancelarGastoGQL extends Mutation<Response> {
+  document = cancelarGasto;
+}

--- a/src/app/modules/financiero/gastos/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/gastos/graphql/graphql-query.ts
@@ -177,6 +177,7 @@ export const filterGastosQuery = gql`
       getContent {
         id
         sucursalId
+        cancelado
         sucursal {
           id
           nombre
@@ -708,5 +709,11 @@ export const gastoRendicionesByPreGastoQuery = gql`
       creadoEn
       tipoGasto { id descripcion }
     }
+  }
+`;
+
+export const cancelarGasto = gql`
+  mutation cancelarGasto($id: ID!, $sucId: ID) {
+    data: cancelarGasto(id: $id, sucId: $sucId)
   }
 `;

--- a/src/app/modules/financiero/gastos/models/gastos.model.ts
+++ b/src/app/modules/financiero/gastos/models/gastos.model.ts
@@ -18,6 +18,7 @@ export class Gasto {
     gastoDetalleList: GastoDetalle[]
     activo: boolean;
     finalizado: boolean;
+    cancelado: boolean;
     creadoEn: Date
     usuario: Usuario
     retiroGs: number;

--- a/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.html
+++ b/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.html
@@ -246,6 +246,13 @@
           </button>
           <mat-menu #menu="matMenu">
             <button mat-menu-item (click)="onAdd(gasto, i)">Editar</button>
+            <button
+              mat-menu-item
+              *ngIf="esAdmin"
+              (click)="onCancelarGasto(gasto)"
+            >
+              {{ gasto.cancelado ? 'Habilitar' : 'Cancelar' }}
+            </button>
           </mat-menu>
         </td>
       </ng-container>

--- a/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.ts
+++ b/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.ts
@@ -15,6 +15,8 @@ import { combineLatest, BehaviorSubject, Observable } from 'rxjs';
 import { switchMap, tap, map, shareReplay } from 'rxjs/operators';
 import { ListPreGastosComponent } from '../list-pre-gastos/list-pre-gastos.component';
 import { GastosDashboardComponent } from '../gastos-dashboard/gastos-dashboard.component';
+import { MainService } from '../../../../../main.service';
+import { ROLES } from '../../../../personas/roles/roles.enum';
 
 @UntilDestroy()
 @Component({
@@ -36,6 +38,9 @@ export class ListGastosComponent implements OnInit {
   private gastoService = inject(GastoService);
   private sucursalService = inject(SucursalService);
   private tabService = inject(TabService);
+  public mainService = inject(MainService);
+
+  esAdmin = false;
 
   expandedGasto: Gasto;
   
@@ -78,6 +83,10 @@ export class ListGastosComponent implements OnInit {
   );
 
   ngOnInit(): void {
+    // Se resuelve aca y no en el template: llamar roles.includes(...) desde el HTML
+    // lo re-evalua en cada ciclo de change detection.
+    this.esAdmin = this.mainService.usuarioActual?.roles?.includes(ROLES.ADMIN) ?? false;
+
     if (this.data?.tabData?.data?.caja?.id) {
       this.idCajaControl.setValue(this.data.tabData.data.caja.id);
     }
@@ -118,6 +127,13 @@ export class ListGastosComponent implements OnInit {
     }
   }
 
+  onCancelarGasto(gasto: Gasto) {
+    if (!gasto?.id) return;
+    this.gastoService.onCancelarGasto(gasto.id, gasto.sucursalId).subscribe(res => {
+      if (res) this.onFiltrar();
+    });
+  }
+
   onIrASolicitudGasto(gasto: Gasto): void {
     const buscarId = gasto?.preGasto?.id || gasto?.id;
     if (!buscarId) return;
@@ -143,6 +159,9 @@ export class ListGastosComponent implements OnInit {
   }
 
   getEstadoSolicitudColor(gasto: Gasto): string {
+    if (gasto?.cancelado) {
+      return '#ef5350';
+    }
     const estadoColor = gasto?.preGasto?.estadoColor;
     if (estadoColor) {
       return estadoColor;
@@ -164,6 +183,9 @@ export class ListGastosComponent implements OnInit {
   }
 
   getEstadoSolicitudIcono(gasto: Gasto): string {
+    if (gasto?.cancelado) {
+      return 'cancel';
+    }
     const estadoIcono = gasto?.preGasto?.estadoIcono;
     if (estadoIcono) {
       return estadoIcono;
@@ -185,6 +207,9 @@ export class ListGastosComponent implements OnInit {
   }
 
   getEstadoSolicitudEtiqueta(gasto: Gasto): string {
+    if (gasto?.cancelado) {
+      return 'CANCELADO';
+    }
     return gasto?.preGasto?.estadoEtiqueta || gasto?.preGasto?.estado || '-';
   }
 

--- a/src/app/modules/financiero/gastos/service/gasto.service.ts
+++ b/src/app/modules/financiero/gastos/service/gasto.service.ts
@@ -39,6 +39,7 @@ import { MontosRetiroDesdeLineasGQL } from '../graphql/montosRetiroDesdeLineas';
 import { PreGastoRetiroConfirmadoGQL } from '../graphql/preGastoRetiroConfirmado';
 import { RegistrarDevolucionSaldoGQL } from '../graphql/registrarDevolucionSaldo';
 import { SaveGastoRendicionGQL } from '../graphql/saveGastoRendicion';
+import { CancelarGastoGQL } from '../graphql/cancelarGasto';
 
 @Injectable({
   providedIn: 'root'
@@ -74,7 +75,8 @@ export class GastoService {
     private montosRetiroDesdeLineasGQL: MontosRetiroDesdeLineasGQL,
     private preGastoRetiroConfirmadoGQL: PreGastoRetiroConfirmadoGQL,
     private registrarDevolucionSaldoGQL: RegistrarDevolucionSaldoGQL,
-    private saveGastoRendicionGQL: SaveGastoRendicionGQL
+    private saveGastoRendicionGQL: SaveGastoRendicionGQL,
+    private cancelarGastoGQL: CancelarGastoGQL
   ) { }
 
   onSave(gasto: Gasto, servidor = true): Observable<Gasto> {
@@ -379,6 +381,13 @@ export class GastoService {
 
   saveGastoRendicion(input: unknown): Observable<unknown> {
     return this.genericService.onSave(this.saveGastoRendicionGQL, input);
+  }
+
+  onCancelarGasto(id: number, sucId: number, servidor = true): Observable<boolean> {
+    return this.genericService.onCustomQuery(this.cancelarGastoGQL, {
+      id,
+      sucId
+    }, servidor);
   }
 
 }

--- a/src/app/modules/financiero/gastos/service/gasto.service.ts
+++ b/src/app/modules/financiero/gastos/service/gasto.service.ts
@@ -384,7 +384,7 @@ export class GastoService {
   }
 
   onCancelarGasto(id: number, sucId: number, servidor = true): Observable<boolean> {
-    return this.genericService.onCustomQuery(this.cancelarGastoGQL, {
+    return this.genericService.onCustomMutation(this.cancelarGastoGQL, {
       id,
       sucId
     }, servidor);


### PR DESCRIPTION
## Qué resuelve

Parte del desktop de la funcionalidad **cancelar un gasto de cajero**. Agrega la acción Cancelar/Habilitar al menú de la lista de gastos, visible solo para ADMIN, y refleja el estado cancelado en el badge.

Backends: `franco-system-backend-filial` #96 y `franco-system-backend-servidor` #190.

## Cambios

- `graphql/cancelarGasto.ts` — clase `Mutation` de Apollo
- `graphql/graphql-query.ts` — documento gql + `cancelado` en `filterGastosQuery`
- `models/gastos.model.ts` — campo `cancelado`
- `service/gasto.service.ts` — `onCancelarGasto`
- `pages/list-gastos` — ítem de menú con `*ngIf="esAdmin"` y label que alterna Cancelar/Habilitar

**Se reutiliza la columna de estado existente.** La lista ya tenía la columna `estadoSolicitud`, rotulada "Estado", que renderiza un badge a partir de `gasto.preGasto.estado` y muestra `'-'` en los gastos comunes de cajero — justo los que se pueden cancelar. El cambio va **dentro de los tres getters que ya existían** (`getEstadoSolicitudColor`, `getEstadoSolicitudIcono`, `getEstadoSolicitudEtiqueta`), dándole prioridad a `cancelado`.

Ventaja concreta: **no se agrega ninguna llamada a función nueva en el HTML**, que es lo que prohíbe la regla de performance del CLAUDE.md. Una columna nueva sí habría sumado llamadas. Por la misma razón `esAdmin` se resuelve en `ngOnInit` y no en el template.

Efecto colateral aceptado: en un gasto originado en un `preGasto`, el badge pasa a mostrar CANCELADO en lugar del estado de la solicitud. Ese estado sigue visible en `list-pre-gastos`, y el botón "Ir a solicitud de gasto" de la misma celda no se toca.

`cancelado` **no** se agrega a `GastoInput` ni a `toInput()`: el backend no lo acepta en el input, y si viajara, un `saveGasto` podría revertir la cancelación sin querer.

## Nota sobre el segundo commit

El primer commit invocaba la mutation con `genericService.onCustomQuery`, que ejecuta `apollo.query()`. Apollo rechaza un documento `mutation` ahí, así que el botón no habría funcionado. El fix lo cambia a `onCustomMutation`, igual que `retiro.service.ts`.

## Cómo probarlo

Con central + filial + desktop levantados, y un usuario ADM:

1. Lista de gastos → filtrar por una caja con gastos.
2. Menú de tres puntos → Cancelar.
3. El badge de Estado pasa a CANCELADO en rojo, y el balance de la caja sube en `retiroGs - vueltoGs` tanto en el central como en el POS de la filial.
4. Habilitar → el balance vuelve al valor original.
5. Con un usuario no ADM, la opción no aparece en el menú.

Probado end-to-end el 2026-08-06 con el gasto 700 (sucursal 24, caja 1170, 270.000 Gs): badge rojo confirmado, el flag replicó del central a la filial, y el total de gastos de esa caja pasó de 270.000 a 0 y volvió a 270.000. `npm run check` sin errores de compilación.

## Impacto en DB

Ninguno directo. Las migraciones están en los PRs de los backends.

## Impacto en rollback

Bajo. Solo agrega una acción de UI y un campo al query. Con un backend viejo que no exponga `cancelado`, el query fallaría — por eso este PR va **último**, después de los dos backends.

## Riesgo

**Bajo.** El cambio de comportamiento se limita a la lista de gastos, y la acción está detrás del rol ADMIN.

**Orden de merge: filial (#96) → central (#190) → este.**