### PR TITLE
fix(financiero,devolucion): chequera, caja virtual y presentacion de la nota de credito

### DIFF
--- a/src/app/modules/financiero/caja-virtual/add-caja-virtual-dialog/add-caja-virtual-dialog.component.html
+++ b/src/app/modules/financiero/caja-virtual/add-caja-virtual-dialog/add-caja-virtual-dialog.component.html
@@ -32,15 +32,13 @@
     </mat-form-field>
 
     <mat-form-field appearance="outline">
-      <mat-label>Sucursal</mat-label>
+      <mat-label>Sucursal (opcional)</mat-label>
       <mat-select [formControl]="sucursalControl">
+        <mat-option [value]="null">Sin sucursal (oficina administrativa)</mat-option>
         <mat-option *ngFor="let sucursal of sucursalList" [value]="sucursal.id">
           {{ sucursal.id}} - {{ sucursal.nombre }}
         </mat-option>
       </mat-select>
-      <mat-error *ngIf="sucursalControl.hasError('required')">
-        La sucursal es requerida
-      </mat-error>
     </mat-form-field>
 
     <mat-form-field appearance="outline" *ngIf="tipoControl.value === 'CAJA_CHICA'">

--- a/src/app/modules/financiero/caja-virtual/add-caja-virtual-dialog/add-caja-virtual-dialog.component.ts
+++ b/src/app/modules/financiero/caja-virtual/add-caja-virtual-dialog/add-caja-virtual-dialog.component.ts
@@ -22,7 +22,7 @@ export class AddCajaVirtualDialogComponent implements OnInit {
   formGroup: FormGroup;
   nombreControl = new FormControl('', Validators.required);
   tipoControl = new FormControl(CajaVirtualTipo.CAJA_MAYOR, Validators.required);
-  sucursalControl = new FormControl(null, Validators.required);
+  sucursalControl = new FormControl(null);
   descripcionControl = new FormControl();
   limiteGsControl = new FormControl();
   activoControl = new FormControl(true);
@@ -85,9 +85,13 @@ export class AddCajaVirtualDialogComponent implements OnInit {
     if (this.isEditing) cajaVirtual.id = this.data.id;
     cajaVirtual.nombre = this.nombreControl.value?.toUpperCase();
     cajaVirtual.tipo = this.tipoControl.value;
-    let sucursal = new Sucursal();
-    sucursal.id = this.sucursalControl.value;
-    cajaVirtual.sucursal = sucursal;
+    // Sucursal es opcional: una caja puede estar en una oficina administrativa
+    // que no es una sucursal. Solo se envia si el usuario eligio una.
+    if (this.sucursalControl.value != null) {
+      let sucursal = new Sucursal();
+      sucursal.id = this.sucursalControl.value;
+      cajaVirtual.sucursal = sucursal;
+    }
     cajaVirtual.descripcion = this.descripcionControl.value;
     cajaVirtual.limiteGs = this.limiteGsControl.value;
     cajaVirtual.activo = this.activoControl.value;

--- a/src/app/modules/financiero/caja-virtual/list-caja-virtual/list-caja-virtual.component.html
+++ b/src/app/modules/financiero/caja-virtual/list-caja-virtual/list-caja-virtual.component.html
@@ -40,7 +40,7 @@
   </div>
 
   <!-- Tabla -->
-  <div table style="height: 100%" fxLayout="column" fxLayoutAlign="space-between start">
+  <div table style="height: 100%; width: 100%" fxLayout="column" fxLayoutAlign="space-between stretch">
     <table mat-table [dataSource]="dataSource" style="width: 100%;">
 
       <ng-container matColumnDef="id">

--- a/src/app/modules/financiero/chequera/chequera.service.ts
+++ b/src/app/modules/financiero/chequera/chequera.service.ts
@@ -66,7 +66,10 @@ export class ChequeraService {
    * @returns Observable de la Chequera guardada
    */
   onSaveChequera(entity: ChequeraInput): Observable<Chequera> {
-    return this.genericService.onSave(this.saveChequeraGQL, { entity });
+    // onSave() ya envuelve su argumento como { entity: input }; pasar { entity }
+    // producía un doble-wrap ({ entity: { entity } }) que el backend rechazaba
+    // con ValidationError. Se pasa el entity crudo, como el resto de los services.
+    return this.genericService.onSave(this.saveChequeraGQL, entity);
   }
 
   /**

--- a/src/app/modules/operaciones/devolucion/acreditar-retiro-dialog/acreditar-retiro-dialog.component.ts
+++ b/src/app/modules/operaciones/devolucion/acreditar-retiro-dialog/acreditar-retiro-dialog.component.ts
@@ -83,13 +83,22 @@ export class AcreditarRetiroDialogComponent implements OnInit {
     const presentaciones = (l.presentaciones || [])
       .slice()
       .sort((a: any, b: any) => (a.cantidad || 1) - (b.cantidad || 1));
+    const cantidadBase = l.cantidadBase || 0;
     // Presentacion base por defecto (principal, o factor 1, o la primera).
+    // Solo sirve la que divide exacto lo devuelto: con la principal x100 y 10
+    // unidades devueltas la nota de credito arrancaba en 0,1 — cantidad
+    // fraccionaria que el operador tenia que corregir a mano.
+    const divideExacto = (p: any) =>
+      cantidadBase % (p?.cantidad || 1) === 0;
     const base =
-      presentaciones.find((p: any) => p.principal) ||
+      [
+        presentaciones.find((p: any) => p.principal),
+        presentaciones.find((p: any) => (p.cantidad || 1) === 1),
+        presentaciones[0],
+      ].find((p: any) => p != null && divideExacto(p)) ||
       presentaciones.find((p: any) => (p.cantidad || 1) === 1) ||
       presentaciones[0];
     const factor = base?.cantidad || 1;
-    const cantidadBase = l.cantidadBase || 0;
     const costoBase = l.costoMedio || 0;
     return {
       productoId: l.productoId,


### PR DESCRIPTION
Cuatro fixes salidos del testing del MVP (Financiero + RRHH + Devoluciones)
contra `central-alpha`. Todos validados en UI.

## Que resuelve

**1. `fix(chequera)`: doble-wrap del input al crear chequera — BLOQUEANTE (#221)**

Sin esto no se podia crear ninguna chequera, lo que dejaba el modulo de cheques
inutilizable de punta a punta. Es el fix que motivo la rama.

**2. `fix(caja-virtual)`: sucursal opcional al crear caja virtual**

**3. `fix(caja-virtual)`: el paginator de la lista ocupa el ancho completo**

**4. `fix(devolucion)`: presentacion que divide exacto en la nota de credito**

El preview de acreditacion elegia la presentacion *principal* del producto sin
mirar la cantidad devuelta. Con una principal `x100` y 10 unidades devueltas, la
linea de la NC arrancaba en **0,1** — cantidad fraccionaria que el operador
tenia que corregir a mano, o emitir la NC mal. Ahora solo se acepta la
presentacion que divide exacto la cantidad base, cayendo a factor 1 si ninguna
lo hace.

## Como probarlo

- **Chequera**: Financiero -> Banco -> Cuenta bancaria -> crear chequera. Antes fallaba.
- **Caja virtual**: crear una sin elegir sucursal; verificar el ancho del paginator en la lista.
- **Nota de credito**: devolucion CON_PROVEEDOR de un producto cuya presentacion
  principal sea `x100`, devolviendo 10 unidades. Separar -> retirar ->
  `Registrar credito`: la linea debe arrancar en `x1` / **10**, no en `x100` / 0,1.

## Riesgo

**Bajo.** Los cuatro son correcciones acotadas a su pantalla, sin cambios de API
ni de modelo. `npm run check` (build AOT) en verde.

## Impacto en auto-update

Ninguno. No se tocan `installer.nsh`, `electron-builder.json` ni los manifests.

## Rollback

Revertir el merge. El unico costo es volver a quedarse sin poder crear
chequeras (#221).

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
