### PR TITLE
fix(transferencias): permitir verificar items y dejar de confirmar con datos vacios

### DIFF
--- a/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
@@ -54,6 +54,11 @@ import {
   TransferenciaItemView,
 } from "../transferencia.model";
 import {
+  aplicarConfirmacion,
+  nombreEtapaDeOrigen,
+  puedeConfirmar,
+} from "../transferencia-item-confirmacion";
+import {
   SeleccionarLotesDialogComponent,
   SeleccionarLotesDialogData,
   SeleccionarLotesDialogResult,
@@ -1017,30 +1022,24 @@ export class EditTransferenciaComponent implements OnInit {
   }
 
   onConfirm(item: TransferenciaItem) {
+    const etapa = this.selectedTransferencia?.etapa;
+
+    // Un item que no paso por la etapa anterior no tiene de donde copiar. Antes se guardaba el null
+    // igual y la fila quedaba en "Falta verificar" para siempre, sin decir por que.
+    if (!puedeConfirmar(item, etapa)) {
+      this.notificacionService.openWarn(
+        'Este producto no tiene datos de ' +
+          nombreEtapaDeOrigen(etapa) +
+          ', así que no se puede verificar. Si no llegó, corresponde rechazarlo.'
+      );
+      return;
+    }
+
     let newItem = new TransferenciaItem();
     item = Object.assign(newItem, item);
-    if (
-      this.selectedTransferencia?.etapa ==
-      EtapaTransferencia.PREPARACION_MERCADERIA
-    ) {
-      item.cantidadPreparacion = item.cantidadPreTransferencia;
-      item.presentacionPreparacion = item.presentacionPreTransferencia;
-      item.vencimientoPreparacion = item?.vencimientoPreTransferencia;
-    } else if (
-      this.selectedTransferencia?.etapa ==
-      EtapaTransferencia.TRANSPORTE_VERIFICACION
-    ) {
-      item.cantidadTransporte = item.cantidadPreparacion;
-      item.presentacionTransporte = item.presentacionPreparacion;
-      item.vencimientoTransporte = item?.vencimientoPreparacion;
-    } else if (
-      this.selectedTransferencia?.etapa ==
-      EtapaTransferencia.RECEPCION_EN_VERIFICACION
-    ) {
-      item.cantidadRecepcion = item.cantidadTransporte;
-      item.presentacionRecepcion = item.presentacionTransporte;
-      item.vencimientoRecepcion = item?.vencimientoTransporte;
-    }
+    item.usuario = item.usuario ?? this.mainService.usuarioActual;
+    aplicarConfirmacion(item, etapa);
+
     this.transferenciaService
       .onSaveTransferenciaItem(item.toInput())
       .pipe(untilDestroyed(this))
@@ -1058,32 +1057,13 @@ export class EditTransferenciaComponent implements OnInit {
   }
 
   onDesconfirm(item: TransferenciaItem) {
-    let newItem = new TransferenciaItem();
-    item = Object.assign(newItem, item);
-    if (
-      this.selectedTransferencia?.etapa ==
-      EtapaTransferencia.PREPARACION_MERCADERIA
-    ) {
-      item.cantidadPreparacion = null;
-      item.presentacionPreparacion = null;
-      item.vencimientoPreparacion = null;
-    } else if (
-      this.selectedTransferencia?.etapa ==
-      EtapaTransferencia.TRANSPORTE_VERIFICACION
-    ) {
-      item.cantidadTransporte = null;
-      item.presentacionTransporte = null;
-      item.vencimientoTransporte = null;
-    } else if (
-      this.selectedTransferencia?.etapa ==
-      EtapaTransferencia.RECEPCION_EN_VERIFICACION
-    ) {
-      item.cantidadRecepcion = null;
-      item.presentacionRecepcion = null;
-      item.vencimientoRecepcion = null;
-    }
+    // Se limpia con una mutation dedicada: en saveTransferenciaItem la ausencia de un campo
+    // significa "no lo toques", asi que mandar nulls ya no vacia nada.
     this.transferenciaService
-      .onSaveTransferenciaItem(item.toInput())
+      .onDesconfirmarTransferenciaItem(
+        item.id,
+        this.selectedTransferencia?.etapa
+      )
       .pipe(untilDestroyed(this))
       .subscribe((res) => {
         if (res != null) {
@@ -1166,6 +1146,10 @@ export class EditTransferenciaComponent implements OnInit {
       .subscribe((res) => {
         this.isDialogOpen = false;
         if (res?.item != null) {
+          // El dialogo devuelve la fila de la grilla, que puede venir sin usuario. Sin esto el input
+          // sale con usuarioId en null y el backend no lo puede guardar.
+          res["item"].usuario =
+            res["item"].usuario ?? this.mainService.usuarioActual;
           this.transferenciaService
             .onSaveTransferenciaItem(res["item"].toInput())
             .pipe(untilDestroyed(this))

--- a/src/app/modules/operaciones/transferencia/graphql/desconfirmarTransferenciaItem.ts
+++ b/src/app/modules/operaciones/transferencia/graphql/desconfirmarTransferenciaItem.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { TransferenciaItem } from '../transferencia.model';
+import { desconfirmarTransferenciaItem } from './graphql-query';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DesconfirmarTransferenciaItemGQL extends Mutation<TransferenciaItem> {
+  document = desconfirmarTransferenciaItem;
+}

--- a/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
+++ b/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
@@ -548,6 +548,48 @@ export const saveTransferenciaItem = gql`
   }
 `;
 
+/**
+ * Vacia las columnas de una etapa del item.
+ *
+ * Va aparte de saveTransferenciaItem porque ahi la ausencia de un campo significa "no lo toques".
+ * Mandar nulls para des-verificar era indistinguible de un input incompleto, y es lo que borraba
+ * etapas enteras sin que nadie lo pidiera.
+ */
+export const desconfirmarTransferenciaItem = gql`
+  mutation desconfirmarTransferenciaItem(
+    $id: ID!
+    $etapa: EtapaTransferencia!
+  ) {
+    data: desconfirmarTransferenciaItem(id: $id, etapa: $etapa) {
+      id
+      cantidadPreparacion
+      cantidadTransporte
+      cantidadRecepcion
+      vencimientoPreparacion
+      vencimientoTransporte
+      vencimientoRecepcion
+      motivoModificacionPreparacion
+      motivoModificacionTransporte
+      motivoModificacionRecepcion
+      motivoRechazoPreparacion
+      motivoRechazoTransporte
+      motivoRechazoRecepcion
+      presentacionPreparacion {
+        id
+      }
+      presentacionTransporte {
+        id
+      }
+      presentacionRecepcion {
+        id
+      }
+      usuario {
+        id
+      }
+    }
+  }
+`;
+
 export const deleteTransferenciaItemQuery = gql`
   mutation deleteTransferenciaItem($id: ID!) {
     data: deleteTransferenciaItem(id: $id)
@@ -788,6 +830,11 @@ export const transferenciaItemPorTransferenciaIdQuery = gql`
         activo
         poseeVencimiento
         creadoEn
+        # Sin esto las filas recien cargadas venian sin usuario, y toInput() mandaba usuarioId en
+        # null: saveTransferenciaItem no puede guardar un item sin responsable.
+        usuario {
+          id
+        }
         lotesAsignados {
           id
           loteId
@@ -1047,6 +1094,11 @@ export const transferenciaItensPorTransferenciaIdWithFilter = gql`
         activo
         poseeVencimiento
         creadoEn
+        # Sin esto las filas recien cargadas venian sin usuario, y toInput() mandaba usuarioId en
+        # null: saveTransferenciaItem no puede guardar un item sin responsable.
+        usuario {
+          id
+        }
         lotesAsignados {
           id
           loteId

--- a/src/app/modules/operaciones/transferencia/transferencia-etapa.enum.ts
+++ b/src/app/modules/operaciones/transferencia/transferencia-etapa.enum.ts
@@ -1,0 +1,20 @@
+/**
+ * Etapas por las que pasa una transferencia, en orden de avance.
+ *
+ * Vive en su propio archivo, sin un solo import, para que la logica que depende solo de la etapa
+ * pueda usarla sin arrastrar `transferencia.model` (que a traves de dateUtils termina importando
+ * @angular/common y obliga a levantar todo Angular para probar una funcion pura).
+ *
+ * `transferencia.model` la re-exporta, asi que los import existentes siguen funcionando igual.
+ */
+export enum EtapaTransferencia {
+  PRE_TRANSFERENCIA_CREACION = 'PRE_TRANSFERENCIA_CREACION',
+  PRE_TRANSFERENCIA_ORIGEN = 'PRE_TRANSFERENCIA_ORIGEN',
+  PREPARACION_MERCADERIA = 'PREPARACION_MERCADERIA',
+  PREPARACION_MERCADERIA_CONCLUIDA = 'PREPARACION_MERCADERIA_CONCLUIDA',
+  TRANSPORTE_VERIFICACION = 'TRANSPORTE_VERIFICACION',
+  TRANSPORTE_EN_CAMINO = 'TRANSPORTE_EN_CAMINO',
+  TRANSPORTE_EN_DESTINO = 'TRANSPORTE_EN_DESTINO',
+  RECEPCION_EN_VERIFICACION = 'RECEPCION_EN_VERIFICACION',
+  RECEPCION_CONCLUIDA = 'RECEPCION_CONCLUIDA',
+}

--- a/src/app/modules/operaciones/transferencia/transferencia-item-confirmacion.spec.ts
+++ b/src/app/modules/operaciones/transferencia/transferencia-item-confirmacion.spec.ts
@@ -1,0 +1,117 @@
+import type { Presentacion } from '../../productos/presentacion/presentacion.model';
+import {
+  aplicarConfirmacion,
+  nombreEtapaDeOrigen,
+  puedeConfirmar,
+} from './transferencia-item-confirmacion';
+import { EtapaTransferencia } from './transferencia-etapa.enum';
+import type { TransferenciaItem } from './transferencia.model';
+
+/**
+ * Confirmar un item copia los datos de la etapa anterior. Cuando esa etapa esta vacia, la copia
+ * traia null y el item quedaba en "Falta verificar" para siempre: es lo que les pasa a los items
+ * 65830 y 65989 de la transferencia 6290, que no se pueden verificar por mas que se clickee.
+ */
+describe('transferencia-item-confirmacion', () => {
+  const presentacion = { id: 13261 } as Presentacion;
+
+  function item(valores: Partial<TransferenciaItem> = {}): TransferenciaItem {
+    return {
+      id: 65830,
+      cantidadPreTransferencia: 3,
+      presentacionPreTransferencia: presentacion,
+      ...valores,
+    } as TransferenciaItem;
+  }
+
+  describe('puedeConfirmar', () => {
+    it('es false en recepcion cuando el item no tiene datos de transporte', () => {
+      const sinTransporte = item({ cantidadTransporte: null });
+
+      expect(
+        puedeConfirmar(sinTransporte, EtapaTransferencia.RECEPCION_EN_VERIFICACION)
+      ).toBe(false);
+    });
+
+    it('es true en recepcion cuando el item tiene datos de transporte', () => {
+      const conTransporte = item({
+        cantidadTransporte: 2,
+        presentacionTransporte: presentacion,
+      });
+
+      expect(
+        puedeConfirmar(conTransporte, EtapaTransferencia.RECEPCION_EN_VERIFICACION)
+      ).toBe(true);
+    });
+
+    it('es false en transporte cuando el item no tiene datos de preparacion', () => {
+      const sinPreparacion = item({ cantidadPreparacion: null });
+
+      expect(
+        puedeConfirmar(sinPreparacion, EtapaTransferencia.TRANSPORTE_VERIFICACION)
+      ).toBe(false);
+    });
+
+    it('es true en preparacion porque copia de pre-transferencia, que siempre tiene cantidad', () => {
+      expect(
+        puedeConfirmar(item(), EtapaTransferencia.PREPARACION_MERCADERIA)
+      ).toBe(true);
+    });
+
+    it('es false en una etapa donde no se confirman items', () => {
+      expect(
+        puedeConfirmar(item(), EtapaTransferencia.TRANSPORTE_EN_CAMINO)
+      ).toBe(false);
+    });
+  });
+
+  describe('aplicarConfirmacion', () => {
+    it('copia transporte a recepcion', () => {
+      const vencimiento = new Date(2027, 0, 31);
+      const origen = item({
+        cantidadTransporte: 2,
+        presentacionTransporte: presentacion,
+        vencimientoTransporte: vencimiento,
+      });
+
+      const confirmado = aplicarConfirmacion(
+        origen,
+        EtapaTransferencia.RECEPCION_EN_VERIFICACION
+      );
+
+      expect(confirmado.cantidadRecepcion).toBe(2);
+      expect(confirmado.presentacionRecepcion).toBe(presentacion);
+      expect(confirmado.vencimientoRecepcion).toBe(vencimiento);
+    });
+
+    it('copia pre-transferencia a preparacion', () => {
+      const confirmado = aplicarConfirmacion(
+        item(),
+        EtapaTransferencia.PREPARACION_MERCADERIA
+      );
+
+      expect(confirmado.cantidadPreparacion).toBe(3);
+      expect(confirmado.presentacionPreparacion).toBe(presentacion);
+    });
+
+    it('no escribe null en la etapa cuando la anterior esta vacia', () => {
+      const sinTransporte = item({ cantidadTransporte: null });
+
+      const confirmado = aplicarConfirmacion(
+        sinTransporte,
+        EtapaTransferencia.RECEPCION_EN_VERIFICACION
+      );
+
+      expect(confirmado.cantidadRecepcion).toBeUndefined();
+      expect(confirmado.presentacionRecepcion).toBeUndefined();
+    });
+  });
+
+  describe('nombreEtapaDeOrigen', () => {
+    it('nombra la etapa que hay que completar antes', () => {
+      expect(
+        nombreEtapaDeOrigen(EtapaTransferencia.RECEPCION_EN_VERIFICACION)
+      ).toBe('transporte');
+    });
+  });
+});

--- a/src/app/modules/operaciones/transferencia/transferencia-item-confirmacion.ts
+++ b/src/app/modules/operaciones/transferencia/transferencia-item-confirmacion.ts
@@ -1,0 +1,105 @@
+import type { Presentacion } from '../../productos/presentacion/presentacion.model';
+import { EtapaTransferencia } from './transferencia-etapa.enum';
+import type { TransferenciaItem } from './transferencia.model';
+
+/**
+ * Confirmar un item en una etapa es copiar lo que trae de la etapa anterior.
+ *
+ * Vive aparte del componente porque es la regla que fallaba en silencio: cuando la etapa anterior
+ * esta vacia la copia trae null y el item queda en "Falta verificar" para siempre, por mas veces que
+ * se apriete Confirmar. Aca es una funcion pura y se puede probar sin levantar Angular: los tipos
+ * entran como `import type` y lo unico que se importa en runtime es el enum de etapas.
+ */
+interface DatosDeEtapa {
+  cantidad: number;
+  presentacion: Presentacion;
+  vencimiento: Date;
+}
+
+/** Datos de los que copia la etapa indicada. Null si en esa etapa no se confirman items. */
+function datosDeOrigen(
+  item: TransferenciaItem,
+  etapa: EtapaTransferencia
+): DatosDeEtapa {
+  switch (etapa) {
+    case EtapaTransferencia.PREPARACION_MERCADERIA:
+      return {
+        cantidad: item?.cantidadPreTransferencia,
+        presentacion: item?.presentacionPreTransferencia,
+        vencimiento: item?.vencimientoPreTransferencia,
+      };
+    case EtapaTransferencia.TRANSPORTE_VERIFICACION:
+      return {
+        cantidad: item?.cantidadPreparacion,
+        presentacion: item?.presentacionPreparacion,
+        vencimiento: item?.vencimientoPreparacion,
+      };
+    case EtapaTransferencia.RECEPCION_EN_VERIFICACION:
+      return {
+        cantidad: item?.cantidadTransporte,
+        presentacion: item?.presentacionTransporte,
+        vencimiento: item?.vencimientoTransporte,
+      };
+    default:
+      return null;
+  }
+}
+
+/**
+ * True si el item tiene de donde copiar. Un item que no paso por la etapa anterior no se puede
+ * confirmar: corresponde rechazarlo, porque esa mercaderia no viajo.
+ */
+export function puedeConfirmar(
+  item: TransferenciaItem,
+  etapa: EtapaTransferencia
+): boolean {
+  const origen = datosDeOrigen(item, etapa);
+  return origen != null && origen.cantidad != null;
+}
+
+/** Nombre de la etapa de la que se copia, para poder explicarle al usuario que es lo que falta. */
+export function nombreEtapaDeOrigen(etapa: EtapaTransferencia): string {
+  switch (etapa) {
+    case EtapaTransferencia.PREPARACION_MERCADERIA:
+      return 'pre-transferencia';
+    case EtapaTransferencia.TRANSPORTE_VERIFICACION:
+      return 'preparación';
+    case EtapaTransferencia.RECEPCION_EN_VERIFICACION:
+      return 'transporte';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Escribe en {@code item} los datos de la etapa confirmada y lo devuelve.
+ *
+ * Si no hay de donde copiar no toca nada: nunca escribe nulls, que era justamente el bug. El
+ * llamador es el que decide sobre que instancia trabajar.
+ */
+export function aplicarConfirmacion(
+  item: TransferenciaItem,
+  etapa: EtapaTransferencia
+): TransferenciaItem {
+  if (!puedeConfirmar(item, etapa)) return item;
+
+  const origen = datosDeOrigen(item, etapa);
+  switch (etapa) {
+    case EtapaTransferencia.PREPARACION_MERCADERIA:
+      item.cantidadPreparacion = origen.cantidad;
+      item.presentacionPreparacion = origen.presentacion;
+      item.vencimientoPreparacion = origen.vencimiento;
+      break;
+    case EtapaTransferencia.TRANSPORTE_VERIFICACION:
+      item.cantidadTransporte = origen.cantidad;
+      item.presentacionTransporte = origen.presentacion;
+      item.vencimientoTransporte = origen.vencimiento;
+      break;
+    case EtapaTransferencia.RECEPCION_EN_VERIFICACION:
+      item.cantidadRecepcion = origen.cantidad;
+      item.presentacionRecepcion = origen.presentacion;
+      item.vencimientoRecepcion = origen.vencimiento;
+      break;
+  }
+  return item;
+}

--- a/src/app/modules/operaciones/transferencia/transferencia.model.ts
+++ b/src/app/modules/operaciones/transferencia/transferencia.model.ts
@@ -36,17 +36,10 @@ export enum TransferenciaItemMotivoModificacion {
   PRESENTACION_INCORRECTA = 'PRESENTACION_INCORRECTA'
 }
 
-export enum EtapaTransferencia {
-  PRE_TRANSFERENCIA_CREACION = 'PRE_TRANSFERENCIA_CREACION',
-  PRE_TRANSFERENCIA_ORIGEN = 'PRE_TRANSFERENCIA_ORIGEN',
-  PREPARACION_MERCADERIA = 'PREPARACION_MERCADERIA',
-  PREPARACION_MERCADERIA_CONCLUIDA = 'PREPARACION_MERCADERIA_CONCLUIDA',
-  TRANSPORTE_VERIFICACION = 'TRANSPORTE_VERIFICACION',
-  TRANSPORTE_EN_CAMINO = 'TRANSPORTE_EN_CAMINO',
-  TRANSPORTE_EN_DESTINO = 'TRANSPORTE_EN_DESTINO',
-  RECEPCION_EN_VERIFICACION = 'RECEPCION_EN_VERIFICACION',
-  RECEPCION_CONCLUIDA = 'RECEPCION_CONCLUIDA'
-}
+// El enum se movio a su propio archivo para que la logica que solo depende de la etapa no tenga que
+// importar este modulo (y con el, todo Angular). Se re-exporta para no tocar los import existentes.
+export { EtapaTransferencia } from './transferencia-etapa.enum';
+import { EtapaTransferencia } from './transferencia-etapa.enum';
 
 export class Transferencia {
   id: number;

--- a/src/app/modules/operaciones/transferencia/transferencia.service.ts
+++ b/src/app/modules/operaciones/transferencia/transferencia.service.ts
@@ -40,6 +40,7 @@ import { Persona } from '../../personas/persona/persona.model';
 import { GetHojaRutaPorFechaGQL } from './graphql/getHojaRutaPorFecha';
 import { GetHojaRutaPorFechaPageGQL } from './graphql/getHojaRutaPorFechaPage';
 import { AlertasTransferenciaItemsGQL } from './graphql/alertasTransferenciaItems';
+import { DesconfirmarTransferenciaItemGQL } from './graphql/desconfirmarTransferenciaItem';
 
 @UntilDestroy({ checkProperties: true })
 @Injectable({
@@ -79,7 +80,8 @@ export class TransferenciaService {
     private getTransferenciasPorHojaRuta: GetTransferenciasPorHojaRutaGQL,
     private getHojaRutaPorFecha: GetHojaRutaPorFechaGQL,
     private getHojaRutaPorFechaPage: GetHojaRutaPorFechaPageGQL,
-    private alertasTransferenciaItemsGQL: AlertasTransferenciaItemsGQL
+    private alertasTransferenciaItemsGQL: AlertasTransferenciaItemsGQL,
+    private desconfirmarTransferenciaItemGQL: DesconfirmarTransferenciaItemGQL
   ) { }
 
   onImprimirTransferencia(id, ticket?, servidor = true) {
@@ -162,6 +164,16 @@ export class TransferenciaService {
 
   onSaveTransferenciaItem(input, precioCosto?: number, servidor = true): Observable<TransferenciaItem> {
     return this.genericCrudService.onSaveCustom(this.saveTransferenciaItem, { entity: input, precioCosto: precioCosto }, servidor);
+  }
+
+  /**
+   * Vacia las columnas de una etapa del item (el "des-verificar" de la grilla).
+   *
+   * No se hace por onSaveTransferenciaItem: ahi la ausencia de un campo significa "no lo toques",
+   * asi que limpiar tiene que ser un pedido explicito.
+   */
+  onDesconfirmarTransferenciaItem(id, etapa: EtapaTransferencia, servidor = true): Observable<TransferenciaItem> {
+    return this.genericCrudService.onCustomMutation(this.desconfirmarTransferenciaItemGQL, { id, etapa }, servidor);
   }
 
   onDeleteTransferenciaItem(id, servidor = true): Observable<boolean> {


### PR DESCRIPTION
## Qué resuelve

En la transferencia 6290 de la instancia `farmacia` hay dos items (65830 y 65989) que muestran "Falta verificar" y no se pueden verificar por más veces que se apriete Confirmar.

`onConfirm` verificaba copiando los datos de la etapa anterior, sin mirar si esa etapa tenía algo. Cuando estaba vacía copiaba `null`, lo guardaba, y la fila seguía diciendo "Falta verificar" — sin explicar nada. Queda en loop para siempre.

No es una hipótesis: en los 64.994 items de la tabla **no existe ni uno solo** con `cantidad_recepcion` cargada y `cantidad_transporte` en `null`. Nunca en la historia del sistema se pudo confirmar en recepción un item que no tuviera datos de transporte.

Además, la query que alimenta la grilla no traía `usuario`, así que `toInput()` mandaba `usuarioId` en `null` y el backend no podía guardar el item (`usuario_id` es NOT NULL). Encaja con que las modificaciones manuales de items se cortaron por completo: venían 15–34 por mes hasta febrero 2026 y el último registro es del 2026-06-15.

## Qué cambia

- **`onConfirm` no confirma con datos vacíos.** Si la etapa anterior no tiene nada, avisa cuál falta y sugiere rechazar el producto, que es lo que corresponde si la mercadería no viajó.
- **La regla se extrae a `transferencia-item-confirmacion.ts`**, como funciones puras (`puedeConfirmar`, `aplicarConfirmacion`, `nombreEtapaDeOrigen`) con tests.
- **`onDesconfirm` usa la mutation `desconfirmarTransferenciaItem`** en lugar de mandar `null`s por `saveTransferenciaItem`. Con el backend preservando campos ausentes, mandar `null` ya no vacía nada — y era indistinguible de un input incompleto.
- **Las dos queries de items traen `usuario { id }`**, y el diálogo de modificación completa el usuario actual si la fila no lo tiene (defensa en los dos lados).

### Un cambio de estructura que conviene mirar

`EtapaTransferencia` se mudó a `transferencia-etapa.enum.ts` y `transferencia.model.ts` lo **re-exporta**, así que ninguno de los 11 archivos que lo importan cambia.

El motivo: `transferencia.model` importa `dateUtils`, que importa `@angular/common` (ESM). Eso obliga a montar todo Angular para probar una función pura. Con el enum aparte, la lógica de confirmación se prueba sin framework.

## Cómo probarlo

```
npm run check   # build AOT — exit 0, 0 errores (los 28 warnings son preexistentes, de deps CommonJS)
```

Los 9 tests de `transferencia-item-confirmacion.spec.ts` cubren: no se puede confirmar sin la etapa anterior (recepción y transporte), sí se puede cuando hay datos, la copia entre etapas, y que nunca se escriba `null`.

**Aviso: `ng test` está roto en este repo y no es por este PR.** Hay dos copias de webpack (5.80.0 en la raíz vs 5.76.1 anidada en `@angular-builders/custom-webpack`) que chocan con `TypeError: The 'compilation' argument must be an instance of Compilation`. `app.component.spec.ts` falla idéntico en `develop`. Los 9 tests se corrieron con `jasmine-core` + `ts-node` directo. Arreglar el runner merece su propio PR; si no se arregla, estos tests no van a correr en CI.

Prueba manual sugerida, contra un backend que ya tenga el PR de `franco-system-backend-servidor`:

1. Abrir una transferencia en preparación con un item cargado después de que la etapa avanzó.
2. Confirmar ese item → tiene que aparecer el aviso, no guardar en silencio.
3. Rechazarlo → tiene que quedar como verificado.
4. Des-verificar un item confirmado → tiene que limpiarse sólo esa etapa.

## Impacto en rollback

Bajo. Sin cambios de esquema ni de contrato hacia atrás.

## Riesgo

**Medio.** Depende de que el backend esté desplegado primero: `desconfirmarTransferenciaItem` no existe en la versión actual, así que des-verificar falla si el desktop se actualiza antes que el server. El resto de los cambios son compatibles con el backend viejo.

PR que lo acompaña: `GabFrank/franco-system-backend-servidor` → `fix/transferencias-validar-etapas-y-preservar-items`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
