### PR TITLE
fix(activos): unifica buscador y corrige signos de interrogación en Equipos e Inmuebles

### DIFF
--- a/src/app/modules/activos/equipos/pages/list-equipos/list-equipos.component.html
+++ b/src/app/modules/activos/equipos/pages/list-equipos/list-equipos.component.html
@@ -11,7 +11,7 @@
     fxLayoutGap="15px"
     style="width: 100%"
   >
-    <div fxFlex="45">
+    <div class="filtro-busqueda">
       <mat-form-field style="width: 100%">
         <mat-label>Código o descripción</mat-label>
         <input

--- a/src/app/modules/activos/equipos/pages/list-equipos/list-equipos.component.scss
+++ b/src/app/modules/activos/equipos/pages/list-equipos/list-equipos.component.scss
@@ -2,6 +2,11 @@ table {
   width: 100%;
 }
 
+.filtro-busqueda {
+  width: 240px;
+  max-width: 240px;
+}
+
 :host {
   ::ng-deep {
     .mat-mdc-text-field-wrapper {

--- a/src/app/modules/activos/inmueble/pages/list-inmuebles/list-inmuebles.component.html
+++ b/src/app/modules/activos/inmueble/pages/list-inmuebles/list-inmuebles.component.html
@@ -1,14 +1,12 @@
 <app-generic-list [data]="(inmuebles$ | async) || []" (filtrar)="onFiltrar()" (resetFiltro)="resetFiltro()"
   (adicionar)="onAdicionar()" [isAdicionar]="true">
-  <div filtros>
-    <div fxLayout="row wrap" fxLayoutAlign="start center" fxLayoutGap="10px" style="width: 100%">
-      <div fxFlex="45">
-        <mat-form-field style="width: 100%">
-          <mat-label>Nombre o direccion</mat-label>
-          <input type="text" matInput [formControl]="filtroControl" (keyup.enter)="onFiltrar()" placeholder="Ej: Local Centro" />
-          <mat-icon matSuffix>search</mat-icon>
-        </mat-form-field>
-      </div>
+  <div filtros fxLayout="row" fxLayoutGap="15px" style="width: 100%">
+    <div class="filtro-busqueda">
+      <mat-form-field style="width: 100%">
+        <mat-label>Nombre o dirección</mat-label>
+        <input type="text" matInput [formControl]="filtroControl" (keyup.enter)="onFiltrar()" placeholder="Ej: Local Centro" />
+        <mat-icon matSuffix>search</mat-icon>
+      </mat-form-field>
     </div>
   </div>
 
@@ -27,12 +25,12 @@
       </ng-container>
 
       <ng-container matColumnDef="direccion">
-        <th mat-header-cell *matHeaderCellDef>Direccion</th>
+        <th mat-header-cell *matHeaderCellDef>Dirección</th>
         <td mat-cell *matCellDef="let row">{{ row.direccion }}</td>
       </ng-container>
 
       <ng-container matColumnDef="paisCity">
-        <th mat-header-cell *matHeaderCellDef>Ubicacion</th>
+        <th mat-header-cell *matHeaderCellDef>Ubicación</th>
         <td mat-cell *matCellDef="let row">{{ row.ciudad?.descripcion }}, {{ row.pais?.descripcion }}</td>
       </ng-container>
 
@@ -60,7 +58,7 @@
             </div>
           </ng-container>
           <ng-template #sinTenencia>
-            <span class="sin-configurar">?</span>
+            <span class="sin-configurar">Sin definir</span>
           </ng-template>
         </td>
       </ng-container>
@@ -71,7 +69,7 @@
       </ng-container>
 
       <ng-container matColumnDef="tasacion">
-        <th mat-header-cell *matHeaderCellDef style="text-align: right">Tasaci?n</th>
+        <th mat-header-cell *matHeaderCellDef style="text-align: right">Tasación</th>
         <td mat-cell *matCellDef="let row" style="text-align: right; line-height: 1.3;">
             <span style="font-weight: 600;">{{ row.valorTasacion | currency:'USD':'symbol':'1.0-0' }}</span>
             <br *ngIf="row.valorTasacionPyg || row.valorTasacionBrl">

--- a/src/app/modules/activos/inmueble/pages/list-inmuebles/list-inmuebles.component.scss
+++ b/src/app/modules/activos/inmueble/pages/list-inmuebles/list-inmuebles.component.scss
@@ -2,6 +2,11 @@ table {
     width: 100%;
 }
 
+.filtro-busqueda {
+    width: 240px;
+    max-width: 240px;
+}
+
 .badge {
     display: inline-block;
     padding: 2px 8px;


### PR DESCRIPTION
## Qué resuelve

**Buscador desalineado.** En Equipos e Inmuebles el filtro usaba `fxFlex="45"`, lo que estiraba el input a casi la mitad del ancho de la pantalla. Ahora los tres listados de activos (Muebles, Equipos, Inmuebles) usan la misma clase `.filtro-busqueda` de 240px que ya tenía Muebles.

**Signos de interrogación en Inmuebles.**
- El header de la columna Tasación se renderizaba como `Tasaci?n` — acento perdido en el encoding del archivo.
- La columna Tenencia mostraba un `?` literal cuando el inmueble no tiene vinculación a sucursal. Reemplazado por "Sin definir", con el mismo estilo gris/itálico del "Sin vincular" de la columna Sucursal.
- De paso, acentos de los headers `Direccion` → `Dirección` y `Ubicacion` → `Ubicación`, y el label `Nombre o direccion` → `Nombre o dirección`.

## Cómo probarlo

1. Activos → Equipos: el buscador "Código o descripción" debe quedar compacto (240px), no ocupando media pantalla.
2. Activos → Inmuebles: mismo buscador compacto; header "Tasación" con acento; un inmueble sin vincular a sucursal debe mostrar "Sin definir" en Tenencia, no un `?`.
3. Activos → Muebles: sin cambios, es la referencia de estilo.

## Riesgo

**Bajo.** Solo template y SCSS, sin cambios de lógica, servicios ni GraphQL. `npm run check` (AOT) pasa en verde.

## Impacto en auto-update

Ninguno — no toca `installer.nsh`, `electron-builder.json` ni manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)