### PR TITLE
feat(personas): confirmar al desactivar un funcionario y mostrar el aviso de usuario inactivo

### DIFF
--- a/src/app/modules/login/login.service.ts
+++ b/src/app/modules/login/login.service.ts
@@ -172,8 +172,11 @@ export class LoginService {
             } else {
               const response: LoginResponse = {
                 usuario: null,
+                // El filial responde 200 con LoginResponse.aviso (ej: "Usuario
+                // inactivo, contacte al administrador"); sin leer 'aviso' el motivo
+                // real se perdía detrás del mensaje genérico de credenciales.
                 error: this.buildAuthErrorResponse(
-                  res?.["message"] || res?.["mensaje"]
+                  res?.["message"] || res?.["mensaje"] || res?.["aviso"]
                 ),
               };
               obs.next(response);
@@ -236,11 +239,15 @@ export class LoginService {
       );
     }
 
-    const serverMessage =
+    // Mensaje que realmente mandó el backend en el body (el central devuelve 401
+    // con {"message": ...}). error.message es el texto que arma Angular y no sirve
+    // para mostrarle al usuario, solo para clasificar el error.
+    const bodyMessage =
       error?.error?.message ||
       error?.error?.mensaje ||
-      error?.message ||
+      error?.error?.aviso ||
       "";
+    const serverMessage = bodyMessage || error?.message || "";
     const normalized = String(serverMessage).toLowerCase();
     const isInvalidCredentials =
       error?.status === 401 ||
