### PR TITLE
feat(lotes): abrir stock por lotes filtrado a 7 dias por defecto

### DIFF
--- a/src/app/modules/operaciones/lote/list-stock-lote/list-stock-lote.component.ts
+++ b/src/app/modules/operaciones/lote/list-stock-lote/list-stock-lote.component.ts
@@ -88,6 +88,14 @@ type FiltroVencimiento = 'VENCIDO' | 'POR_VENCER';
 const DIAS_POR_VENCER = 30;
 
 /**
+ * Ventana con la que se abre la pantalla, precargada en el rango "Vence o se retira entre".
+ *
+ * Va como valor del rango y no como un atajo más: así el operador VE en el campo por qué el
+ * listado viene recortado, y lo corrige o lo borra desde el mismo control con el que ya trabaja.
+ */
+const DIAS_VENCIMIENTO_POR_DEFECTO = 7;
+
+/**
  * Pantalla "Stock por lotes": responde "¿dónde tengo qué?".
  *
  * El saldo se deriva del ledger operaciones.movimiento_stock_lote y se resuelve contra el maestro
@@ -210,7 +218,29 @@ export class ListStockLoteComponent implements OnInit {
       .pipe(debounceTime(400), distinctUntilChanged(), untilDestroyed(this))
       .subscribe(() => this.onFiltrar(true));
 
+    this.precargarVencimientoPorDefecto();
     this.onBuscar();
+  }
+
+  /**
+   * Abre la pantalla con el rango "Vence o se retira entre" cargado de hoy a hoy + 7 días.
+   *
+   * Se cargan las DOS puntas y no solo el tope: con el piso vacío el campo muestra su placeholder
+   * ("DESDE – 15/8/2026") en vez de un rango legible.
+   *
+   * Efecto lateral de cerrar el rango: lo que YA venció queda afuera del listado inicial, porque
+   * su fecha es anterior al piso. Para eso está el atajo "Vencido", que limpia el rango y trae
+   * exactamente ese conjunto.
+   *
+   * Se hace acá y no en la construcción del FormGroup para no evaluar la fecha al instanciar el
+   * componente: la pantalla vive en una tab que puede quedar abierta de un día para el otro.
+   */
+  private precargarVencimientoPorDefecto(): void {
+    const desde = new Date();
+    const hasta = new Date();
+    hasta.setDate(hasta.getDate() + DIAS_VENCIMIENTO_POR_DEFECTO);
+    this.vencimiento.get('desde').setValue(desde);
+    this.vencimiento.get('hasta').setValue(hasta);
   }
 
   /**
@@ -284,10 +314,12 @@ export class ListStockLoteComponent implements OnInit {
 
   resetFiltro(): void {
     this.filtros.reset();
-    // El rango no cuelga de `filtros`, así que no lo alcanza el reset de arriba.
-    this.vencimiento.reset();
     this.proveedorSeleccionado = null;
     this.filtroVencimiento = null;
+    // El rango no cuelga de `filtros`, así que no lo alcanza el reset de arriba. Se recarga con el
+    // valor por defecto en vez de vaciarse: "Limpiar Filtro" deja la pantalla como recién abierta,
+    // no en un estado que no se puede alcanzar de ninguna otra forma.
+    this.precargarVencimientoPorDefecto();
     this.onFiltrar();
   }
 


### PR DESCRIPTION
## Qué resuelve

La pantalla **Stock por lotes** abría con el listado completo. Para responder la pregunta con la que se entra ahí — *"¿qué hay que sacar esta semana?"* — el operador tenía que armar el rango de fechas a mano cada vez.

Ahora el rango **"Vence o se retira entre"** viene precargado de hoy a hoy + 7 días.

## Cómo está implementado

El valor va en el control de rango y **no** como un atajo nuevo al lado de "Vencido" / "Mes". Así el operador ve en el campo por qué el listado viene recortado, y lo corrige o lo borra desde el mismo control con el que ya trabaja, en vez de tener que descubrir un chip prendido.

- `precargarVencimientoPorDefecto()` se llama desde `ngOnInit`, no desde la construcción del `FormGroup`: la pantalla vive en una tab que puede quedar abierta de un día para el otro, y la fecha no debe congelarse al instanciar el componente.
- `resetFiltro()` recarga ese valor en vez de vaciarlo, para que **"Limpiar Filtro"** deje la pantalla como recién abierta y no en un estado que no se puede alcanzar de ninguna otra forma.
- Se cargan las **dos** puntas del rango y no solo el tope: con el piso vacío el campo mostraba su placeholder (`DESDE – 15/8/2026`) en lugar de un rango legible.

## Cambio de comportamiento a tener en cuenta

Al cerrar el rango, **lo que ya venció queda fuera del listado inicial**, porque su fecha es anterior al piso. Antes, con el inicio vacío, entraba.

No se pierde acceso a ese conjunto: el atajo **"Vencido"** limpia el rango y lo trae exactamente. Deja de venir mezclado al abrir, que es lo que se buscaba.

## Cómo probarlo

1. Abrir **Operaciones → Stock por lotes**.
2. El campo "Vence o se retira entre" debe mostrar `hoy – hoy+7`, con las dos fechas visibles y sin el placeholder `DESDE`.
3. El listado trae solo los lotes cuyo retiro (o vencimiento, si no hay retiro) cae en esa ventana.
4. Tocar **"Limpiar Filtro"**: se borran producto, lote, proveedor, sucursal y estado, se apagan los chips, y el rango vuelve a `hoy – hoy+7`.
5. Tocar **"Vencido"** o **"Mes"**: siguen pisando el rango como antes.
6. Borrar las fechas a mano: vuelve a listar todo.

> En entornos con pocos datos de prueba la pantalla puede abrir vacía si ningún lote vence en los próximos 7 días. Es el comportamiento correcto, no un fallo.

## Impacto

| Aspecto | Estado |
|---|---|
| Backend | **Ninguno.** Reusa los parámetros `vencimientoDesde` / `vencimientoHasta` que la consulta ya exponía |
| Schema GraphQL | Sin cambios |
| Base de datos | Sin cambios |
| Auto-update / `installer.nsh` / `electron-builder.json` | Sin cambios |
| Archivos tocados | 1 (`list-stock-lote.component.ts`), +34 / −2 |

## Riesgo

**Bajo.** Un solo componente, sin cambios de API ni de datos. El único efecto observable fuera de la pantalla es que quien la abría esperando el listado completo ahora lo ve filtrado — reversible con un click en "Limpiar Filtro" o borrando las fechas.

`npm run check` (AOT producción) en verde.