### PR TITLE
ci(web): despliegue de la app como web en Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,90 @@
+name: Deploy Web
+
+# Publica la app como web pura en Cloudflare Pages.
+#
+# A propósito NO cuelga de `release.yml`: publicar la web es un DEPLOY, no un
+# RELEASE. Atarla al tag obligaría a cortar una versión —y con ella un instalador
+# nuevo para toda la flota Electron del canal— cada vez que se quiera republicar
+# el sitio. Es el mismo criterio que ya usa el workflow `Deploy` del central:
+# manual, parametrizado, con aprobación para producción.
+#
+# `workflow_dispatch` solo aparece si este archivo existe en la rama por defecto
+# (master). Desde ahí se puede lanzar con cualquier `ref`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Rama o tag a compilar (ej: develop, master, v4.0.0)'
+        required: true
+        default: 'develop'
+      canal:
+        description: 'Canal destino'
+        required: true
+        type: choice
+        options: [alpha, beta, prod]
+        default: alpha
+
+concurrency:
+  group: deploy-web-${{ github.event.inputs.canal }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Solo `prod` pasa por el environment con revisor obligatorio.
+    environment: ${{ github.event.inputs.canal == 'prod' && 'production' || '' }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Set up Node.js
+        # wrangler 4 exige Node >= 22. Los demás jobs del repo usan 18 y por eso
+        # este no puede compartir su configuración.
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Sellar version en el build
+        # Sin tag no hay número de semantic-release, así que la web se identifica
+        # por ref + commit. Es lo único que después permite saber qué está
+        # sirviendo cada puerta.
+        run: |
+          SELLO="${{ github.event.inputs.ref }}-$(git rev-parse --short HEAD)"
+          sed -i "s/version: '0.0.0'/version: '${SELLO}'/" src/environments/environment.web.prod.ts
+          grep -n "version:" src/environments/environment.web.prod.ts
+
+      - name: Build web (AOT, produccion)
+        run: npm run web:build
+
+      - name: Publicar en Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          CANAL="${{ github.event.inputs.canal }}"
+          # Angular 15 emite directo en dist/, sin el subdirectorio browser/ que
+          # usa la PWA en Angular 21.
+          npx wrangler pages deploy dist \
+            --project-name="frc-desk-${CANAL}" \
+            --branch=main \
+            --commit-dirty=true
+
+      - name: Resumen
+        run: |
+          CANAL="${{ github.event.inputs.canal }}"
+          case "$CANAL" in
+            alpha) PUERTAS="alpha.desk.frcsuite.com" ;;
+            beta)  PUERTAS="beta.desk.frcsuite.com" ;;
+            prod)  PUERTAS="farmacia.desk.frcsuite.com, bodega.desk.frcsuite.com" ;;
+          esac
+          echo "### Web publicada en \`${CANAL}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- ref: \`${{ github.event.inputs.ref }}\` ($(git rev-parse --short HEAD))" >> $GITHUB_STEP_SUMMARY
+          echo "- puertas: ${PUERTAS}" >> $GITHUB_STEP_SUMMARY