@@ -251,7 +258,11 @@ export class LoginService {
       normalized.includes("unauthorized");
 
     if (isInvalidCredentials) {
-      return this.buildAuthErrorResponse();
+      // Si el backend explicó el motivo (usuario inactivo, usuario inexistente),
+      // se muestra ese texto en vez del genérico de credenciales.
+      return bodyMessage
+        ? this.buildAuthErrorResponse(bodyMessage)
+        : this.buildAuthErrorResponse();
     }
 
     if (error?.status === 0) {

--- a/src/app/modules/personas/clientes/cliente.model.ts
+++ b/src/app/modules/personas/clientes/cliente.model.ts
@@ -18,6 +18,7 @@ export class Cliente {
   tributa: boolean
   verificadoSet: boolean
   direccion: string;
+  activo: boolean;
 
   toInput(): ClienteInput {
     let input = new ClienteInput;
@@ -34,6 +35,7 @@ export class Cliente {
     input.saldo = this.saldo
     input.direccion = this.direccion;
     input.documento = this.documento;
+    input.activo = this.activo;
     return input;
   }
 }
@@ -53,6 +55,7 @@ export class ClienteInput {
   tributa: boolean
   verificadoSet: boolean
   direccion: string;
+  activo: boolean;
 
 }
 

--- a/src/app/modules/personas/clientes/graphql/graphql-query.ts
+++ b/src/app/modules/personas/clientes/graphql/graphql-query.ts
@@ -46,6 +46,7 @@ export const clientesSearchByPersona = gql`
       }
       tributa
       verificadoSet
+      activo
       contactos {
         id
         telefono
@@ -80,6 +81,7 @@ export const clientePorPersonaDocumento = gql`
       }
       tributa
       verificadoSet
+      activo
       contactos {
         id
         telefono
@@ -118,6 +120,7 @@ export const clientePorPersonaDocumentoDetallado = gql`
         }
         tributa
         verificadoSet
+        activo
         contactos {
           id
           telefono

--- a/src/app/modules/personas/funcionarios/adicionar-funcionario-dialog/adicionar-funcionario-dialog.component.ts
+++ b/src/app/modules/personas/funcionarios/adicionar-funcionario-dialog/adicionar-funcionario-dialog.component.ts
@@ -283,6 +283,27 @@ export class AdicionarFuncionarioDialogComponent implements OnInit {
 
   onSave() {
     if (this.selectedFuncionario == null) this.selectedFuncionario = new Funcionario();
+
+    const estabaActivo = this.selectedFuncionario.activo !== false;
+    const quedaInactivo = this.activoControl.value === false;
+    const esEdicion = this.selectedFuncionario.id != null;
+
+    if (esEdicion && estabaActivo && quedaInactivo) {
+      this.dialogoService
+        .confirm(
+          'Atención!!',
+          'Al desactivar este funcionario su usuario no podrá iniciar sesión y su cliente pasará a tipo NORMAL con crédito 0. ¿Desea continuar?'
+        )
+        .pipe(untilDestroyed(this))
+        .subscribe((confirmado) => {
+          if (confirmado) this.guardarFuncionario();
+        });
+      return;
+    }
+    this.guardarFuncionario();
+  }
+
+  private guardarFuncionario() {
     this.selectedFuncionario.activo = this.activoControl.value;
     this.selectedFuncionario.credito = this.creditoControl.value;
     this.selectedFuncionario.diarista = this.diaristaControl.value;


### PR DESCRIPTION
## Qué resuelve

Parte del desktop de una funcionalidad que abarca tres repos: desactivar un funcionario ahora desactiva también su usuario (no puede loguearse) y su cliente (pasa a NORMAL con crédito 0). Va junto con el PR del central y el del filial, misma rama `feat/funcionario-inactivo-cascada`.

## Qué incluye

1. **Aviso de confirmación al desactivar.** Desactivar un funcionario borra su crédito y el de su cliente. Eso no se deduce de un checkbox, así que ahora se pide confirmación explicando qué va a pasar. El diálogo aparece **solo** al pasar de activo a inactivo en una edición: no al crear, no al reactivar, no en un guardado que no toca el checkbox.

2. **Mostrar el aviso de "Usuario inactivo".** El backend ya devolvía el mensaje, pero el usuario nunca lo veía y le aparecía "usuario o contraseña incorrectos" — mandándolo a resetear una contraseña que no era el problema. Dos causas distintas, una por backend:
   - el filial manda el texto en `LoginResponse.aviso`, y el desktop solo leía `message`/`mensaje`;
   - el central devolvía un 500 sin cuerpo, y `normalizeLoginError` además descartaba el texto en los 401.

3. **Exponer `cliente.activo`** en el modelo, en `toInput()` y en las tres queries que leen la ficha del cliente, para que el flag viaje en vez de perderse.

## Detalle que importa

- El estado previo se lee **antes** de volcar los controles al modelo: en ese momento `selectedFuncionario.activo` todavía tiene lo que vino de la base. Invertir el orden haría que la comparación siempre dé igual y el diálogo nunca aparezca.
- `!== false` y no `=== true`: un funcionario con `activo` en null cuenta como activo, igual que en el backend.
- El fix de login cambia también los textos preexistentes de contraseña inválida y usuario inexistente contra el central: antes mostraban un error genérico de servidor, ahora muestran el mensaje real. Es una mejora, no una regresión.

## Cómo probarlo

1. Personas → Funcionarios, abrir uno activo con crédito, desmarcar "activo", guardar → aparece el aviso; confirmar.
2. Cerrar sesión e intentar entrar con ese usuario → "Usuario inactivo, contacte al administrador". Probar contra los dos backends.
3. Reactivar → el login vuelve a andar; el crédito queda en 0 y se recarga a mano.
4. Regresión: editar un cliente cualquiera y guardar → sigue activo.
5. Regresión: guardar el funcionario reactivado sin tocar el checkbox → no cambia nada de su usuario ni de su cliente.

Los 5 pasos se probaron end-to-end contra la base real, incluido el mensaje de login en ambos backends.

## Impacto en rollback

Seguro: son cambios de UI y de modelo, sin estado persistido propio. Revertir devuelve el comportamiento anterior.

## Riesgo

**Bajo-medio.** El cambio en `login.service.ts` toca el camino de autenticación. Se verificó que no afecta el camino de éxito ni el de error de conexión (status 0), y que un 500 genuino sigue mostrando el mensaje de siempre.

Spec: `docs/superpowers/specs/2026-08-06-funcionario-inactivo-cascada-design.md` (en el workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)