--- a/angular.json
+++ b/angular.json
@@ -31,6 +31,11 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
+              {
+                "glob": "_headers",
+                "input": "src",
+                "output": "/"
+              },
               "src/assets",
               {
                 "glob": "**/*.wasm",

--- a/src/_headers
+++ b/src/_headers
@@ -1,0 +1,6 @@
+/index.html
+  Cache-Control: no-cache
+/*.js
+  Cache-Control: public, max-age=31536000, immutable
+/*.css
+  Cache-Control: public, max-age=31536000, immutable

--- a/src/app/commons/core/utils/webEndpoints.ts
+++ b/src/app/commons/core/utils/webEndpoints.ts
@@ -1,0 +1,55 @@
+/**
+ * Resolución de endpoints cuando la app se sirve como web pura (Cloudflare Pages)
+ * en vez de correr dentro de Electron.
+ *
+ * En Electron el servidor sale de la configuración del usuario (ip + puerto) y se
+ * habla HTTP plano dentro de la red. Servida por HTTPS eso no es posible: el
+ * navegador bloquea por mixed content cualquier request `http://` o `ws://`
+ * hecha desde una página `https://`.
+ *
+ * La solución es la misma que usa la PWA: un mapa hostname → API. El canal lo
+ * define qué proyecto de Cloudflare Pages sirvió la página; el backend por
+ * defecto lo define el hostname. Un solo build sirve todas las puertas, y una
+ * empresa nueva es una línea acá, no una compilación nueva.
+ */
+
+/** Hostname de la puerta → hostname del central que le corresponde. */
+export const API_CENTRAL_POR_HOST: Record<string, string> = {
+  'farmacia.desk.frcsuite.com': 'farmacia-api.frcsuite.com',
+  'bodega.desk.frcsuite.com': 'bodega-api.frcsuite.com',
+  'beta.desk.frcsuite.com': 'farmacia-api.frcsuite.com',
+  'alpha.desk.frcsuite.com': 'alpha-api.frcsuite.com',
+};
+
+/**
+ * Central que corresponde al hostname desde el que se sirvió la app, o `null`
+ * si no es una puerta conocida — Electron, `localhost`, o una preview de Pages.
+ * Que el fallback NO sea producción es parte del diseño.
+ */
+export function apiCentralDelHost(): string | null {
+  if (typeof location === 'undefined' || !location.hostname) return null;
+  return API_CENTRAL_POR_HOST[location.hostname] || null;
+}
+
+/** true si la app se está sirviendo por HTTPS (es decir: es la web publicada). */
+export function servidoPorHttps(): boolean {
+  return typeof location !== 'undefined' && location.protocol === 'https:';
+}
+
+/**
+ * Arma las URLs HTTP y WebSocket de un servidor respetando el esquema con el
+ * que se sirvió la app.
+ *
+ * Por HTTPS el puerto se omite a propósito: tanto nginx (farmacia/bodega) como
+ * el túnel de cloudflared (alpha) terminan el TLS en 443, y el puerto interno
+ * (8081/8082/8083) no forma parte de la URL pública.
+ */
+export function urlsDeServidor(
+  ip: string,
+  puerto: string | number
+): { http: string; ws: string } {
+  if (servidoPorHttps()) {
+    return { http: `https://${ip}`, ws: `wss://${ip}` };
+  }
+  return { http: `http://${ip}:${puerto}`, ws: `ws://${ip}:${puerto}` };
+}

--- a/src/app/modules/activos/shared/services/ente-documento.service.ts
+++ b/src/app/modules/activos/shared/services/ente-documento.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { ConfiguracionService } from '../../../../shared/services/configuracion.service';
+import { urlsDeServidor } from '../../../../commons/core/utils/webEndpoints';
 
 @Injectable({ providedIn: 'root' })
 export class EnteDocumentoService {
@@ -10,7 +11,7 @@ export class EnteDocumentoService {
     const ip = cfg?.serverIp || 'localhost';
     const port = cfg?.serverPort || '8082';
     const nombre = encodeURIComponent(fileName);
-    return `http://${ip}:${port}/api/activos/documentos/${nombre}`;
+    return `${urlsDeServidor(ip, port).http}/api/activos/documentos/${nombre}`;
   }
 
   leerArchivoComoBase64(file: File): Promise<string> {

--- a/src/app/modules/activos/vehiculos/gps/service/gps-websocket.service.ts
+++ b/src/app/modules/activos/vehiculos/gps/service/gps-websocket.service.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, Observable, Subject, Subscription } from 'rxjs';
 import SockJS from 'sockjs-client';
 import { ConfiguracionService, ConfiguracionSistema } from '../../../../../shared/services/configuracion.service';
 import { environment } from '../../../../../../environments/environment.prod';
+import { urlsDeServidor } from '../../../../../commons/core/utils/webEndpoints';
 export interface TelemetriaWsDTO {
     gpsId: number;
     imei: string;
@@ -234,7 +235,7 @@ export class GpsWebSocketService implements OnDestroy {
     private getWebSocketUrl(): string {
         const serverIp = this.currentServerIp || 'localhost';
         const serverPort = this.currentServerPort || '8080';
-        return `http://${serverIp}:${serverPort}/ws/gps`;
+        return `${urlsDeServidor(serverIp, serverPort).http}/ws/gps`;
     }
 
     getCurrentUrl(): string {

--- a/src/app/modules/login/login.service.ts
+++ b/src/app/modules/login/login.service.ts
@@ -23,6 +23,7 @@ import { ElectronService } from "../../commons/core/electron/electron.service";
 import { InicioSesion } from "../configuracion/models/inicio-sesion.model";
 import { TipoDispositivo } from "../configuracion/inicio-sesion/tipo-dispositivo.model";
 import { NotificarInicioSesionGQL } from "../configuracion/inicio-sesion/graphql/notificarInicioSesion.gql";
+import { urlsDeServidor } from '../../commons/core/utils/webEndpoints';
 
 @UntilDestroy({ checkProperties: true })
 @Injectable({
@@ -129,7 +130,7 @@ export class LoginService {
       };
       let httpResponse = this.http
         .post(
-          `http://${serverIp}:${serverPort}/login`,
+          `${urlsDeServidor(serverIp, serverPort).http}/login`,
           httpBody,
           this.httpOptions
         )
@@ -213,7 +214,7 @@ export class LoginService {
 
     if (!centralIp || !centralPort) return of(null);
 
-    return this.http.post(`http://${centralIp}:${centralPort}/login`, {
+    return this.http.post(`${urlsDeServidor(centralIp, centralPort).http}/login`, {
       nickname: nickname,
       password: password
     }, this.httpOptions).pipe(

--- a/src/app/shared/services/configuracion.service.ts
+++ b/src/app/shared/services/configuracion.service.ts
@@ -4,6 +4,7 @@ import { Observable, of, throwError, Subject } from 'rxjs';
 import { catchError, map, tap, switchMap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { ConfiguracionDialogComponent } from '../components/configuracion-dialog/configuracion-dialog.component';
+import { apiCentralDelHost } from '../../commons/core/utils/webEndpoints';
 
 export type UpdateChannel = 'stable' | 'beta' | 'alpha' | 'dev';
 
@@ -713,7 +714,31 @@ export class ConfiguracionService {
         }
       }
     }
-    return this.config;
+    return this.aplicarOverrideWeb(this.config);
+  }
+
+  /**
+   * Cuando la app se sirve desde una puerta web conocida, el servidor no lo
+   * elige el usuario: lo define el hostname. Además se fuerza `isLocal: false`,
+   * porque el filial vive en la LAN de cada sucursal y hablando HTTP plano — una
+   * página servida por HTTPS no puede alcanzarlo.
+   *
+   * El override es una capa en memoria y NO se persiste: dentro de Electron
+   * `apiCentralDelHost()` devuelve `null` y esto no hace absolutamente nada.
+   */
+  private aplicarOverrideWeb(config: ConfiguracionSistema): ConfiguracionSistema {
+    const apiCentral = apiCentralDelHost();
+    if (!config || !apiCentral) return config;
+
+    return {
+      ...config,
+      serverCentralIp: apiCentral,
+      serverCentralPort: '443',
+      serverIp: apiCentral,
+      serverPort: '443',
+      isLocal: false,
+      isConfigured: true
+    };
   }
 
   /**

--- a/src/app/shared/services/graphql-connection.service.ts
+++ b/src/app/shared/services/graphql-connection.service.ts
@@ -16,6 +16,7 @@ import { BehaviorSubject } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { ConfiguracionService, ConfiguracionSistema } from './configuracion.service';
 import { NotificacionSnackbarService, NotificacionColor } from '../../notificacion-snackbar.service';
+import { urlsDeServidor } from '../../commons/core/utils/webEndpoints';
 
 // Connection status subjects that can be subscribed to by components
 export const connectionStatusSub = new BehaviorSubject<boolean>(null);
@@ -160,12 +161,15 @@ export class GraphqlConnectionService {
     const serverPort = this.isLocal ? (config.serverPort || (this.isDev ? '8081' : null)) : null;
 
     // Create HTTP URLs - only create local URL if isLocal is true
-    const url2 = `http://${serverCentralIp}:${serverCentralPort}/graphql`;
-    const url = this.isLocal ? `http://${serverIp}:${serverPort}/graphql` : null;
+    const central = urlsDeServidor(serverCentralIp, serverCentralPort);
+    const local = this.isLocal ? urlsDeServidor(serverIp, serverPort) : null;
+
+    const url2 = `${central.http}/graphql`;
+    const url = local ? `${local.http}/graphql` : null;
 
     // Create WebSocket URLs - only create local WebSocket URL if isLocal is true
-    const wUri2 = `ws://${serverCentralIp}:${serverCentralPort}/subscriptions`;
-    const wUri = this.isLocal ? `ws://${serverIp}:${serverPort}/subscriptions` : null;
+    const wUri2 = `${central.ws}/subscriptions`;
+    const wUri = local ? `${local.ws}/subscriptions` : null;
 
     // Create the context for basic authentication
     const basic = setContext((operation, context) => ({}));
@@ -616,10 +620,10 @@ export class GraphqlConnectionService {
       if (this.isLocal) {
         const serverIp = config.serverIp;
         const serverPort = config.serverPort;
-        wUri = `ws://${serverIp}:${serverPort}/subscriptions`;
+        wUri = `${urlsDeServidor(serverIp, serverPort).ws}/subscriptions`;
       }
 
-      const wUri2 = `ws://${serverCentralIp}:${serverCentralPort}/subscriptions`;
+      const wUri2 = `${urlsDeServidor(serverCentralIp, serverCentralPort).ws}/subscriptions`;
 
       this.setupWebSocketClients(wUri, wUri2);
 

--- a/src/app/shared/services/hora-servidor.service.ts
+++ b/src/app/shared/services/hora-servidor.service.ts
@@ -5,6 +5,7 @@ import { catchError, take, timeout } from 'rxjs/operators';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { environment } from '../../../environments/environment';
 import { ConfiguracionService } from './configuracion.service';
+import { urlsDeServidor } from '../../commons/core/utils/webEndpoints';
 
 /** IANA — backend (`app.timezone`) y APIs que piden nombre de zona. */
 export const ZONA_HORARIA_PARAGUAY = 'America/Asuncion';
@@ -51,7 +52,7 @@ export class HoraServidorService implements OnDestroy {
         const config = this.configService.getConfig();
         const serverIp = config?.serverCentralIp || config?.serverIp || environment['serverCentralIp'] || environment['serverIp'];
         const serverPort = config?.serverCentralPort || config?.serverPort || environment['serverCentralPort'] || environment['serverPort'];
-        const url = `http://${serverIp}:${serverPort}/config/hora-servidor`;
+        const url = `${urlsDeServidor(serverIp, serverPort).http}/config/hora-servidor`;
 
         const antesRequest = Date.now();
 

--- a/src/app/shared/services/notification-http.service.ts
+++ b/src/app/shared/services/notification-http.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ConfiguracionService } from './configuracion.service';
+import { urlsDeServidor } from '../../commons/core/utils/webEndpoints';
 
 export interface VentaStockCriticoItemPayload {
     productoId: number;
@@ -33,7 +34,7 @@ export class NotificationHttpService {
         const config = this.configService.getConfig();
         const centralIp = config?.serverCentralIp || 'localhost';
         const centralPort = config?.serverCentralPort || '8081';
-        return `http://${centralIp}:${centralPort}`;
+        return urlsDeServidor(centralIp, centralPort).http;
     }
 
     sendCompraCreditoNotification(

--- a/src/environments/environment.web.prod.ts
+++ b/src/environments/environment.web.prod.ts
@@ -1,0 +1,36 @@
+import { ipAddress, port, ipCentralAddress, centralPort } from "./conectionConfig";
+
+/**
+ * Build web de producción — la que publica Cloudflare Pages en
+ * `<empresa>.desk.frcsuite.com`.
+ *
+ * Los valores de servidor de acá son SOLO el fallback para un hostname que no
+ * esté en el mapa de `commons/core/utils/webEndpoints.ts` (una preview de Pages,
+ * `localhost`). En las puertas conocidas el central lo define el hostname, no
+ * este archivo. Que el fallback no sea producción es deliberado.
+ */
+export const APP_CONFIG = {
+  production: true,
+  environment: 'WEB'
+};
+
+export const environment = {
+  production: true,
+  version: '0.0.0',
+  usuario: 1,
+  sucursalId: 1,
+  firebaseConfig: {
+    apiKey: "AIzaSyDXo7_lxOte36xJzucflKYPXKTxeYosEKI",
+    authDomain: "bodega-franco-frc.firebaseapp.com",
+    projectId: "bodega-franco-frc",
+    storageBucket: "bodega-franco-frc.firebasestorage.app",
+    messagingSenderId: "170136643206",
+    appId: "1:170136643206:web:f041a6acbfa412dea5d307",
+    measurementId: "G-3SKWPWH95N",
+    vapidKey: "BD2NBAWDMVmY7hiM9HJB-F9E1oMCBcBS9-JeJ1CxNDkDdrlp8jWzHngYHPnNqqmkFJPNU-5xPMpCpt3hGMPrSLM"
+  },
+  serverIp: ipAddress,
+  serverPort: port,
+  serverCentralIp: ipCentralAddress,
+  serverCentralPort: centralPort
+};


### PR DESCRIPTION
## Qué resuelve

Habilita servir la app como **web pura** en `<empresa>.desk.frcsuite.com` (Cloudflare Pages), como cliente **solo de central** — admin y consulta, no POS.

**Esta PR no genera versión.** Todos los commits son `chore:`/`ci:`, así que `semantic-release` no corta tag y **no se empaqueta ni publica ningún instalador**. La flota Electron no se entera.

## Cambios

- `commons/core/utils/webEndpoints.ts` — mapa hostname → central y helper que deriva el esquema de `location.protocol`. Por HTTPS omite el puerto a propósito: nginx y el túnel terminan el TLS en 443.
- Reemplazo de las URLs `http://`/`ws://` hardcodeadas en `graphql-connection`, `login`, `hora-servidor`, `notification-http`, `ente-documento` y `gps-websocket`. Sin esto el navegador las bloquea por mixed content.
- `configuracion.service.ts` — override en memoria (no persistido) cuando el hostname es una puerta conocida: central por hostname e `isLocal:false`, porque el filial vive en la LAN y habla HTTP plano.
- `environment.web.prod.ts` — **no existía**, y `angular.json` ya lo referenciaba en la configuración `web-production`. O sea que `npm run web:build` fallaba antes de compilar nada.
- `src/_headers` + entrada en `angular.json` — control de caché de Pages. Sin service worker, el `index.html` sin cachear es el único mecanismo de actualización que hay.
- `.github/workflows/deploy-web.yml` — `workflow_dispatch` por `ref` + `canal`, con el environment `production` como aprobación para las puertas productivas.

## Cómo probarlo

`npm run web:build` — corrido local, verde, 73 MB / 1892 archivos, `_headers` en la raíz de `dist`.

Después del merge: `Deploy Web` con `ref=master, canal=prod` publica `farmacia.desk` y `bodega.desk`.

## Riesgo

**Bajo para Electron.** Fuera de una puerta web `apiCentralDelHost()` devuelve `null`, el override no corre y las URLs se arman exactamente igual que antes.

Sin impacto en auto-update: no se tocan `installer.nsh`, `electron-builder.json` ni los manifests.