### PR TITLE
feat(financiero): accesos por caja, pagos de RRHH desde el hub y ajuste bancario

### DIFF
--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.html
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.html
@@ -144,7 +144,7 @@
               <th mat-header-cell *matHeaderCellDef style="text-align: center;">Tipo</th>
               <td mat-cell *matCellDef="let row" style="text-align: center;">
                 <span class="tipo-chip" [style.background-color]="row._color">
-                  {{ label(row) }}
+                  {{ row._label }}
                 </span>
               </td>
             </ng-container>

--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.html
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.html
@@ -144,7 +144,7 @@
               <th mat-header-cell *matHeaderCellDef style="text-align: center;">Tipo</th>
               <td mat-cell *matCellDef="let row" style="text-align: center;">
                 <span class="tipo-chip" [style.background-color]="row._color">
-                  {{ tipoMovimientoLabels[row.tipoMovimiento] || row.tipoMovimiento }}
+                  {{ label(row) }}
                 </span>
               </td>
             </ng-container>

--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
@@ -259,9 +259,16 @@ export class CajaVirtualDashboardComponent implements OnInit {
     row._color = this.tipoColores[m.tipoMovimiento as any] || '#607d8b';
     row._colorTexto = this.tipoColoresTexto[m.tipoMovimiento as any] || '#b0bec5';
     const nav = this.origenNav[m.origenTipo as any];
-    row._verOrigen = !!nav;
-    row._origenLabel = nav?.label;
-    row._origenIcon = nav?.icon;
+    // Un pago del motor ofrece su desglose; si no, se cae al registro por origen.
+    if (m.esPagoConsolidado && m.referenciaId) {
+      row._verOrigen = true;
+      row._origenLabel = 'Ver detalle del pago';
+      row._origenIcon = 'receipt_long';
+    } else {
+      row._verOrigen = !!nav;
+      row._origenLabel = nav?.label;
+      row._origenIcon = nav?.icon;
+    }
     row._anulable = this.puedeGestionar
       && m.tipoMovimiento !== CajaVirtualTipoMovimiento.AJUSTE
       && m.activo !== false;
@@ -380,7 +387,6 @@ export class CajaVirtualDashboardComponent implements OnInit {
       label: 'Ir a Vales (RRHH)', icon: 'payments',
       open: () => this.tabService.addTab(new Tab(ListValeComponent, 'Vales', null, null)),
     },
-    ...this.navDetallePago(['PAGO_CPP', 'GASTO', 'RRHH_LIQUIDACION_SUELDO', 'RRHH_LIQUIDACION_FINAL', 'RRHH_AGUINALDO']),
     OPERACION_FINANCIERA: {
       label: 'Ver operación financiera', icon: 'swap_horiz',
       open: (row) => {
@@ -395,41 +401,34 @@ export class CajaVirtualDashboardComponent implements OnInit {
 
 
   /**
-   * Entradas de "Ir al origen" para los movimientos que genera el motor de pago.
+   * Desglose de un evento de pago, abierto desde su movimiento en la caja.
    *
-   * Un evento que paga N documentos postea UN movimiento consolidado, cuya descripción no
-   * puede nombrarlos a todos (ver PagoProveedorService.etiquetaDe). El destino natural es el
-   * desglose del pago, no una pantalla de listado. El movimiento lleva referenciaId = pago.id.
-   *
-   * RRHH_VALE queda afuera a propósito: convive con los vales del atajo viejo (egreso directo),
-   * cuyo referenciaId es el id del vale y no el de un evento de pago — abrirles el detalle
-   * daría una tabla vacía. Esos siguen yendo a la lista de Vales.
+   * Un evento que paga N documentos postea UN movimiento consolidado, cuya descripción no puede
+   * nombrarlos a todos (ver PagoProveedorService.etiquetaDe). El movimiento lleva
+   * referenciaId = pago.id, y el backend marca cuáles son de un pago con esPagoConsolidado.
    */
-  private navDetallePago(origenes: string[]): Record<string, { label: string; icon: string; open: (row: MovimientoRow) => void }> {
-    const entrada = {
-      label: 'Ver detalle del pago', icon: 'receipt_long',
-      open: (row: MovimientoRow) => {
-        if (!row.referenciaId) return;
-        const data: DetallePagoDialogData = { pagoId: row.referenciaId, descripcion: row.descripcion };
-        this.dialog.open(DetallePagoDialogComponent, {
-          width: '65vw', maxWidth: '95vw', height: '70vh', data,
-        });
-      },
-    };
-    const out: Record<string, typeof entrada> = {};
-    origenes.forEach(o => out[o] = entrada);
-    return out;
+  private abrirDetallePago(row: MovimientoRow) {
+    if (!row.referenciaId) return;
+    const data: DetallePagoDialogData = { pagoId: row.referenciaId, descripcion: row.descripcion };
+    this.dialog.open(DetallePagoDialogComponent, {
+      width: '65vw', maxWidth: '95vw', height: '70vh', data,
+    });
   }
 
   irAlOrigen(row: MovimientoRow) {
+    if (row.esPagoConsolidado && row.referenciaId) return this.abrirDetallePago(row);
     this.origenNav[row.origenTipo as any]?.open(row);
   }
 
   onAnular(mov: MovimientoCajaVirtual) {
     if (!mov?.id) return;
     const esOpFinanciera = mov.origenTipo === 'OPERACION_FINANCIERA' && !!mov.referenciaId;
-    // El movimiento consolidado del pago CPP lleva referenciaId = origenId = pago.id (el evento).
-    const esPagoCpp = mov.origenTipo === 'PAGO_CPP' && !!mov.referenciaId;
+    // El movimiento consolidado del pago lleva referenciaId = origenId = pago.id (el evento).
+    //
+    // Se pregunta por esPagoConsolidado y NO por el origenTipo: desde que el movimiento lleva el
+    // concepto real (gasto, vale, liquidación…), el origen ya no distingue un pago del motor de
+    // un egreso directo del módulo — los de RRHH usan el mismo valor para las dos cosas.
+    const esPagoCpp = !!mov.esPagoConsolidado && !!mov.referenciaId;
 
     let titulo: string, mensaje: string, exito: string;
     if (esPagoCpp) {

--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
@@ -34,6 +34,7 @@ import { dateToString } from '../../../../commons/core/utils/dateUtils';
 
 // Fila de la tabla de movimientos con campos de display precalculados.
 interface MovimientoRow extends MovimientoCajaVirtual {
+  _label?: string;          // concepto real del movimiento (del origenTipo, no del tipo grueso)
   _color?: string;          // color saturado del chip (fondo)
   _colorTexto?: string;     // color claro del monto (texto sobre fondo oscuro)
   _anulable?: boolean;
@@ -106,11 +107,6 @@ export class CajaVirtualDashboardComponent implements OnInit {
   showFiltros = false;
 
   puedeGestionar = false;
-
-  /** Concepto real del movimiento: sale del origen, no del tipo grueso (ver caja-virtual.model). */
-  label(row: MovimientoCajaVirtual): string {
-    return labelMovimiento(row?.origenTipo, row?.tipoMovimiento, this.tipoMovimientoLabels);
-  }
 
   tipoMovimientoList = [
     { label: 'Ingreso', value: CajaVirtualTipoMovimiento.INGRESO },
@@ -256,6 +252,8 @@ export class CajaVirtualDashboardComponent implements OnInit {
 
   private toRow(m: MovimientoCajaVirtual): MovimientoRow {
     const row = m as MovimientoRow;
+    // Concepto real del movimiento: sale del origen, no del tipo grueso (ver caja-virtual.model).
+    row._label = labelMovimiento(m.origenTipo, m.tipoMovimiento, this.tipoMovimientoLabels);
     row._color = this.tipoColores[m.tipoMovimiento as any] || '#607d8b';
     row._colorTexto = this.tipoColoresTexto[m.tipoMovimiento as any] || '#b0bec5';
     const nav = this.origenNav[m.origenTipo as any];

--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
@@ -23,6 +23,7 @@ import { ROLES } from '../../../personas/roles/roles.enum';
 import { AddEntradaVariaDialogComponent, EntradaVariaDialogData } from '../../entrada-varia/add-entrada-varia-dialog/add-entrada-varia-dialog.component';
 import { ListEntradasVariasDialogComponent } from '../../entrada-varia/list-entradas-varias-dialog/list-entradas-varias-dialog.component';
 import { AddOperacionFinancieraDialogComponent } from '../../operacion-financiera/add-operacion-financiera-dialog/add-operacion-financiera-dialog.component';
+import { DetallePagoDialogComponent, DetallePagoDialogData } from '../detalle-pago-dialog/detalle-pago-dialog.component';
 import { OperacionFinancieraDetalleDialogComponent } from '../../operacion-financiera/operacion-financiera-detalle-dialog/operacion-financiera-detalle-dialog.component';
 import { OperacionFinancieraService } from '../../operacion-financiera/operacion-financiera.service';
 import { PagarComprasService } from '../pagar-compras-dialog/pagar-compras.service';
@@ -379,6 +380,7 @@ export class CajaVirtualDashboardComponent implements OnInit {
       label: 'Ir a Vales (RRHH)', icon: 'payments',
       open: () => this.tabService.addTab(new Tab(ListValeComponent, 'Vales', null, null)),
     },
+    ...this.navDetallePago(['PAGO_CPP', 'GASTO', 'RRHH_LIQUIDACION_SUELDO', 'RRHH_LIQUIDACION_FINAL', 'RRHH_AGUINALDO']),
     OPERACION_FINANCIERA: {
       label: 'Ver operación financiera', icon: 'swap_horiz',
       open: (row) => {
@@ -390,6 +392,34 @@ export class CajaVirtualDashboardComponent implements OnInit {
       },
     },
   };
+
+
+  /**
+   * Entradas de "Ir al origen" para los movimientos que genera el motor de pago.
+   *
+   * Un evento que paga N documentos postea UN movimiento consolidado, cuya descripción no
+   * puede nombrarlos a todos (ver PagoProveedorService.etiquetaDe). El destino natural es el
+   * desglose del pago, no una pantalla de listado. El movimiento lleva referenciaId = pago.id.
+   *
+   * RRHH_VALE queda afuera a propósito: convive con los vales del atajo viejo (egreso directo),
+   * cuyo referenciaId es el id del vale y no el de un evento de pago — abrirles el detalle
+   * daría una tabla vacía. Esos siguen yendo a la lista de Vales.
+   */
+  private navDetallePago(origenes: string[]): Record<string, { label: string; icon: string; open: (row: MovimientoRow) => void }> {
+    const entrada = {
+      label: 'Ver detalle del pago', icon: 'receipt_long',
+      open: (row: MovimientoRow) => {
+        if (!row.referenciaId) return;
+        const data: DetallePagoDialogData = { pagoId: row.referenciaId, descripcion: row.descripcion };
+        this.dialog.open(DetallePagoDialogComponent, {
+          width: '65vw', maxWidth: '95vw', height: '70vh', data,
+        });
+      },
+    };
+    const out: Record<string, typeof entrada> = {};
+    origenes.forEach(o => out[o] = entrada);
+    return out;
+  }
 
   irAlOrigen(row: MovimientoRow) {
     this.origenNav[row.origenTipo as any]?.open(row);

--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
@@ -251,7 +251,9 @@ export class CajaVirtualDashboardComponent implements OnInit {
   }
 
   private toRow(m: MovimientoCajaVirtual): MovimientoRow {
-    const row = m as MovimientoRow;
+    // Clonar antes de agregar props de display: Apollo congela los resultados y en dev
+    // asignar sobre el objeto devuelto tira TypeError (mismo patron que cheques-dashboard).
+    const row = { ...m } as MovimientoRow;
     // Concepto real del movimiento: sale del origen, no del tipo grueso (ver caja-virtual.model).
     row._label = labelMovimiento(m.origenTipo, m.tipoMovimiento, this.tipoMovimientoLabels);
     row._color = this.tipoColores[m.tipoMovimiento as any] || '#607d8b';

--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
@@ -9,7 +9,8 @@ import { Tab } from '../../../../layouts/tab/tab.model';
 import { TabService } from '../../../../layouts/tab/tab.service';
 import { ListValeComponent } from '../../../rrhh/vale/list-vale/list-vale.component';
 import { CajaVirtual, CajaVirtualTipoMovimiento, MovimientoCajaVirtual,
-         CajaVirtualSaldoItem, CuentaBancariaResumen, CajaVirtualConfiguracion } from '../caja-virtual.model';
+         CajaVirtualSaldoItem, CuentaBancariaResumen, CajaVirtualConfiguracion,
+         labelMovimiento } from '../caja-virtual.model';
 import { CajaVirtualService } from '../caja-virtual.service';
 import { PageInfo } from '../../../../app.component';
 import { AddMovimientoCajaVirtualDialogComponent, MovimientoDialogData } from '../add-movimiento-caja-virtual-dialog/add-movimiento-caja-virtual-dialog.component';
@@ -104,6 +105,11 @@ export class CajaVirtualDashboardComponent implements OnInit {
   showFiltros = false;
 
   puedeGestionar = false;
+
+  /** Concepto real del movimiento: sale del origen, no del tipo grueso (ver caja-virtual.model). */
+  label(row: MovimientoCajaVirtual): string {
+    return labelMovimiento(row?.origenTipo, row?.tipoMovimiento, this.tipoMovimientoLabels);
+  }
 
   tipoMovimientoList = [
     { label: 'Ingreso', value: CajaVirtualTipoMovimiento.INGRESO },

--- a/src/app/modules/financiero/caja-virtual/caja-virtual.model.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual.model.ts
@@ -146,3 +146,49 @@ export interface CajaVirtualConfiguracionInput {
   cuentasBancariasVisiblesIds?: number[];
   cuentasBancariasOrden?: string;
 }
+
+/**
+ * Etiqueta del concepto real de un movimiento de caja.
+ *
+ * El `tipoMovimiento` es grueso (INGRESO / EGRESO / PAGO_PROVEEDOR / ...): un pago de
+ * gasto, uno de compra y uno de liquidacion de sueldo salen todos iguales. El `origenTipo`
+ * (que el backend ya persiste en cada movimiento) sí dice de qué se trata, y es lo que se
+ * muestra. Solo cuando el origen no aporta nada — MANUAL, o ausente en movimientos viejos —
+ * se cae al `tipoMovimiento`.
+ */
+export const ORIGEN_MOVIMIENTO_LABELS: Record<string, string> = {
+  ANULACION: 'Anulación',
+  RRHH_VALE: 'Vale',
+  RRHH_PRESTAMO: 'Préstamo',
+  RRHH_AGUINALDO: 'Aguinaldo',
+  RRHH_LIQUIDACION_SUELDO: 'Liquidación',
+  RRHH_LIQUIDACION_FINAL: 'Finiquito',
+  RETIRO_CAJA: 'Retiro de PDV',
+  VENTA_CREDITO_COBRO: 'Cobro de crédito',
+  DEVOLUCION: 'Devolución',
+  GASTO: 'Gasto',
+  ENTRADA_VARIA: 'Entrada varia',
+  OPERACION_FINANCIERA: 'Operación financiera',
+  PAGO_CPP: 'Compra',
+  CHEQUE: 'Cheque',
+  ACREDITACION_POS: 'Acreditación POS',
+  MALETIN: 'Maletín',
+};
+
+/**
+ * Etiqueta a mostrar para un movimiento. `fallback` es el mapa de `tipoMovimiento` del
+ * componente (cada uno tiene el suyo).
+ *
+ * El color NO se deriva del origen a proposito: se sigue tomando del `tipoMovimiento`, que
+ * codifica la direccion de la plata (verde entra / rojo sale) y cuyas variantes de texto
+ * estan verificadas con contraste WCAG AA. Inventar 16 colores nuevos rompería las dos cosas.
+ */
+export function labelMovimiento(
+  origenTipo: string | null | undefined,
+  tipoMovimiento: string | null | undefined,
+  fallback: Record<string, string>
+): string {
+  const porOrigen = origenTipo ? ORIGEN_MOVIMIENTO_LABELS[origenTipo] : null;
+  if (porOrigen) return porOrigen;
+  return (tipoMovimiento && fallback[tipoMovimiento]) || tipoMovimiento || '';
+}

--- a/src/app/modules/financiero/caja-virtual/caja-virtual.model.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual.model.ts
@@ -76,6 +76,8 @@ export class MovimientoCajaVirtual {
   moneda: Moneda;
   referenciaId: number;
   origenTipo: string;
+  /** true si el movimiento es el asiento de un evento de pago (lo resuelve el backend). */
+  esPagoConsolidado: boolean;
   descripcion: string;
   usuario: Usuario;
   cajaOrigen: CajaVirtual;

--- a/src/app/modules/financiero/caja-virtual/caja-virtual.service.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual.service.ts
@@ -10,6 +10,10 @@ import { CajaVirtualesPorTipoGQL } from './graphql/cajaVirtualesPorTipo';
 import { CajaVirtualesActivasGQL } from './graphql/cajaVirtualesActivas';
 import { SaveCajaVirtualGQL } from './graphql/saveCajaVirtual';
 import { DeleteCajaVirtualGQL } from './graphql/deleteCajaVirtual';
+import { CajaVirtualAccesosGQL } from './graphql/cajaVirtualAccesos';
+import { OtorgarAccesoCajaGQL } from './graphql/otorgarAccesoCaja';
+import { RevocarAccesoCajaGQL } from './graphql/revocarAccesoCaja';
+import { TransferirPropiedadCajaGQL } from './graphql/transferirPropiedadCaja';
 import { SaveMovimientoCajaVirtualGQL } from './graphql/saveMovimientoCajaVirtual';
 import { MovimientosCajaVirtualGQL, MovimientosCajaVirtualPorFechaGQL } from './graphql/movimientosCajaVirtual';
 import { RealizarTransferenciaCajaVirtualGQL } from './graphql/realizarTransferenciaCajaVirtual';
@@ -43,7 +47,33 @@ export class CajaVirtualService {
     private movimientosFilterGQL: MovimientosCajaVirtualFilterGQL,
     private configuracionGQL: CajaVirtualConfiguracionGQL,
     private saveConfiguracionGQL: SaveCajaVirtualConfiguracionGQL,
+    private accesosGQL: CajaVirtualAccesosGQL,
+    private otorgarAccesoGQL: OtorgarAccesoCajaGQL,
+    private revocarAccesoGQL: RevocarAccesoCajaGQL,
+    private transferirPropiedadGQL: TransferirPropiedadCajaGQL,
   ) { }
+
+  // ── Acceso por caja (ACL) ──
+  // Solo el responsable de la caja (o un ADMIN) puede consultar y modificar esta lista;
+  // el backend lo verifica, el front solo esconde la opcion.
+
+  onGetAccesos(cajaVirtualId: number): Observable<any> {
+    return this.genericService.onCustomQuery(this.accesosGQL, { cajaVirtualId });
+  }
+
+  onOtorgarAcceso(cajaVirtualId: number, usuarioId: number, puedeLeer: boolean, puedeEscribir: boolean): Observable<any> {
+    return this.genericService.onSaveCustom(this.otorgarAccesoGQL, {
+      cajaVirtualId, usuarioId, puedeLeer, puedeEscribir,
+    });
+  }
+
+  onRevocarAcceso(cajaVirtualId: number, usuarioId: number): Observable<any> {
+    return this.genericService.onSaveCustom(this.revocarAccesoGQL, { cajaVirtualId, usuarioId });
+  }
+
+  onTransferirPropiedad(cajaVirtualId: number, nuevoPropietarioId: number): Observable<any> {
+    return this.genericService.onSaveCustom(this.transferirPropiedadGQL, { cajaVirtualId, nuevoPropietarioId });
+  }
 
   onGetAll(page = 0, size = 10): Observable<PageInfo<CajaVirtual>> {
     return this.genericService.onCustomQuery(this.cajaVirtualesGQL, { page, size });

--- a/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.html
+++ b/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.html
@@ -1,0 +1,70 @@
+<h2 mat-dialog-title class="dp-title">
+  <mat-icon>receipt_long</mat-icon>
+  <span>Detalle del pago</span>
+  <span class="dp-sub" *ngIf="data?.descripcion">{{ data.descripcion }}</span>
+</h2>
+
+<mat-dialog-content class="dp-content">
+  <div class="dp-cargando" *ngIf="isLoading">Cargando…</div>
+  <div class="dp-vacio" *ngIf="!isLoading && cantidad === 0">
+    Este movimiento no tiene documentos asociados.
+  </div>
+
+  <ng-container *ngIf="!isLoading && cantidad > 0">
+    <div class="dp-resumen">
+      <span class="dp-chip">{{ cantidad }} documento{{ cantidad === 1 ? '' : 's' }}</span>
+      <span class="dp-chip dp-total" *ngFor="let t of totales">
+        {{ t.simbolo }} {{ t.total | number:'1.0-2' }} <em>{{ t.denominacion }}</em>
+      </span>
+    </div>
+
+    <div class="dp-tabla-wrap">
+      <table mat-table [dataSource]="dataSource" class="dp-tabla">
+        <ng-container matColumnDef="solicitud">
+          <th mat-header-cell *matHeaderCellDef>N°</th>
+          <td mat-cell *matCellDef="let row">{{ row.solicitudPagoId }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="tipo">
+          <th mat-header-cell *matHeaderCellDef>Tipo</th>
+          <td mat-cell *matCellDef="let row">{{ row.tipo }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="descripcion">
+          <th mat-header-cell *matHeaderCellDef style="text-align: left;">Descripción</th>
+          <td mat-cell *matCellDef="let row" style="text-align: left;" [title]="row.descripcion">
+            {{ row.descripcion }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="beneficiario">
+          <th mat-header-cell *matHeaderCellDef style="text-align: left;">Beneficiario</th>
+          <td mat-cell *matCellDef="let row" style="text-align: left;">{{ row.proveedorNombre }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="imputado">
+          <th mat-header-cell *matHeaderCellDef style="text-align: right;">Imputado</th>
+          <td mat-cell *matCellDef="let row" style="text-align: right;">
+            {{ row.monedaSimbolo }} {{ row.montoImputado | number:'1.0-2' }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="estado">
+          <th mat-header-cell *matHeaderCellDef>Estado</th>
+          <td mat-cell *matCellDef="let row">
+            <span class="dp-estado" [class.saldado]="row._saldado">
+              {{ row._saldado ? 'Saldado' : row.estado }}
+            </span>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
+    </div>
+  </ng-container>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cerrar()">Cerrar</button>
+</mat-dialog-actions>

--- a/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.html
+++ b/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.html
@@ -1,10 +1,8 @@
-<h2 mat-dialog-title class="dp-title">
-  <mat-icon>receipt_long</mat-icon>
-  <span>Detalle del pago</span>
-  <span class="dp-sub" *ngIf="data?.descripcion">{{ data.descripcion }}</span>
-</h2>
+<div class="detalle-pago-dialog">
+  <h2 class="titulo-dialog">Detalle del pago</h2>
+  <div class="subtitulo-dialog" *ngIf="data?.descripcion">{{ data.descripcion }}</div>
 
-<mat-dialog-content class="dp-content">
+  <mat-dialog-content class="dp-content">
   <div class="dp-cargando" *ngIf="isLoading">Cargando…</div>
   <div class="dp-vacio" *ngIf="!isLoading && cantidad === 0">
     Este movimiento no tiene documentos asociados.
@@ -65,6 +63,7 @@
   </ng-container>
 </mat-dialog-content>
 
-<mat-dialog-actions align="end">
-  <button mat-button (click)="cerrar()">Cerrar</button>
-</mat-dialog-actions>
+  <mat-dialog-actions align="end" class="dp-acciones">
+    <button mat-button (click)="cerrar()">Cerrar</button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.scss
+++ b/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.scss
@@ -1,0 +1,70 @@
+// Detalle read-only del evento de pago. App siempre en dark: nada de fondos claros.
+.dp-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #ffffff;
+
+  .dp-sub {
+    margin-left: 8px;
+    font-size: 0.72em;
+    font-weight: 400;
+    color: #ffa726;              // subtítulo naranja (convención de diálogos)
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.dp-content { max-height: 60vh; }
+
+.dp-cargando,
+.dp-vacio {
+  padding: 24px 4px;
+  text-align: center;
+  opacity: 0.7;
+}
+
+.dp-resumen {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.dp-chip {
+  padding: 3px 10px;
+  border-radius: 12px;
+  background: #424242;
+  font-size: 0.8em;
+
+  &.dp-total { font-weight: 600; }
+
+  em {
+    font-style: normal;
+    opacity: 0.7;
+    font-weight: 400;
+  }
+}
+
+// La tabla puede ser ancha: scrollea dentro del diálogo, no empuja el layout.
+.dp-tabla-wrap { overflow-x: auto; }
+
+.dp-tabla {
+  width: 100%;
+  background: transparent;
+
+  th,
+  td { text-align: center; }        // centrado por default (convención del repo)
+
+  td { font-size: 0.86em; }
+}
+
+.dp-estado {
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: #5d4037;
+  font-size: 0.78em;
+
+  &.saldado { background: #2e7d32; }
+}

--- a/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.scss
+++ b/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.scss
@@ -1,22 +1,41 @@
 // Detalle read-only del evento de pago. App siempre en dark: nada de fondos claros.
-.dp-title {
+//
+// Cabecera con el patrón del resto de los diálogos del módulo (ver
+// ingresar-retiro-caja-mayor-dialog): título centrado en su línea, subtítulo naranja debajo,
+// y el cuerpo ocupando el alto restante para que las acciones queden abajo y no flotando.
+.detalle-pago-dialog {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  color: #ffffff;
-
-  .dp-sub {
-    margin-left: 8px;
-    font-size: 0.72em;
-    font-weight: 400;
-    color: #ffa726;              // subtítulo naranja (convención de diálogos)
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+  flex-direction: column;
+  height: 100%;
+  padding: 8px 16px 4px;
+  box-sizing: border-box;
 }
 
-.dp-content { max-height: 60vh; }
+.titulo-dialog {
+  text-align: center;
+  margin: 4px 0 2px;
+  font-weight: 500;
+  font-size: 20px;
+  color: #fff;
+}
+
+.subtitulo-dialog {
+  text-align: center;
+  margin: 0 0 10px;
+  font-size: 13px;
+  color: #ff9800;
+}
+
+.dp-content {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 0;
+}
+
+.dp-acciones {
+  flex: 0 0 auto;
+  padding: 4px 0 0;
+}
 
 .dp-cargando,
 .dp-vacio {

--- a/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.ts
+++ b/src/app/modules/financiero/caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component.ts
@@ -1,0 +1,111 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatTableDataSource } from '@angular/material/table';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { PagarComprasService } from '../pagar-compras-dialog/pagar-compras.service';
+
+export interface DetallePagoDialogData {
+  /** Id del evento de pago. En el movimiento viaja como referenciaId / origenId. */
+  pagoId: number;
+  /** Etiqueta del movimiento, para encabezar el detalle. */
+  descripcion?: string;
+}
+
+interface DetalleRow {
+  solicitudPagoId: number;
+  tipo: string;
+  descripcion: string;
+  proveedorNombre: string;
+  monedaSimbolo: string;
+  monedaDenominacion: string;
+  decimales: number;
+  montoImputado: number;
+  montoTotal: number;
+  montoPagado: number;
+  estado: string;
+  /** El documento quedó saldado con este pago (no arrastra saldo). */
+  _saldado: boolean;
+}
+
+/**
+ * Desglose de un evento de pago, abierto desde el movimiento de caja.
+ *
+ * <p>Un evento que paga N documentos postea <b>un</b> movimiento consolidado — que es lo
+ * contablemente correcto y lo que la anulación revierte como unidad — así que su descripción
+ * no puede nombrar a los N. Este diálogo responde esa pregunta leyendo el desglose real
+ * (`detalleDePago`), en vez de embutir una lista en el texto del movimiento.</p>
+ */
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'app-detalle-pago-dialog',
+  templateUrl: './detalle-pago-dialog.component.html',
+  styleUrls: ['./detalle-pago-dialog.component.scss']
+})
+export class DetallePagoDialogComponent implements OnInit {
+
+  displayedColumns = ['solicitud', 'tipo', 'descripcion', 'beneficiario', 'imputado', 'estado'];
+  dataSource = new MatTableDataSource<DetalleRow>([]);
+  isLoading = true;
+
+  cantidad = 0;
+  /** Total imputado por moneda: un evento puede pagar documentos en monedas distintas. */
+  totales: { simbolo: string; denominacion: string; decimales: number; total: number }[] = [];
+
+  private tipoLabels: Record<string, string> = {
+    COMPRA: 'Compra',
+    GASTO: 'Gasto',
+    RRHH: 'RRHH',
+  };
+
+  constructor(
+    private dialogRef: MatDialogRef<DetallePagoDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: DetallePagoDialogData,
+    private pagarComprasService: PagarComprasService,
+  ) {}
+
+  ngOnInit(): void {
+    this.pagarComprasService.onGetDetalleDePago(this.data.pagoId)
+      .pipe(untilDestroyed(this))
+      .subscribe(res => {
+        this.isLoading = false;
+        const filas: DetalleRow[] = (res || []).map((d: any) => this.toRow(d));
+        this.dataSource.data = filas;
+        this.cantidad = filas.length;
+        this.totales = this.agruparPorMoneda(filas);
+      });
+  }
+
+  private toRow(d: any): DetalleRow {
+    const total = d.montoTotal || 0;
+    const pagado = d.montoPagado || 0;
+    return {
+      solicitudPagoId: d.solicitudPagoId,
+      tipo: this.tipoLabels[d.tipo] || d.tipo || '—',
+      descripcion: d.descripcion || '—',
+      proveedorNombre: d.proveedorNombre || '—',
+      monedaSimbolo: d.monedaSimbolo || '',
+      monedaDenominacion: d.monedaDenominacion || '',
+      decimales: d.decimales != null ? d.decimales : 0,
+      montoImputado: d.montoImputado || 0,
+      montoTotal: total,
+      montoPagado: pagado,
+      estado: d.estado || '—',
+      _saldado: total > 0 && pagado >= total,
+    };
+  }
+
+  /** Un evento puede pagar documentos en monedas distintas: no se suman entre sí. */
+  private agruparPorMoneda(filas: DetalleRow[]) {
+    const porMoneda = new Map<string, { simbolo: string; denominacion: string; decimales: number; total: number }>();
+    filas.forEach(f => {
+      const clave = f.monedaDenominacion || '—';
+      const acc = porMoneda.get(clave)
+        || { simbolo: f.monedaSimbolo, denominacion: clave, decimales: f.decimales, total: 0 };
+      acc.total += f.montoImputado;
+      porMoneda.set(clave, acc);
+    });
+    return Array.from(porMoneda.values());
+  }
+
+  cerrar(): void { this.dialogRef.close(null); }
+}

--- a/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.html
+++ b/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.html
@@ -1,10 +1,8 @@
-<h2 mat-dialog-title class="ga-title">
-  <mat-icon>group</mat-icon>
-  <span>Accesos de la caja</span>
-  <span class="ga-sub">{{ data.cajaVirtual?.nombre }}</span>
-</h2>
+<div class="gestionar-accesos-dialog">
+  <h2 class="titulo-dialog">Accesos de la caja</h2>
+  <div class="subtitulo-dialog">{{ data.cajaVirtual?.nombre }}</div>
 
-<mat-dialog-content class="ga-content">
+  <mat-dialog-content class="ga-content">
   <p class="ga-hint">
     Solo estos usuarios pueden ver esta caja. El permiso de <strong>escritura</strong> habilita
     mover plata: ingresos, egresos, transferencias y anulaciones.
@@ -90,6 +88,7 @@
   </div>
 </mat-dialog-content>
 
-<mat-dialog-actions align="end">
-  <button mat-button (click)="cerrar()">Cerrar</button>
-</mat-dialog-actions>
+  <mat-dialog-actions align="end" class="ga-acciones">
+    <button mat-button (click)="cerrar()">Cerrar</button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.html
+++ b/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.html
@@ -1,0 +1,95 @@
+<h2 mat-dialog-title class="ga-title">
+  <mat-icon>group</mat-icon>
+  <span>Accesos de la caja</span>
+  <span class="ga-sub">{{ data.cajaVirtual?.nombre }}</span>
+</h2>
+
+<mat-dialog-content class="ga-content">
+  <p class="ga-hint">
+    Solo estos usuarios pueden ver esta caja. El permiso de <strong>escritura</strong> habilita
+    mover plata: ingresos, egresos, transferencias y anulaciones.
+  </p>
+  <p class="ga-hint ga-responsable">
+    Responsable: <strong>{{ responsableNombre }}</strong> — tiene acceso total y administra esta lista.
+  </p>
+
+  <!-- Alta -->
+  <div class="ga-alta">
+    <mat-form-field appearance="outline" class="ga-buscador" subscriptSizing="dynamic">
+      <mat-label>Agregar usuario</mat-label>
+      <input matInput [formControl]="usuarioControl" [matAutocomplete]="autoUsuario"
+             placeholder="Nombre o usuario (mín. 2 letras)">
+      <mat-autocomplete #autoUsuario="matAutocomplete" [displayWith]="displayUsuario">
+        <mat-option *ngFor="let u of usuariosFiltrados" [value]="u">
+          {{ u.persona?.nombre || '—' }} <small>({{ u.nickname }})</small>
+        </mat-option>
+      </mat-autocomplete>
+    </mat-form-field>
+
+    <mat-checkbox [(ngModel)]="nuevoPuedeEscribir" class="ga-check">Puede mover plata</mat-checkbox>
+
+    <button mat-raised-button color="primary" type="button" (click)="onAgregar()" [disabled]="isSaving">
+      <mat-icon>add</mat-icon> Agregar
+    </button>
+  </div>
+
+  <div class="ga-cargando" *ngIf="isLoading">Cargando…</div>
+  <div class="ga-vacio" *ngIf="!isLoading && dataSource.data.length === 0">
+    Nadie más tiene acceso. Solo el responsable (y un administrador) puede operar esta caja.
+  </div>
+
+  <div class="ga-tabla-wrap" *ngIf="!isLoading && dataSource.data.length > 0">
+    <table mat-table [dataSource]="dataSource" class="ga-tabla">
+      <ng-container matColumnDef="usuario">
+        <th mat-header-cell *matHeaderCellDef style="text-align: left;">Usuario</th>
+        <td mat-cell *matCellDef="let row" style="text-align: left;">
+          {{ row.nombre }} <small class="ga-nick">({{ row.nickname }})</small>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="leer">
+        <th mat-header-cell *matHeaderCellDef>Ver</th>
+        <td mat-cell *matCellDef="let row">
+          <mat-icon class="ga-si">check</mat-icon>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="escribir">
+        <th mat-header-cell *matHeaderCellDef>Mover plata</th>
+        <td mat-cell *matCellDef="let row">
+          <mat-slide-toggle [checked]="row.puedeEscribir" [disabled]="isSaving"
+                            (change)="onToggleEscritura(row, $event.checked)"></mat-slide-toggle>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="otorgadoPor">
+        <th mat-header-cell *matHeaderCellDef>Otorgado por</th>
+        <td mat-cell *matCellDef="let row">{{ row.otorgadoPor }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>Acciones</th>
+        <td mat-cell *matCellDef="let row">
+          <button mat-icon-button [matMenuTriggerFor]="menu" [disabled]="isSaving">
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #menu="matMenu">
+            <button mat-menu-item (click)="onTransferirPropiedad(row)">
+              <mat-icon>swap_horiz</mat-icon><span>Hacerlo responsable</span>
+            </button>
+            <button mat-menu-item (click)="onRevocar(row)">
+              <mat-icon>person_remove</mat-icon><span>Quitar acceso</span>
+            </button>
+          </mat-menu>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cerrar()">Cerrar</button>
+</mat-dialog-actions>

--- a/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.scss
+++ b/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.scss
@@ -1,0 +1,63 @@
+// App siempre en dark: nada de fondos claros.
+.ga-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #ffffff;
+
+  .ga-sub {
+    margin-left: 8px;
+    font-size: 0.72em;
+    font-weight: 400;
+    color: #ffa726;              // subtítulo naranja (convención de diálogos)
+  }
+}
+
+.ga-content { max-height: 60vh; }
+
+.ga-hint {
+  margin: 0 0 6px;
+  font-size: 0.82em;
+  opacity: 0.75;
+
+  &.ga-responsable { margin-bottom: 14px; }
+}
+
+.ga-alta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+
+  .ga-buscador { flex: 1 1 320px; }
+  .ga-check { flex: 0 0 auto; }
+}
+
+.ga-cargando,
+.ga-vacio {
+  padding: 20px 4px;
+  text-align: center;
+  opacity: 0.7;
+}
+
+.ga-tabla-wrap { overflow-x: auto; }
+
+.ga-tabla {
+  width: 100%;
+  background: transparent;
+
+  th,
+  td { text-align: center; }        // centrado por default (convención del repo)
+
+  td { font-size: 0.86em; }
+}
+
+.ga-nick { opacity: 0.6; }
+
+.ga-si {
+  color: #81c784;
+  font-size: 18px;
+  height: 18px;
+  width: 18px;
+}

--- a/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.scss
+++ b/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.scss
@@ -1,19 +1,41 @@
 // App siempre en dark: nada de fondos claros.
-.ga-title {
+//
+// Cabecera con el patrón del resto de los diálogos del módulo (ver
+// ingresar-retiro-caja-mayor-dialog): título centrado en su línea, subtítulo naranja debajo,
+// y el cuerpo ocupando el alto restante para que las acciones queden abajo y no flotando.
+.gestionar-accesos-dialog {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  color: #ffffff;
-
-  .ga-sub {
-    margin-left: 8px;
-    font-size: 0.72em;
-    font-weight: 400;
-    color: #ffa726;              // subtítulo naranja (convención de diálogos)
-  }
+  flex-direction: column;
+  height: 100%;
+  padding: 8px 16px 4px;
+  box-sizing: border-box;
 }
 
-.ga-content { max-height: 60vh; }
+.titulo-dialog {
+  text-align: center;
+  margin: 4px 0 2px;
+  font-weight: 500;
+  font-size: 20px;
+  color: #fff;
+}
+
+.subtitulo-dialog {
+  text-align: center;
+  margin: 0 0 10px;
+  font-size: 13px;
+  color: #ff9800;
+}
+
+.ga-content {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 0;
+}
+
+.ga-acciones {
+  flex: 0 0 auto;
+  padding: 4px 0 0;
+}
 
 .ga-hint {
   margin: 0 0 6px;

--- a/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.ts
+++ b/src/app/modules/financiero/caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component.ts
@@ -1,0 +1,204 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatTableDataSource } from '@angular/material/table';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { CajaVirtual } from '../caja-virtual.model';
+import { CajaVirtualService } from '../caja-virtual.service';
+import { UsuarioService } from '../../../personas/usuarios/usuario.service';
+import { Usuario } from '../../../personas/usuarios/usuario.model';
+import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
+import { NotificacionSnackbarService, NotificacionColor } from '../../../../notificacion-snackbar.service';
+
+export interface GestionarAccesosCajaData {
+  cajaVirtual: CajaVirtual;
+}
+
+interface AccesoRow {
+  id: number;
+  usuarioId: number;
+  nickname: string;
+  nombre: string;
+  puedeLeer: boolean;
+  puedeEscribir: boolean;
+  otorgadoPor: string;
+}
+
+/**
+ * Lista de usuarios habilitados en una caja.
+ *
+ * <p>El rol de tesorería habilita la capacidad (ver / mover plata); esta lista delimita sobre
+ * qué cajas. El responsable de la caja no figura acá: tiene acceso total implícito y es quien
+ * administra la lista — por eso el diálogo solo se le ofrece a él (y a un ADMIN). El backend
+ * lo verifica igual; esconder la opción es comodidad, no seguridad.</p>
+ */
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'app-gestionar-accesos-caja-dialog',
+  templateUrl: './gestionar-accesos-caja-dialog.component.html',
+  styleUrls: ['./gestionar-accesos-caja-dialog.component.scss']
+})
+export class GestionarAccesosCajaDialogComponent implements OnInit {
+
+  displayedColumns = ['usuario', 'leer', 'escribir', 'otorgadoPor', 'acciones'];
+  dataSource = new MatTableDataSource<AccesoRow>([]);
+  isLoading = true;
+  isSaving = false;
+
+  /** Alta: buscador de usuario + los dos permisos. */
+  usuarioControl = new FormControl(null);
+  usuariosFiltrados: Usuario[] = [];
+  nuevoPuedeEscribir = false;
+
+  responsableNombre = '';
+
+  displayUsuario = (u: Usuario): string =>
+    u ? (u.persona?.nombre ? `${u.persona.nombre} (${u.nickname})` : u.nickname) : '';
+
+  constructor(
+    private dialogRef: MatDialogRef<GestionarAccesosCajaDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: GestionarAccesosCajaData,
+    private cajaVirtualService: CajaVirtualService,
+    private usuarioService: UsuarioService,
+    private dialogos: DialogosService,
+    private notificacion: NotificacionSnackbarService,
+  ) {}
+
+  ngOnInit(): void {
+    const resp = this.data.cajaVirtual?.usuario;
+    this.responsableNombre = resp
+      ? (resp.persona?.nombre ? `${resp.persona.nombre} (${resp.nickname})` : resp.nickname)
+      : '—';
+
+    this.usuarioControl.valueChanges.pipe(untilDestroyed(this)).subscribe(val => {
+      if (typeof val === 'string' && val.trim().length >= 2) {
+        this.usuarioService.onSearchUsuarioPaginated(val.trim(), 0, 10)
+          .pipe(untilDestroyed(this))
+          .subscribe(r => this.usuariosFiltrados = (r?.getContent as Usuario[]) || []);
+      } else if (typeof val !== 'string') {
+        this.usuariosFiltrados = [];
+      }
+    });
+
+    this.cargar();
+  }
+
+  cargar(): void {
+    this.isLoading = true;
+    this.cajaVirtualService.onGetAccesos(this.data.cajaVirtual.id)
+      .pipe(untilDestroyed(this))
+      .subscribe(res => {
+        this.isLoading = false;
+        this.dataSource.data = (res || []).map((a: any) => ({
+          id: a.id,
+          usuarioId: a.usuario?.id,
+          nickname: a.usuario?.nickname || '—',
+          nombre: a.usuario?.persona?.nombre || '—',
+          puedeLeer: !!a.puedeLeer,
+          puedeEscribir: !!a.puedeEscribir,
+          otorgadoPor: a.otorgadoPor?.nickname || '—',
+        } as AccesoRow));
+      });
+  }
+
+  /** Alta desde el buscador. El backend rechaza otorgarle acceso al propio responsable. */
+  onAgregar(): void {
+    const u: any = this.usuarioControl.value;
+    if (!u || typeof u === 'string' || !u.id) {
+      return this.err('Elegí un usuario de la lista');
+    }
+    this.guardar(u.id, true, this.nuevoPuedeEscribir, () => {
+      this.usuarioControl.setValue(null);
+      this.usuariosFiltrados = [];
+      this.nuevoPuedeEscribir = false;
+    });
+  }
+
+  /**
+   * Cambia el permiso de escritura de una fila existente.
+   *
+   * La lectura no se puede apagar: un acceso sin lectura no sirve para nada, y el camino para
+   * sacarle el acceso a alguien es revocarlo — que además borra la fila en vez de dejar una
+   * inerte.
+   */
+  onToggleEscritura(row: AccesoRow, valor: boolean): void {
+    this.guardar(row.usuarioId, true, valor);
+  }
+
+  private guardar(usuarioId: number, puedeLeer: boolean, puedeEscribir: boolean, luego?: () => void): void {
+    this.isSaving = true;
+    this.cajaVirtualService.onOtorgarAcceso(this.data.cajaVirtual.id, usuarioId, puedeLeer, puedeEscribir)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: res => {
+          this.isSaving = false;
+          if (res != null) {
+            this.ok('Acceso actualizado');
+            if (luego) luego();
+            this.cargar();
+          }
+        },
+        error: e => { this.isSaving = false; this.err(this.mensaje(e)); },
+      });
+  }
+
+  onRevocar(row: AccesoRow): void {
+    this.dialogos.confirm(
+      'Quitar acceso',
+      `¿Quitarle el acceso a ${row.nombre} sobre esta caja?`,
+      row.puedeEscribir ? 'Hoy puede mover plata en la caja.' : null,
+      null, true, 'Sí, quitar', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(r => {
+      if (r !== true) return;
+      this.isSaving = true;
+      this.cajaVirtualService.onRevocarAcceso(this.data.cajaVirtual.id, row.usuarioId)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: () => { this.isSaving = false; this.ok('Acceso quitado'); this.cargar(); },
+          error: e => { this.isSaving = false; this.err(this.mensaje(e)); },
+        });
+    });
+  }
+
+  /**
+   * Pasa la caja a otro responsable. Es lo que evita que quede huérfana cuando su responsable
+   * deja la empresa: sin dueño, nadie puede administrar la lista.
+   */
+  onTransferirPropiedad(row: AccesoRow): void {
+    this.dialogos.confirm(
+      'Transferir responsabilidad',
+      `¿Pasar la caja a ${row.nombre}?`,
+      'Va a poder administrar los accesos, y vos dejás de poder hacerlo.',
+      null, true, 'Sí, transferir', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(r => {
+      if (r !== true) return;
+      this.isSaving = true;
+      this.cajaVirtualService.onTransferirPropiedad(this.data.cajaVirtual.id, row.usuarioId)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: res => {
+            this.isSaving = false;
+            if (res != null) {
+              this.ok('Responsable actualizado');
+              this.dialogRef.close(true);
+            }
+          },
+          error: e => { this.isSaving = false; this.err(this.mensaje(e)); },
+        });
+    });
+  }
+
+  private mensaje(e: any): string {
+    return e?.graphQLErrors?.[0]?.message || e?.message || 'No se pudo completar la operación';
+  }
+
+  private ok(texto: string): void {
+    this.notificacion.notification$.next({ texto, color: NotificacionColor.success, duracion: 3 });
+  }
+
+  private err(texto: string): void {
+    this.notificacion.notification$.next({ texto, color: NotificacionColor.warn, duracion: 5 });
+  }
+
+  cerrar(): void { this.dialogRef.close(null); }
+}

--- a/src/app/modules/financiero/caja-virtual/graphql/cajaVirtualAccesos.ts
+++ b/src/app/modules/financiero/caja-virtual/graphql/cajaVirtualAccesos.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { cajaVirtualAccesosQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class CajaVirtualAccesosGQL extends Query<Response> {
+  document = cajaVirtualAccesosQuery;
+}

--- a/src/app/modules/financiero/caja-virtual/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/caja-virtual/graphql/graphql-query.ts
@@ -172,6 +172,7 @@ const movimientoFields = `
   }
   referenciaId
   origenTipo
+  esPagoConsolidado
   descripcion
   usuario {
     id

--- a/src/app/modules/financiero/caja-virtual/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/caja-virtual/graphql/graphql-query.ts
@@ -277,3 +277,49 @@ export const realizarTransferenciaQuery = gql`
     )
   }
 `;
+
+// ── Acceso por caja (ACL) ──
+// El rol habilita la capacidad, estas filas delimitan sobre que cajas. El responsable de la
+// caja tiene acceso total implicito y NO aparece en la lista: es quien la administra.
+export const cajaVirtualAccesosQuery = gql`
+  query ($cajaVirtualId: ID!) {
+    data: cajaVirtualAccesos(cajaVirtualId: $cajaVirtualId) {
+      id
+      puedeLeer
+      puedeEscribir
+      creadoEn
+      usuario { id nickname persona { id nombre } }
+      otorgadoPor { id nickname }
+    }
+  }
+`;
+
+export const otorgarAccesoCajaMutation = gql`
+  mutation ($cajaVirtualId: ID!, $usuarioId: ID!, $puedeLeer: Boolean, $puedeEscribir: Boolean) {
+    data: otorgarAccesoCaja(
+      cajaVirtualId: $cajaVirtualId, usuarioId: $usuarioId,
+      puedeLeer: $puedeLeer, puedeEscribir: $puedeEscribir
+    ) {
+      id
+      puedeLeer
+      puedeEscribir
+      usuario { id nickname persona { id nombre } }
+    }
+  }
+`;
+
+export const revocarAccesoCajaMutation = gql`
+  mutation ($cajaVirtualId: ID!, $usuarioId: ID!) {
+    data: revocarAccesoCaja(cajaVirtualId: $cajaVirtualId, usuarioId: $usuarioId)
+  }
+`;
+
+export const transferirPropiedadCajaMutation = gql`
+  mutation ($cajaVirtualId: ID!, $nuevoPropietarioId: ID!) {
+    data: transferirPropiedadCaja(cajaVirtualId: $cajaVirtualId, nuevoPropietarioId: $nuevoPropietarioId) {
+      id
+      nombre
+      usuario { id nickname persona { id nombre } }
+    }
+  }
+`;

--- a/src/app/modules/financiero/caja-virtual/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/caja-virtual/graphql/graphql-query.ts
@@ -17,6 +17,7 @@ const cajaVirtualFields = `
   }
   usuario {
     id
+    nickname
     persona {
       id
       nombre
@@ -174,6 +175,7 @@ const movimientoFields = `
   descripcion
   usuario {
     id
+    nickname
     persona {
       id
       nombre

--- a/src/app/modules/financiero/caja-virtual/graphql/otorgarAccesoCaja.ts
+++ b/src/app/modules/financiero/caja-virtual/graphql/otorgarAccesoCaja.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { otorgarAccesoCajaMutation } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class OtorgarAccesoCajaGQL extends Mutation<Response> {
+  document = otorgarAccesoCajaMutation;
+}

--- a/src/app/modules/financiero/caja-virtual/graphql/revocarAccesoCaja.ts
+++ b/src/app/modules/financiero/caja-virtual/graphql/revocarAccesoCaja.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { revocarAccesoCajaMutation } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class RevocarAccesoCajaGQL extends Mutation<Response> {
+  document = revocarAccesoCajaMutation;
+}

--- a/src/app/modules/financiero/caja-virtual/graphql/transferirPropiedadCaja.ts
+++ b/src/app/modules/financiero/caja-virtual/graphql/transferirPropiedadCaja.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { transferirPropiedadCajaMutation } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class TransferirPropiedadCajaGQL extends Mutation<Response> {
+  document = transferirPropiedadCajaMutation;
+}

--- a/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.html
+++ b/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.html
@@ -110,7 +110,7 @@
             [style.color]="tipoColores[row.tipoMovimiento] || '#ffffff'"
             style="font-weight: 600; font-size: 0.8em;"
           >
-            {{ label(row) }}
+            {{ row._label }}
           </span>
         </td>
       </ng-container>

--- a/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.html
+++ b/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.html
@@ -110,7 +110,7 @@
             [style.color]="tipoColores[row.tipoMovimiento] || '#ffffff'"
             style="font-weight: 600; font-size: 0.8em;"
           >
-            {{ tipoMovimientoLabels[row.tipoMovimiento] || row.tipoMovimiento }}
+            {{ label(row) }}
           </span>
         </td>
       </ng-container>

--- a/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.ts
+++ b/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.ts
@@ -4,6 +4,11 @@ import { MatTableDataSource } from '@angular/material/table';
 import { PageEvent } from '@angular/material/paginator';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { CajaVirtual, MovimientoCajaVirtual, labelMovimiento } from '../caja-virtual.model';
+
+/** Fila con el concepto ya resuelto (no se calcula en el template). */
+interface MovimientoRow extends MovimientoCajaVirtual {
+  _label?: string;
+}
 import { CajaVirtualService } from '../caja-virtual.service';
 import { PageInfo } from '../../../../app.component';
 import { FormControl, FormGroup } from '@angular/forms';
@@ -16,7 +21,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 })
 export class HistorialMovimientosCajaVirtualComponent implements OnInit {
 
-  dataSource = new MatTableDataSource<MovimientoCajaVirtual>([]);
+  dataSource = new MatTableDataSource<MovimientoRow>([]);
   isSearching = false;
   pageIndex = 0;
   pageSize = 20;
@@ -56,11 +61,6 @@ export class HistorialMovimientosCajaVirtualComponent implements OnInit {
     AJUSTE: '#607d8b',
   };
 
-  /** Concepto real del movimiento: sale del origen, no del tipo grueso (ver caja-virtual.model). */
-  label(row: MovimientoCajaVirtual): string {
-    return labelMovimiento(row?.origenTipo, row?.tipoMovimiento, this.tipoMovimientoLabels);
-  }
-
   constructor(
     @Inject(MAT_DIALOG_DATA) public cajaVirtual: CajaVirtual,
     private cajaVirtualService: CajaVirtualService
@@ -94,7 +94,13 @@ export class HistorialMovimientosCajaVirtualComponent implements OnInit {
     this.isSearching = false;
     if (res != null) {
       this.selectedPageInfo = res;
-      this.dataSource.data = res.getContent;
+      // Concepto real del movimiento, precomputado: sale del origen y no del tipo grueso
+      // (ver caja-virtual.model). Se resuelve acá y no en el template para no recalcularlo
+      // en cada ciclo de change detection.
+      this.dataSource.data = (res.getContent || []).map(m => {
+        (m as MovimientoRow)._label = labelMovimiento(m.origenTipo, m.tipoMovimiento, this.tipoMovimientoLabels);
+        return m as MovimientoRow;
+      });
     }
   }
 

--- a/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.ts
+++ b/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.ts
@@ -3,7 +3,7 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { PageEvent } from '@angular/material/paginator';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { CajaVirtual, MovimientoCajaVirtual } from '../caja-virtual.model';
+import { CajaVirtual, MovimientoCajaVirtual, labelMovimiento } from '../caja-virtual.model';
 import { CajaVirtualService } from '../caja-virtual.service';
 import { PageInfo } from '../../../../app.component';
 import { FormControl, FormGroup } from '@angular/forms';
@@ -55,6 +55,11 @@ export class HistorialMovimientosCajaVirtualComponent implements OnInit {
     PAGO_PROVEEDOR: '#9c27b0',
     AJUSTE: '#607d8b',
   };
+
+  /** Concepto real del movimiento: sale del origen, no del tipo grueso (ver caja-virtual.model). */
+  label(row: MovimientoCajaVirtual): string {
+    return labelMovimiento(row?.origenTipo, row?.tipoMovimiento, this.tipoMovimientoLabels);
+  }
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public cajaVirtual: CajaVirtual,

--- a/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.ts
+++ b/src/app/modules/financiero/caja-virtual/historial-movimientos-caja-virtual/historial-movimientos-caja-virtual.component.ts
@@ -4,14 +4,14 @@ import { MatTableDataSource } from '@angular/material/table';
 import { PageEvent } from '@angular/material/paginator';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { CajaVirtual, MovimientoCajaVirtual, labelMovimiento } from '../caja-virtual.model';
+import { CajaVirtualService } from '../caja-virtual.service';
+import { PageInfo } from '../../../../app.component';
+import { FormControl, FormGroup } from '@angular/forms';
 
 /** Fila con el concepto ya resuelto (no se calcula en el template). */
 interface MovimientoRow extends MovimientoCajaVirtual {
   _label?: string;
 }
-import { CajaVirtualService } from '../caja-virtual.service';
-import { PageInfo } from '../../../../app.component';
-import { FormControl, FormGroup } from '@angular/forms';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -97,10 +97,12 @@ export class HistorialMovimientosCajaVirtualComponent implements OnInit {
       // Concepto real del movimiento, precomputado: sale del origen y no del tipo grueso
       // (ver caja-virtual.model). Se resuelve acá y no en el template para no recalcularlo
       // en cada ciclo de change detection.
-      this.dataSource.data = (res.getContent || []).map(m => {
-        (m as MovimientoRow)._label = labelMovimiento(m.origenTipo, m.tipoMovimiento, this.tipoMovimientoLabels);
-        return m as MovimientoRow;
-      });
+      // Clonar antes de agregar props de display: Apollo congela los resultados y en dev
+      // asignar sobre el objeto devuelto tira TypeError.
+      this.dataSource.data = (res.getContent || []).map(m => ({
+        ...m,
+        _label: labelMovimiento(m.origenTipo, m.tipoMovimiento, this.tipoMovimientoLabels),
+      } as MovimientoRow));
     }
   }
 

--- a/src/app/modules/financiero/caja-virtual/list-caja-virtual/list-caja-virtual.component.html
+++ b/src/app/modules/financiero/caja-virtual/list-caja-virtual/list-caja-virtual.component.html
@@ -109,6 +109,9 @@
             <button mat-menu-item (click)="onHistorial(row)">
               <mat-icon>history</mat-icon><span>Historial de movimientos</span>
             </button>
+            <button mat-menu-item (click)="onGestionarAccesos(row)" *ngIf="row._puedeAdminAccesos">
+              <mat-icon>group</mat-icon><span>Gestionar accesos</span>
+            </button>
             <button mat-menu-item (click)="onEdit(row)" [disabled]="!puedeGestionar">
               <mat-icon>edit</mat-icon><span>Editar</span>
             </button>

--- a/src/app/modules/financiero/caja-virtual/list-caja-virtual/list-caja-virtual.component.ts
+++ b/src/app/modules/financiero/caja-virtual/list-caja-virtual/list-caja-virtual.component.ts
@@ -134,8 +134,11 @@ export class ListCajaVirtualComponent implements OnInit {
    */
   private marcarAdminAccesos(rows: any[]): any[] {
     const yo = this.mainService.usuarioActual?.id;
-    (rows || []).forEach(r => r._puedeAdminAccesos = this.esAdmin || (!!yo && r?.usuario?.id === yo));
-    return rows || [];
+    // Clonar: Apollo congela los resultados y asignar props sobre ellos tira TypeError en dev.
+    return (rows || []).map(r => ({
+      ...r,
+      _puedeAdminAccesos: this.esAdmin || (!!yo && r?.usuario?.id === yo),
+    }));
   }
 
   onGestionarAccesos(item: CajaVirtual) {

--- a/src/app/modules/financiero/caja-virtual/list-caja-virtual/list-caja-virtual.component.ts
+++ b/src/app/modules/financiero/caja-virtual/list-caja-virtual/list-caja-virtual.component.ts
@@ -16,6 +16,7 @@ import { TabService, TabData } from '../../../../layouts/tab/tab.service';
 import { CajaVirtualDashboardComponent } from '../caja-virtual-dashboard/caja-virtual-dashboard.component';
 import { MainService } from '../../../../main.service';
 import { ROLES } from '../../../personas/roles/roles.enum';
+import { GestionarAccesosCajaDialogComponent, GestionarAccesosCajaData } from '../gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component';
 import { SucursalService } from '../../../empresarial/sucursal/sucursal.service';
 import { Sucursal } from '../../../empresarial/sucursal/sucursal.model';
 
@@ -67,6 +68,7 @@ export class ListCajaVirtualComponent implements OnInit {
   activoControl = new FormControl();
 
   puedeGestionar = false;
+  esAdmin = false;
 
   constructor(
     private cajaVirtualService: CajaVirtualService,
@@ -80,6 +82,7 @@ export class ListCajaVirtualComponent implements OnInit {
 
   ngOnInit(): void {
     this.puedeGestionar = this.mainService.tieneAlgunRol([ROLES.TESORERIA_GESTIONAR]);
+    this.esAdmin = this.mainService.tieneAlgunRol([ROLES.ADMIN]);
     this.sucursalService.onGetAllSucursales().pipe(untilDestroyed(this)).subscribe(res => {
       if (res) this.sucursalList = res;
     });
@@ -99,7 +102,7 @@ export class ListCajaVirtualComponent implements OnInit {
         this.isSearching = false;
         if (res != null) {
           this.selectedPageInfo = res;
-          this.dataSource.data = res.getContent;
+          this.dataSource.data = this.marcarAdminAccesos(res.getContent);
         }
       });
   }
@@ -118,6 +121,29 @@ export class ListCajaVirtualComponent implements OnInit {
       width: '500px',
       data: null
     }).afterClosed().subscribe(res => {
+      if (res != null) this.onFiltrar();
+    });
+  }
+
+  /**
+   * Administrar la lista de accesos: solo el responsable de la caja (quien la creó) o un
+   * ADMIN. El backend lo verifica igual — esconder la opción es comodidad, no seguridad.
+   *
+   * Se resuelve al cargar y no en el template: llamar funciones desde el HTML las re-evalúa
+   * en cada ciclo de change detection.
+   */
+  private marcarAdminAccesos(rows: any[]): any[] {
+    const yo = this.mainService.usuarioActual?.id;
+    (rows || []).forEach(r => r._puedeAdminAccesos = this.esAdmin || (!!yo && r?.usuario?.id === yo));
+    return rows || [];
+  }
+
+  onGestionarAccesos(item: CajaVirtual) {
+    const data: GestionarAccesosCajaData = { cajaVirtual: item };
+    this.dialog.open(GestionarAccesosCajaDialogComponent, {
+      width: '65vw', maxWidth: '95vw', height: '70vh', data
+    }).afterClosed().subscribe(res => {
+      // La transferencia de responsabilidad cambia quién puede administrar: recargar.
       if (res != null) this.onFiltrar();
     });
   }

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/aguinaldosPendientesPago.ts
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/aguinaldosPendientesPago.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { aguinaldosPendientesPagoQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class AguinaldosPendientesPagoGQL extends Query<Response> {
+  document = aguinaldosPendientesPagoQuery;
+}

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/detalleDePago.ts
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/detalleDePago.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { detalleDePagoQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class DetalleDePagoGQL extends Query<Response> {
+  document = detalleDePagoQuery;
+}

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/finiquitosPendientesPago.ts
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/finiquitosPendientesPago.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { finiquitosPendientesPagoQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class FiniquitosPendientesPagoGQL extends Query<Response> {
+  document = finiquitosPendientesPagoQuery;
+}

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/graphql-query.ts
@@ -142,3 +142,66 @@ export const pagarValesMixtoMutation = gql`
     }
   }
 `;
+
+// ── Pago de documentos de RRHH desde la caja (liquidacion / finiquito / aguinaldo) ──
+// Mismo puente que el vale: la obligacion de pago es una SolicitudPago tipo RRHH y el
+// pago va por el motor de CPP. Los tres conceptos comparten proyeccion.
+const pagoRrhhPendienteFields = `
+  concepto
+  id
+  fecha
+  periodo
+  monto
+  saldoPendiente
+  descripcion
+  funcionarioNombre
+  funcionario { id persona { id nombre } }
+  moneda { id denominacion simbolo principal decimales }
+`;
+
+export const liquidacionesPendientesPagoQuery = gql`
+  query {
+    data: liquidacionesPendientesPago { ${pagoRrhhPendienteFields} }
+  }
+`;
+
+export const finiquitosPendientesPagoQuery = gql`
+  query {
+    data: finiquitosPendientesPago { ${pagoRrhhPendienteFields} }
+  }
+`;
+
+export const aguinaldosPendientesPagoQuery = gql`
+  query {
+    data: aguinaldosPendientesPago { ${pagoRrhhPendienteFields} }
+  }
+`;
+
+export const pagarRrhhMixtoMutation = gql`
+  mutation ($pagos: [PagoRrhhConLineasInput!]!) {
+    data: pagarRrhhMixto(pagos: $pagos) {
+      id
+      estado
+    }
+  }
+`;
+
+// Desglose de un evento de pago: que documentos se pagaron y cuanto se imputo a cada uno.
+// Lo necesita el detalle del movimiento consolidado, cuya descripcion no puede nombrar a los N.
+export const detalleDePagoQuery = gql`
+  query ($pagoId: ID!) {
+    data: detalleDePago(pagoId: $pagoId) {
+      solicitudPagoId
+      tipo
+      descripcion
+      proveedorNombre
+      monedaDenominacion
+      monedaSimbolo
+      decimales
+      montoImputado
+      montoTotal
+      montoPagado
+      estado
+    }
+  }
+`;

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/liquidacionesPendientesPago.ts
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/liquidacionesPendientesPago.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { liquidacionesPendientesPagoQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class LiquidacionesPendientesPagoGQL extends Query<Response> {
+  document = liquidacionesPendientesPagoQuery;
+}

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/pagarRrhhMixto.ts
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/graphql/pagarRrhhMixto.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { pagarRrhhMixtoMutation } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class PagarRrhhMixtoGQL extends Mutation<Response> {
+  document = pagarRrhhMixtoMutation;
+}

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras-dialog.component.html
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras-dialog.component.html
@@ -110,10 +110,10 @@
 
     <!-- ═══ PASO 1: NOTAS ═══ -->
     <mat-step [completed]="haySeleccion">
-      <ng-template matStepLabel>{{ esVale ? 'Seleccionar vales' : 'Seleccionar notas' }}</ng-template>
+      <ng-template matStepLabel>{{ esRrhh ? 'Seleccionar documento' : (esVale ? 'Seleccionar vales' : 'Seleccionar notas') }}</ng-template>
       <div class="paso">
         <!-- Compras: filtro por proveedor -->
-        <mat-form-field *ngIf="!esGasto && !esVale" appearance="outline" class="filtro-prov" subscriptSizing="dynamic">
+        <mat-form-field *ngIf="!esGasto && !esVale && !esRrhh" appearance="outline" class="filtro-prov" subscriptSizing="dynamic">
           <mat-label>Filtrar por proveedor</mat-label>
           <input matInput [formControl]="filtroProveedorControl" placeholder="Nombre del proveedor" />
           <mat-icon matSuffix>search</mat-icon>
@@ -161,7 +161,7 @@
           </button>
         </div>
 
-        <div class="hint" *ngIf="proveedorNombreSel && !esGasto && !esVale">
+        <div class="hint" *ngIf="proveedorNombreSel && !esGasto && !esVale && !esRrhh">
           <mat-icon>info</mat-icon> Solo se pueden sumar notas de <strong>{{ proveedorNombreSel }}</strong> en {{ monedaDeuda?.denominacion }}.
         </div>
 
@@ -201,6 +201,13 @@
                 <span class="chip-bloqueado" *ngIf="row._bloqueado" [title]="row._bloqueoMotivo">sin moneda</span>
               </td>
             </ng-container>
+            <ng-container matColumnDef="periodo">
+              <th mat-header-cell *matHeaderCellDef style="text-align: center;">Período</th>
+              <td mat-cell *matCellDef="let row" style="text-align: center;" [class.dim]="row._disabled">
+                {{ row._categoria || '—' }}
+                <span class="chip-bloqueado" *ngIf="row._bloqueado" [title]="row._bloqueoMotivo">sin saldo</span>
+              </td>
+            </ng-container>
             <ng-container matColumnDef="numero">
               <th mat-header-cell *matHeaderCellDef style="text-align: center;">Solicitud</th>
               <td mat-cell *matCellDef="let row" style="text-align: center;" [class.dim]="row._disabled">{{ row.numeroSolicitud }}</td>
@@ -225,16 +232,17 @@
             <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
           </table>
           <div class="vacio" *ngIf="!isLoading && dataSource.data.length === 0">
-            <ng-container *ngIf="esVale">No hay vales pendientes de pago. Creá uno con "Nuevo Vale".</ng-container>
+            <ng-container *ngIf="esVale && !esRrhh">No hay vales pendientes de pago. Creá uno con "Nuevo Vale".</ng-container>
             <ng-container *ngIf="esGasto">No hay gastos pendientes. Creá uno con "Nuevo gasto".</ng-container>
-            <ng-container *ngIf="!esVale && !esGasto">No hay solicitudes de pago pendientes.</ng-container>
+            <ng-container *ngIf="esRrhh">No hay {{ tituloPlural }} pendientes de pago. Se aprueban desde RRHH.</ng-container>
+            <ng-container *ngIf="!esVale && !esGasto && !esRrhh">No hay solicitudes de pago pendientes.</ng-container>
           </div>
         </div>
 
         <div class="tabla-footer">
           <div class="mini-cards" *ngIf="haySeleccion">
             <div class="mini-card">
-              <span class="mc-label">{{ esVale ? 'Vales' : 'Notas' }}</span>
+              <span class="mc-label">{{ esRrhh ? tituloPlural : (esVale ? 'Vales' : 'Notas') }}</span>
               <strong class="mc-valor">{{ cantidadNotas }}</strong>
             </div>
             <div class="mini-card">
@@ -432,11 +440,11 @@
       <ng-template matStepLabel>Revisar y confirmar</ng-template>
       <div class="paso revisar">
         <div class="rev-card">
-          <div class="rev-titulo">{{ esVale ? 'Funcionario' : (esGasto ? 'Beneficiario' : 'Proveedor') }}</div>
+          <div class="rev-titulo">{{ (esVale || esRrhh) ? 'Funcionario' : (esGasto ? 'Beneficiario' : 'Proveedor') }}</div>
           <div class="rev-valor">{{ proveedorNombreSel }}</div>
         </div>
         <div class="rev-card">
-          <div class="rev-titulo">{{ esVale ? 'Vales' : 'Notas' }} ({{ monedaDeuda?.denominacion }})</div>
+          <div class="rev-titulo">{{ esRrhh ? tituloPlural : (esVale ? 'Vales' : 'Notas') }} ({{ monedaDeuda?.denominacion }})</div>
           <div class="rev-linea" *ngFor="let r of todas">
             <ng-container *ngIf="r._sel">
               <span>{{ r.numeroSolicitud }}</span>

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras-dialog.component.html
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras-dialog.component.html
@@ -161,6 +161,18 @@
           </button>
         </div>
 
+        <!-- RRHH: filtros de la tabla. No hay alta: el documento nace aprobado en RRHH. -->
+        <div *ngIf="esRrhh" class="gasto-filtros" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
+          <mat-form-field appearance="outline" fxFlex="0 0 80px" subscriptSizing="dynamic">
+            <mat-label>N°</mat-label>
+            <input matInput [formControl]="filtroIdControl" placeholder="Id" />
+          </mat-form-field>
+          <mat-form-field appearance="outline" fxFlex="1 1 0" subscriptSizing="dynamic">
+            <mat-label>Funcionario</mat-label>
+            <input matInput [formControl]="filtroProveedorControl" placeholder="Nombre del funcionario" />
+          </mat-form-field>
+        </div>
+
         <div class="hint" *ngIf="proveedorNombreSel && !esGasto && !esVale && !esRrhh">
           <mat-icon>info</mat-icon> Solo se pueden sumar notas de <strong>{{ proveedorNombreSel }}</strong> en {{ monedaDeuda?.denominacion }}.
         </div>

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras-dialog.component.ts
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras-dialog.component.ts
@@ -175,15 +175,12 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
   /** Los modos de RRHH pagan de a uno: tildar una fila destilda las demas. */
   seleccionSimple = false;
 
-  /** Plural del concepto, para los textos de la tabla vacia y del resumen. */
-  get tituloPlural(): string {
-    switch (this.conceptoRrhh) {
-      case 'LIQUIDACION': return 'liquidaciones';
-      case 'FINIQUITO':   return 'finiquitos';
-      case 'AGUINALDO':   return 'aguinaldos';
-      default:            return 'documentos';
-    }
-  }
+  /**
+   * Plural del concepto, para los textos de la tabla vacía y del resumen. Es un campo y no
+   * un getter porque se usa en el template: un getter se re-evalúa en cada ciclo de change
+   * detection. Se resuelve una vez en ngOnInit, con el modo.
+   */
+  tituloPlural = 'documentos';
 
   // ── Modo VALES (mismo builder; fuente = valesPendientes + alta de vale) ──
   // La unidad pagable es el vale de RRHH: el backend le resuelve su obligación de pago.
@@ -249,6 +246,8 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
       this.montoEditable = false;
       this.titulo = this.conceptoRrhh === 'LIQUIDACION' ? 'Pagar Liquidación'
         : this.conceptoRrhh === 'FINIQUITO' ? 'Pagar Finiquito' : 'Pagar Aguinaldo';
+      this.tituloPlural = this.conceptoRrhh === 'LIQUIDACION' ? 'liquidaciones'
+        : this.conceptoRrhh === 'FINIQUITO' ? 'finiquitos' : 'aguinaldos';
       this.displayedColumns = ['sel', 'id', 'funcionario', 'periodo', 'descripcion', 'saldo', 'montoAPagar'];
       // Filtros de la tabla: N° / Funcionario (client-side sobre lo cargado).
       this.filtroIdControl.valueChanges.pipe(untilDestroyed(this)).subscribe(() => this.aplicarFiltro());

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras-dialog.component.ts
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras-dialog.component.ts
@@ -23,11 +23,16 @@ import { Proveedor } from '../../../personas/proveedor/proveedor.model';
 import { Funcionario } from '../../../personas/funcionarios/funcionario.model';
 import { FuncionarioService } from '../../../personas/funcionarios/funcionario.service';
 import { MotivoValeService } from '../../../rrhh/motivo-vale/motivo-vale.service';
+import { ConceptoRrhh, PagoRrhhConLineas } from './pagar-compras.service';
 
 export interface PagarComprasDialogData {
   cajaVirtual: CajaVirtual;
-  // GASTOS y VALES reusan el mismo builder de pago; default COMPRAS.
-  modo?: 'COMPRAS' | 'GASTOS' | 'VALES';
+  // Todos los modos reusan el mismo builder de pago; default COMPRAS.
+  //
+  // Cardinalidad: COMPRAS/GASTOS/VALES seleccionan varios documentos (carrito); los tres
+  // modos de RRHH seleccionan uno solo — la nomina no se paga en una sola operacion, cada
+  // liquidacion/finiquito/aguinaldo se paga por separado.
+  modo?: 'COMPRAS' | 'GASTOS' | 'VALES' | 'LIQUIDACION' | 'FINIQUITO' | 'AGUINALDO';
 }
 
 /** Un cheque del plan de una solicitud (forma de pago CHEQUE ya registrada). */
@@ -162,6 +167,24 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
   vistaNuevoGasto = false;       // true = oculta el stepper y muestra solo el form de gasto
   creandoGasto = false;
 
+  // ── Modos de RRHH: LIQUIDACION / FINIQUITO / AGUINALDO ──
+  // Mismo builder y mismo puente que el vale (la obligacion de pago es una SolicitudPago
+  // tipo RRHH), pero el documento no se puede crear desde la caja: nace en RRHH, aprobado.
+  esRrhh = false;
+  conceptoRrhh: ConceptoRrhh | null = null;
+  /** Los modos de RRHH pagan de a uno: tildar una fila destilda las demas. */
+  seleccionSimple = false;
+
+  /** Plural del concepto, para los textos de la tabla vacia y del resumen. */
+  get tituloPlural(): string {
+    switch (this.conceptoRrhh) {
+      case 'LIQUIDACION': return 'liquidaciones';
+      case 'FINIQUITO':   return 'finiquitos';
+      case 'AGUINALDO':   return 'aguinaldos';
+      default:            return 'documentos';
+    }
+  }
+
   // ── Modo VALES (mismo builder; fuente = valesPendientes + alta de vale) ──
   // La unidad pagable es el vale de RRHH: el backend le resuelve su obligación de pago.
   esVale = false;
@@ -216,6 +239,20 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
   ngOnInit(): void {
     this.esGasto = this.data?.modo === 'GASTOS';
     this.esVale = this.data?.modo === 'VALES';
+    this.esRrhh = this.data?.modo === 'LIQUIDACION' || this.data?.modo === 'FINIQUITO'
+      || this.data?.modo === 'AGUINALDO';
+    if (this.esRrhh) {
+      this.conceptoRrhh = this.data.modo as ConceptoRrhh;
+      this.seleccionSimple = true;
+      // El documento se paga entero: ni la liquidacion ni el finiquito ni el aguinaldo
+      // llevan saldo, entregar de menos deja una diferencia que nadie reclama despues.
+      this.montoEditable = false;
+      this.titulo = this.conceptoRrhh === 'LIQUIDACION' ? 'Pagar Liquidación'
+        : this.conceptoRrhh === 'FINIQUITO' ? 'Pagar Finiquito' : 'Pagar Aguinaldo';
+      this.displayedColumns = ['sel', 'id', 'funcionario', 'periodo', 'descripcion', 'saldo', 'montoAPagar'];
+      // Filtros de la tabla: N° / Funcionario (client-side sobre lo cargado).
+      this.filtroIdControl.valueChanges.pipe(untilDestroyed(this)).subscribe(() => this.aplicarFiltro());
+    }
     if (this.esVale) {
       this.titulo = 'Pagar Vale';
       this.montoEditable = false;
@@ -280,14 +317,19 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
 
   cargar() {
     this.isLoading = true;
-    const fuente$ = this.esVale
-      ? this.pagarComprasService.onGetValesPendientes()
-      : this.esGasto
-        ? this.pagarComprasService.onGetGastosPendientes()
-        : this.pagarComprasService.onGetPendientes();
+    const fuente$ = this.esRrhh
+      ? (this.conceptoRrhh === 'LIQUIDACION' ? this.pagarComprasService.onGetLiquidacionesPendientes()
+        : this.conceptoRrhh === 'FINIQUITO' ? this.pagarComprasService.onGetFiniquitosPendientes()
+        : this.pagarComprasService.onGetAguinaldosPendientes())
+      : this.esVale
+        ? this.pagarComprasService.onGetValesPendientes()
+        : this.esGasto
+          ? this.pagarComprasService.onGetGastosPendientes()
+          : this.pagarComprasService.onGetPendientes();
     fuente$.pipe(untilDestroyed(this)).subscribe(res => {
       this.isLoading = false;
-      this.todas = (res || []).map((s: any) => this.esVale ? this.toRowVale(s) : this.toRow(s));
+      this.todas = (res || []).map((s: any) => this.esRrhh ? this.toRowRrhh(s)
+        : this.esVale ? this.toRowVale(s) : this.toRow(s));
       this.aplicarFiltro();
     });
   }
@@ -310,6 +352,32 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
       // Hay vales viejos sin moneda: sin ella no se sabe en qué moneda sale la plata.
       _bloqueado: !v.moneda?.id,
       _bloqueoMotivo: !v.moneda?.id ? 'Sin moneda definida: corregilo desde RRHH' : undefined,
+    };
+  }
+
+  /**
+   * Fila de los modos de RRHH. El "N°" es el id del documento y el tercero es el
+   * funcionario; el "periodo" ubica el documento (2026-07 en liquidacion, 2026 en aguinaldo).
+   */
+  private toRowRrhh(p: any): SolicitudRow {
+    const saldo = p.saldoPendiente != null ? p.saldoPendiente : (p.monto || 0);
+    const nombre = p.funcionarioNombre || p.funcionario?.persona?.nombre || '—';
+    const sinMoneda = !p.moneda?.id;
+    return {
+      id: p.id, numeroSolicitud: String(p.id),
+      proveedorId: p.funcionario?.id, proveedorNombre: nombre,
+      monedaId: p.moneda?.id, monedaSimbolo: p.moneda?.simbolo || '',
+      monedaDenominacion: p.moneda?.denominacion || '',
+      decimales: this.decimales(p.moneda), saldoPendiente: saldo,
+      _sel: false, _disabled: false, _montoAPagar: saldo, _currencyOpts: this.currencyOpts(p.moneda),
+      _planCheques: [],
+      _descripcion: p.descripcion || '',
+      _categoria: p.periodo || '',
+      // Sin moneda no se sabe en que moneda sale la plata; saldo 0 no tiene nada que pagar.
+      _bloqueado: sinMoneda || saldo <= 0,
+      _bloqueoMotivo: sinMoneda
+        ? 'Sin moneda: falta configurar la moneda principal'
+        : (saldo <= 0 ? 'Sin saldo pendiente' : undefined),
     };
   }
 
@@ -359,6 +427,15 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
         (!fid || String(r.id).includes(fid)) &&
         (!ffun || (r.proveedorNombre || '').toUpperCase().includes(ffun)) &&
         (!fmot || (r._categoria || '').toUpperCase().includes(fmot))
+      );
+      return;
+    }
+    if (this.esRrhh) {
+      const fid = (this.filtroIdControl.value || '').trim();
+      const ffun = (this.filtroProveedorControl.value || '').toUpperCase().trim();
+      this.dataSource.data = this.todas.filter(r =>
+        (!fid || String(r.id).includes(fid)) &&
+        (!ffun || (r.proveedorNombre || '').toUpperCase().includes(ffun))
       );
       return;
     }
@@ -485,7 +562,10 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
   // ── Paso 1: selección (mismo proveedor + misma moneda) ──
   onToggle(row: SolicitudRow) {
     if (row._disabled || row._bloqueado) return;
-    row._sel = !row._sel;
+    const nuevo = !row._sel;
+    // Los modos de RRHH pagan de a uno: tildar una fila destilda cualquier otra.
+    if (this.seleccionSimple && nuevo) this.todas.forEach(r => r._sel = false);
+    row._sel = nuevo;
     this.recomputarSeleccion();
   }
 
@@ -502,7 +582,7 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
       this.monedaDeuda = this.monedaList.find(m => m.id === primero.monedaId) || null;
       // Compras: mismo proveedor + misma moneda. Gastos y vales: solo misma moneda
       // (el beneficiario/funcionario puede variar o faltar).
-      this.todas.forEach(r => r._disabled = r._bloqueado || !r._sel && ((this.esGasto || this.esVale)
+      this.todas.forEach(r => r._disabled = r._bloqueado || !r._sel && ((this.esGasto || this.esVale || this.esRrhh)
         ? r.monedaId !== primero.monedaId
         : (r.proveedorId !== primero.proveedorId || r.monedaId !== primero.monedaId)));
       if (this.monedaDeuda) this.getRateGs(this.monedaDeuda).pipe(untilDestroyed(this)).subscribe(); // warm cache
@@ -820,10 +900,15 @@ export class PagarComprasDialogComponent implements OnInit, AfterViewInit {
     this.isSaving = true;
     // El modo VALES paga por valeId: el backend resuelve/crea la obligación de pago de cada vale
     // (los vales que vienen del mobile nacen sin ella) y delega en el mismo motor de pago.
-    const pago$ = this.esVale
-      ? this.pagarComprasService.onPagarValesMixto(
-          pagos.map(p => ({ valeId: p.solicitudId, lineas: p.lineas } as ValeConLineas)))
-      : this.pagarComprasService.onPagarMixto(pagos);
+    const pago$ = this.esRrhh
+      ? this.pagarComprasService.onPagarRrhhMixto(
+          pagos.map(p => ({
+            concepto: this.conceptoRrhh!, documentoId: p.solicitudId, lineas: p.lineas,
+          } as PagoRrhhConLineas)))
+      : this.esVale
+        ? this.pagarComprasService.onPagarValesMixto(
+            pagos.map(p => ({ valeId: p.solicitudId, lineas: p.lineas } as ValeConLineas)))
+        : this.pagarComprasService.onPagarMixto(pagos);
     pago$.pipe(untilDestroyed(this)).subscribe({
       next: res => {
         this.isSaving = false;

--- a/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras.service.ts
+++ b/src/app/modules/financiero/caja-virtual/pagar-compras-dialog/pagar-compras.service.ts
@@ -12,6 +12,11 @@ import { CrearGastoParaPagoGQL } from './graphql/crearGastoParaPago';
 import { ValesPendientesGQL } from './graphql/valesPendientes';
 import { CrearValeParaPagoGQL } from './graphql/crearValeParaPago';
 import { PagarValesMixtoGQL } from './graphql/pagarValesMixto';
+import { LiquidacionesPendientesPagoGQL } from './graphql/liquidacionesPendientesPago';
+import { FiniquitosPendientesPagoGQL } from './graphql/finiquitosPendientesPago';
+import { AguinaldosPendientesPagoGQL } from './graphql/aguinaldosPendientesPago';
+import { PagarRrhhMixtoGQL } from './graphql/pagarRrhhMixto';
+import { DetalleDePagoGQL } from './graphql/detalleDePago';
 
 export interface GastoParaPagoInput {
   tipoGastoId?: number;
@@ -25,6 +30,9 @@ export interface GastoParaPagoInput {
 }
 
 export interface PagoLote { solicitudId: number; monedaId: number; monto: number; }
+
+/** Concepto de RRHH pagable desde la caja. Espeja el enum ConceptoRrhhPagable del central. */
+export type ConceptoRrhh = 'LIQUIDACION' | 'FINIQUITO' | 'AGUINALDO';
 
 // Una línea de pago (mixto): fuente + caja/cuenta + moneda + monto (+ conversión).
 // AJUSTE = línea de diferencia de cambio/redondeo (no mueve efectivo), marcada descuento/aumento.
@@ -53,6 +61,9 @@ export interface SolicitudConLineas { solicitudId: number; lineas: LineaPagoInpu
 /** Modo VALES: la unidad pagable es el vale; el backend resuelve su obligación de pago. */
 export interface ValeConLineas { valeId: number; lineas: LineaPagoInput[]; }
 
+/** Un documento de RRHH con su reparto de formas de pago (espejo de ValeConLineas). */
+export interface PagoRrhhConLineas { concepto: ConceptoRrhh; documentoId: number; lineas: LineaPagoInput[]; }
+
 export interface ValeParaPagoInput {
   funcionarioId: number;
   motivoId?: number;
@@ -77,7 +88,20 @@ export class PagarComprasService {
     private valesPendientesGQL: ValesPendientesGQL,
     private crearValeGQL: CrearValeParaPagoGQL,
     private pagarValesMixtoGQL: PagarValesMixtoGQL,
+    private liquidacionesPendientesGQL: LiquidacionesPendientesPagoGQL,
+    private finiquitosPendientesGQL: FiniquitosPendientesPagoGQL,
+    private aguinaldosPendientesGQL: AguinaldosPendientesPagoGQL,
+    private pagarRrhhMixtoGQL: PagarRrhhMixtoGQL,
+    private detalleDePagoGQL: DetalleDePagoGQL,
   ) { }
+
+  /**
+   * Desglose de un evento de pago: que documentos se pagaron y cuanto se imputo a cada uno.
+   * El movimiento consolidado de caja no puede decirlo en su descripcion cuando son varios.
+   */
+  onGetDetalleDePago(pagoId: number, servidor = true): Observable<any> {
+    return this.genericService.onCustomQuery(this.detalleDePagoGQL, { pagoId }, servidor);
+  }
 
   /** Vales pagables (estado SOLICITADO) con su saldo. */
   onGetValesPendientes(servidor = true): Observable<any> {
@@ -92,6 +116,29 @@ export class PagarComprasService {
   /** Paga N vales como un único evento consolidado. El pago parcial de un vale está prohibido. */
   onPagarValesMixto(pagos: ValeConLineas[], servidor = true): Observable<any> {
     return this.mutar(this.pagarValesMixtoGQL, { pagos }, servidor);
+  }
+
+  /** Liquidaciones mensuales APROBADAS todavia sin pagar. */
+  onGetLiquidacionesPendientes(servidor = true): Observable<any> {
+    return this.genericService.onCustomQuery(this.liquidacionesPendientesGQL, {}, servidor);
+  }
+
+  /** Finiquitos APROBADOS todavia sin pagar. */
+  onGetFiniquitosPendientes(servidor = true): Observable<any> {
+    return this.genericService.onCustomQuery(this.finiquitosPendientesGQL, {}, servidor);
+  }
+
+  /** Aguinaldos APROBADOS todavia sin pagar. */
+  onGetAguinaldosPendientes(servidor = true): Observable<any> {
+    return this.genericService.onCustomQuery(this.aguinaldosPendientesGQL, {}, servidor);
+  }
+
+  /**
+   * Paga documentos de RRHH (liquidacion / finiquito / aguinaldo) con el motor de CPP.
+   * El pago parcial esta prohibido, y en la practica se manda de a uno.
+   */
+  onPagarRrhhMixto(pagos: PagoRrhhConLineas[], servidor = true): Observable<any> {
+    return this.mutar(this.pagarRrhhMixtoGQL, { pagos }, servidor);
   }
 
   /** Gastos pagables (SolicitudPago tipo GASTO en SOLICITADO/PARCIAL). */

--- a/src/app/modules/financiero/caja-virtual/registrar-egreso-dialog/registrar-egreso-dialog.component.ts
+++ b/src/app/modules/financiero/caja-virtual/registrar-egreso-dialog/registrar-egreso-dialog.component.ts
@@ -28,6 +28,9 @@ export class RegistrarEgresoDialogComponent {
     { tipo: 'PAGO_CPP', titulo: 'Pagar Compras', descripcion: 'Pagar solicitudes de compra pendientes (CPP)', icono: 'shopping_cart_checkout', color: '#00695c' },
     { tipo: 'GASTO', titulo: 'Pagar Gasto', descripcion: 'Pagar o crear un gasto (ANDE, alquiler, servicios…)', icono: 'request_quote', color: '#5d4037' },
     { tipo: 'VALE', titulo: 'Pagar Vale', descripcion: 'Pagar o crear un vale/adelanto a funcionario', icono: 'receipt_long', color: '#ad1457' },
+    { tipo: 'LIQUIDACION', titulo: 'Pagar Liquidación', descripcion: 'Pagar una liquidación mensual aprobada', icono: 'payments', color: '#1565c0' },
+    { tipo: 'FINIQUITO', titulo: 'Pagar Finiquito', descripcion: 'Pagar una liquidación final aprobada', icono: 'logout', color: '#4527a0' },
+    { tipo: 'AGUINALDO', titulo: 'Pagar Aguinaldo', descripcion: 'Pagar un aguinaldo aprobado (fuera de la liquidación)', icono: 'card_giftcard', color: '#00695c' },
     { tipo: 'AJUSTE', titulo: 'Ajuste de Saldo', descripcion: 'Corrección negativa del saldo con motivo', icono: 'tune', color: '#6a1b9a' },
   ];
 
@@ -48,8 +51,14 @@ export class RegistrarEgresoDialogComponent {
       this.abrir(MaletinTesoreriaDialogComponent, { width: '480px', data: d });
       return;
     }
-    if (op.tipo === 'PAGO_CPP' || op.tipo === 'GASTO' || op.tipo === 'VALE') {
-      const modo = op.tipo === 'GASTO' ? 'GASTOS' : op.tipo === 'VALE' ? 'VALES' : 'COMPRAS';
+    // Todos los conceptos pagables van por el mismo builder de pago; cambia el modo.
+    if (op.tipo === 'PAGO_CPP' || op.tipo === 'GASTO' || op.tipo === 'VALE'
+        || op.tipo === 'LIQUIDACION' || op.tipo === 'FINIQUITO' || op.tipo === 'AGUINALDO') {
+      const modo: PagarComprasDialogData['modo'] =
+        op.tipo === 'GASTO' ? 'GASTOS'
+        : op.tipo === 'VALE' ? 'VALES'
+        : op.tipo === 'PAGO_CPP' ? 'COMPRAS'
+        : op.tipo;
       const d: PagarComprasDialogData = { cajaVirtual: this.data.cajaVirtual, modo };
       this.abrir(PagarComprasDialogComponent, { width: '65vw', maxWidth: '95vw', minWidth: '760px', height: '70vh', panelClass: 'pagar-compras-panel', data: d });
       return;

--- a/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.html
+++ b/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.html
@@ -1,0 +1,56 @@
+<h2 mat-dialog-title class="aj-title">
+  <mat-icon>tune</mat-icon>
+  <span>Ajustar saldo</span>
+  <span class="aj-sub">{{ data.cuentaBancaria?.banco?.nombre }} · {{ data.cuentaBancaria?.numero }}</span>
+</h2>
+
+<mat-dialog-content class="aj-content">
+  <p class="aj-hint">
+    Corrige el saldo contra el extracto real. El ajuste <strong>no tiene contrapartida</strong>:
+    queda registrado con tu usuario y el motivo, que es toda su trazabilidad.
+  </p>
+
+  <div class="aj-saldos">
+    <div class="aj-saldo">
+      <span class="aj-label">Saldo actual</span>
+      <strong>{{ monedaSimbolo }} {{ saldoActual | number:'1.0-2' }}</strong>
+    </div>
+    <mat-icon class="aj-flecha">arrow_forward</mat-icon>
+    <div class="aj-saldo">
+      <span class="aj-label">Saldo resultante</span>
+      <strong [class.aj-sube]="saldoResultante > saldoActual"
+              [class.aj-baja]="saldoResultante < saldoActual">
+        {{ monedaSimbolo }} {{ saldoResultante | number:'1.0-2' }}
+      </strong>
+    </div>
+  </div>
+
+  <div class="aj-signo">
+    <button mat-stroked-button type="button" class="aj-btn-signo"
+            [class.activo-mas]="positivo" (click)="onCambiarSigno(true)">
+      <mat-icon>add</mat-icon> Aumentar
+    </button>
+    <button mat-stroked-button type="button" class="aj-btn-signo"
+            [class.activo-menos]="!positivo" (click)="onCambiarSigno(false)">
+      <mat-icon>remove</mat-icon> Disminuir
+    </button>
+  </div>
+
+  <mat-form-field appearance="outline" class="aj-campo" subscriptSizing="dynamic">
+    <mat-label>Monto del ajuste ({{ monedaDenominacion }})</mat-label>
+    <input matInput [formControl]="montoControl" currencyMask [options]="currencyOpts" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="aj-campo" subscriptSizing="dynamic">
+    <mat-label>Motivo</mat-label>
+    <input matInput [formControl]="motivoControl"
+           placeholder="Ej: diferencia con extracto del 19/08 — comisión no registrada" />
+  </mat-form-field>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cerrar()" [disabled]="isSaving">Cancelar</button>
+  <button mat-raised-button color="primary" (click)="onGuardar()" [disabled]="isSaving">
+    <mat-icon>check</mat-icon> Aplicar ajuste
+  </button>
+</mat-dialog-actions>

--- a/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.html
+++ b/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.html
@@ -1,10 +1,10 @@
-<h2 mat-dialog-title class="aj-title">
-  <mat-icon>tune</mat-icon>
-  <span>Ajustar saldo</span>
-  <span class="aj-sub">{{ data.cuentaBancaria?.banco?.nombre }} · {{ data.cuentaBancaria?.numero }}</span>
-</h2>
+<div class="ajustar-saldo-dialog">
+  <h2 class="titulo-dialog">Ajustar saldo</h2>
+  <div class="subtitulo-dialog">
+    {{ data.cuentaBancaria?.banco?.nombre }} · {{ data.cuentaBancaria?.numero }}
+  </div>
 
-<mat-dialog-content class="aj-content">
+  <mat-dialog-content class="aj-content">
   <p class="aj-hint">
     Corrige el saldo contra el extracto real. El ajuste <strong>no tiene contrapartida</strong>:
     queda registrado con tu usuario y el motivo, que es toda su trazabilidad.
@@ -48,9 +48,10 @@
   </mat-form-field>
 </mat-dialog-content>
 
-<mat-dialog-actions align="end">
-  <button mat-button (click)="cerrar()" [disabled]="isSaving">Cancelar</button>
-  <button mat-raised-button color="primary" (click)="onGuardar()" [disabled]="isSaving">
-    <mat-icon>check</mat-icon> Aplicar ajuste
-  </button>
-</mat-dialog-actions>
+  <mat-dialog-actions align="end" class="aj-acciones">
+    <button mat-button (click)="cerrar()" [disabled]="isSaving">Cancelar</button>
+    <button mat-raised-button color="primary" (click)="onGuardar()" [disabled]="isSaving">
+      <mat-icon>check</mat-icon> Aplicar ajuste
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.scss
+++ b/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.scss
@@ -1,16 +1,32 @@
 // App siempre en dark: nada de fondos claros.
-.aj-title {
+//
+// Cabecera con el patrón del resto de los diálogos del módulo (ver
+// ingresar-retiro-caja-mayor-dialog): título centrado en su línea y subtítulo naranja debajo.
+.ajustar-saldo-dialog {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  color: #ffffff;
+  flex-direction: column;
+  padding: 8px 16px 4px;
+  box-sizing: border-box;
+}
 
-  .aj-sub {
-    margin-left: 8px;
-    font-size: 0.72em;
-    font-weight: 400;
-    color: #ffa726;              // subtítulo naranja (convención de diálogos)
-  }
+.titulo-dialog {
+  text-align: center;
+  margin: 4px 0 2px;
+  font-weight: 500;
+  font-size: 20px;
+  color: #fff;
+}
+
+.subtitulo-dialog {
+  text-align: center;
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: #ff9800;
+}
+
+.aj-acciones {
+  flex: 0 0 auto;
+  padding: 4px 0 0;
 }
 
 .aj-hint {

--- a/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.scss
+++ b/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.scss
@@ -1,0 +1,75 @@
+// App siempre en dark: nada de fondos claros.
+.aj-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #ffffff;
+
+  .aj-sub {
+    margin-left: 8px;
+    font-size: 0.72em;
+    font-weight: 400;
+    color: #ffa726;              // subtítulo naranja (convención de diálogos)
+  }
+}
+
+.aj-hint {
+  margin: 0 0 16px;
+  font-size: 0.82em;
+  opacity: 0.75;
+}
+
+.aj-saldos {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 12px;
+  margin-bottom: 16px;
+  border-radius: 6px;
+  background: #3a3a3a;
+
+  .aj-saldo {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .aj-label {
+    font-size: 0.72em;
+    opacity: 0.65;
+    text-transform: uppercase;
+  }
+
+  strong { font-size: 1.05em; }
+
+  // Verde sube / rojo baja: mismas variantes claras que el resto del módulo (contraste AA).
+  .aj-sube { color: #81c784; }
+  .aj-baja { color: #ff8a80; }
+
+  .aj-flecha { opacity: 0.5; }
+}
+
+.aj-signo {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+
+  .aj-btn-signo { flex: 1 1 0; }
+
+  .activo-mas {
+    background: #2e7d32;
+    color: #ffffff;
+  }
+
+  .activo-menos {
+    background: #c62828;
+    color: #ffffff;
+  }
+}
+
+.aj-campo {
+  width: 100%;
+  margin-bottom: 14px;
+}

--- a/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.ts
+++ b/src/app/modules/financiero/cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component.ts
@@ -1,0 +1,123 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { CuentaBancaria } from '../cuenta-bancaria.model';
+import { CuentaBancariaService } from '../cuenta-bancaria.service';
+import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
+import { NotificacionSnackbarService, NotificacionColor } from '../../../../notificacion-snackbar.service';
+
+export interface AjustarSaldoCuentaData {
+  cuentaBancaria: CuentaBancaria;
+}
+
+/**
+ * Corrección del saldo de una cuenta bancaria contra el extracto real.
+ *
+ * <p>Un ajuste no tiene contrapartida: es plata que aparece o desaparece del ledger. Por eso el
+ * motivo es obligatorio (queda en la descripción del movimiento, que es toda su trazabilidad) y
+ * se confirma mostrando el saldo resultante antes de aplicarlo.</p>
+ */
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'app-ajustar-saldo-cuenta-dialog',
+  templateUrl: './ajustar-saldo-cuenta-dialog.component.html',
+  styleUrls: ['./ajustar-saldo-cuenta-dialog.component.scss']
+})
+export class AjustarSaldoCuentaDialogComponent implements OnInit {
+
+  /** true = suma al saldo, false = resta. */
+  positivo = true;
+  montoControl = new FormControl(null, [Validators.required, Validators.min(0.0001)]);
+  motivoControl = new FormControl('', [Validators.required, Validators.minLength(4)]);
+
+  saldoActual = 0;
+  monedaSimbolo = '';
+  monedaDenominacion = '';
+  currencyOpts: any;
+  isSaving = false;
+
+  /** Saldo que va a quedar. Se recalcula al tipear; el template solo lo lee. */
+  saldoResultante = 0;
+
+  constructor(
+    private dialogRef: MatDialogRef<AjustarSaldoCuentaDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: AjustarSaldoCuentaData,
+    private cuentaBancariaService: CuentaBancariaService,
+    private dialogos: DialogosService,
+    private notificacion: NotificacionSnackbarService,
+  ) {}
+
+  ngOnInit(): void {
+    const cta: any = this.data.cuentaBancaria;
+    this.saldoActual = cta?.saldo || 0;
+    this.monedaSimbolo = cta?.moneda?.simbolo || '';
+    this.monedaDenominacion = cta?.moneda?.denominacion || '';
+    this.currencyOpts = this.buildCurrencyOptions(cta?.moneda);
+    this.recalcular();
+
+    this.montoControl.valueChanges.pipe(untilDestroyed(this)).subscribe(() => this.recalcular());
+  }
+
+  onCambiarSigno(positivo: boolean): void {
+    this.positivo = positivo;
+    this.recalcular();
+  }
+
+  private recalcular(): void {
+    const monto = Math.abs(Number(this.montoControl.value) || 0);
+    this.saldoResultante = this.saldoActual + (this.positivo ? monto : -monto);
+  }
+
+  private buildCurrencyOptions(moneda: any): any {
+    const decimales = moneda?.decimales != null
+      ? moneda.decimales
+      : ((moneda?.denominacion || '').toUpperCase().includes('GUARANI') ? 0 : 2);
+    return {
+      align: 'right', allowNegative: false, decimal: ',', precision: decimales, thousands: '.',
+      prefix: moneda?.simbolo ? moneda.simbolo + ' ' : '', suffix: '', nullable: true, min: 0, max: null,
+    };
+  }
+
+  onGuardar(): void {
+    if (this.montoControl.invalid) return this.err('Ingresá un monto mayor a cero');
+    if (this.motivoControl.invalid) return this.err('El motivo es obligatorio (mín. 4 caracteres)');
+
+    const monto = Math.abs(Number(this.montoControl.value));
+    const signo = this.positivo ? '+' : '−';
+
+    this.dialogos.confirm(
+      'Confirmar ajuste de saldo',
+      `¿Aplicar un ajuste de ${signo} ${this.monedaSimbolo} ${monto.toLocaleString('es-PY')} a esta cuenta?`,
+      'Un ajuste no tiene contrapartida: queda registrado con tu usuario y el motivo.',
+      null, true, 'Sí, ajustar', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(res => {
+      if (res !== true) return;
+      this.isSaving = true;
+      this.cuentaBancariaService
+        .onAjustarSaldo(this.data.cuentaBancaria.id, monto, this.positivo, this.motivoControl.value)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: r => {
+            this.isSaving = false;
+            if (r != null) {
+              this.notificacion.notification$.next({
+                texto: 'Saldo ajustado', color: NotificacionColor.success, duracion: 3,
+              });
+              this.dialogRef.close(r);
+            }
+          },
+          error: e => {
+            this.isSaving = false;
+            this.err(e?.graphQLErrors?.[0]?.message || e?.message || 'No se pudo ajustar el saldo');
+          },
+        });
+    });
+  }
+
+  private err(texto: string): void {
+    this.notificacion.notification$.next({ texto, color: NotificacionColor.warn, duracion: 5 });
+  }
+
+  cerrar(): void { this.dialogRef.close(null); }
+}

--- a/src/app/modules/financiero/cuenta-bancaria/cuenta-bancaria.component.html
+++ b/src/app/modules/financiero/cuenta-bancaria/cuenta-bancaria.component.html
@@ -98,6 +98,9 @@
             <button mat-menu-item (click)="onVerMovimientos(row)">
               <mat-icon>receipt_long</mat-icon><span>Ver movimientos</span>
             </button>
+            <button mat-menu-item (click)="onAjustarSaldo(row)" [disabled]="!puedeGestionar">
+              <mat-icon>tune</mat-icon><span>Ajustar saldo</span>
+            </button>
             <button mat-menu-item (click)="onEdit(row)" [disabled]="!puedeGestionar">
               <mat-icon>edit</mat-icon><span>Editar</span>
             </button>

--- a/src/app/modules/financiero/cuenta-bancaria/cuenta-bancaria.component.ts
+++ b/src/app/modules/financiero/cuenta-bancaria/cuenta-bancaria.component.ts
@@ -6,6 +6,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { CuentaBancaria, TipoCuenta } from './cuenta-bancaria.model';
 import { CuentaBancariaService } from './cuenta-bancaria.service';
 import { AddCuentaBancariaDialogComponent } from './add-cuenta-bancaria-dialog/add-cuenta-bancaria-dialog.component';
+import { AjustarSaldoCuentaDialogComponent, AjustarSaldoCuentaData } from './ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component';
 import { ListMovimientosBancariosDialogComponent } from '../operacion-financiera/list-movimientos-bancarios-dialog/list-movimientos-bancarios-dialog.component';
 import { NotificacionSnackbarService } from '../../../notificacion-snackbar.service';
 import { DialogosService } from '../../../shared/components/dialogos/dialogos.service';
@@ -122,6 +123,19 @@ export class CuentaBancariaComponent implements OnInit {
   onVerMovimientos(item: CuentaBancaria) {
     this.dialog.open(ListMovimientosBancariosDialogComponent, {
       width: '95vw', maxWidth: '1200px', height: '85vh', data: item
+    });
+  }
+
+  /**
+   * Ajusta el saldo de la cuenta contra el extracto real. Exige TESORERIA GESTIONAR, igual que
+   * editar la cuenta: un ajuste crea o borra plata del ledger sin contrapartida.
+   */
+  onAjustarSaldo(item: CuentaBancaria) {
+    const data: AjustarSaldoCuentaData = { cuentaBancaria: item };
+    this.dialog.open(AjustarSaldoCuentaDialogComponent, {
+      width: '520px', maxWidth: '95vw', data
+    }).afterClosed().subscribe(res => {
+      if (res != null) this.cargar();
     });
   }
 }

--- a/src/app/modules/financiero/cuenta-bancaria/cuenta-bancaria.service.ts
+++ b/src/app/modules/financiero/cuenta-bancaria/cuenta-bancaria.service.ts
@@ -6,6 +6,7 @@ import { CuentasBancariasGQL } from './graphql/cuentasBancarias';
 import { CuentasBancariasOperablesGQL } from './graphql/cuentasBancariasOperables';
 import { SaveCuentaBancariaGQL } from './graphql/saveCuentaBancaria';
 import { DeleteCuentaBancariaGQL } from './graphql/deleteCuentaBancaria';
+import { AjustarSaldoCuentaBancariaGQL } from './graphql/ajustarSaldoCuentaBancaria';
 
 @Injectable({
   providedIn: 'root'
@@ -18,6 +19,7 @@ export class CuentaBancariaService {
     private cuentasBancariasOperablesGQL: CuentasBancariasOperablesGQL,
     private saveCuentaBancariaGQL: SaveCuentaBancariaGQL,
     private deleteCuentaBancariaGQL: DeleteCuentaBancariaGQL,
+    private ajustarSaldoGQL: AjustarSaldoCuentaBancariaGQL,
   ) { }
 
   onGetAll(page = 0, size = 100): Observable<CuentaBancaria[]> {
@@ -40,5 +42,15 @@ export class CuentaBancariaService {
 
   onDelete(id: number): Observable<boolean> {
     return this.genericService.onSaveCustom(this.deleteCuentaBancariaGQL, { id });
+  }
+
+  /**
+   * Ajusta el saldo de la cuenta contra el extracto real. El motivo es obligatorio: un ajuste
+   * no tiene contrapartida, y ese texto es toda la trazabilidad que le queda al movimiento.
+   */
+  onAjustarSaldo(cuentaBancariaId: number, monto: number, positivo: boolean, motivo: string): Observable<any> {
+    return this.genericService.onSaveCustom(this.ajustarSaldoGQL, {
+      cuentaBancariaId, monto, positivo, motivo,
+    });
   }
 }

--- a/src/app/modules/financiero/cuenta-bancaria/graphql/ajustarSaldoCuentaBancaria.ts
+++ b/src/app/modules/financiero/cuenta-bancaria/graphql/ajustarSaldoCuentaBancaria.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { ajustarSaldoCuentaBancariaMutation } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class AjustarSaldoCuentaBancariaGQL extends Mutation<Response> {
+  document = ajustarSaldoCuentaBancariaMutation;
+}

--- a/src/app/modules/financiero/cuenta-bancaria/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/cuenta-bancaria/graphql/graphql-query.ts
@@ -59,3 +59,20 @@ export const deleteCuentaBancariaMutation = gql`
     data: deleteCuentaBancaria(id: $id)
   }
 `;
+
+// Ajuste de saldo contra el extracto real. Deja un movimiento AJUSTE_POSITIVO/NEGATIVO con el
+// motivo, que es toda su trazabilidad: un ajuste no tiene contrapartida.
+export const ajustarSaldoCuentaBancariaMutation = gql`
+  mutation ($cuentaBancariaId: ID!, $monto: Float!, $positivo: Boolean!, $motivo: String!) {
+    data: ajustarSaldoCuentaBancaria(
+      cuentaBancariaId: $cuentaBancariaId, monto: $monto, positivo: $positivo, motivo: $motivo
+    ) {
+      id
+      tipoMovimiento
+      monto
+      saldoAnterior
+      saldoPosterior
+      descripcion
+    }
+  }
+`;

--- a/src/app/modules/financiero/financiero.module.ts
+++ b/src/app/modules/financiero/financiero.module.ts
@@ -75,6 +75,7 @@ import { ListEntradasVariasDialogComponent } from './entrada-varia/list-entradas
 import { AddOperacionFinancieraDialogComponent } from './operacion-financiera/add-operacion-financiera-dialog/add-operacion-financiera-dialog.component';
 import { OperacionFinancieraDetalleDialogComponent } from './operacion-financiera/operacion-financiera-detalle-dialog/operacion-financiera-detalle-dialog.component';
 import { DetallePagoDialogComponent } from './caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component';
+import { GestionarAccesosCajaDialogComponent } from './caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component';
 import { ChequesDashboardComponent } from './cheque/cheques-dashboard/cheques-dashboard.component';
 import { EmitirChequeDialogComponent } from './cheque/emitir-cheque-dialog/emitir-cheque-dialog.component';
 import { EditChequeraDialogComponent } from './chequera/edit-chequera-dialog/edit-chequera-dialog.component';
@@ -153,6 +154,7 @@ import { AddCuentaBancariaDialogComponent } from './cuenta-bancaria/add-cuenta-b
     AddOperacionFinancieraDialogComponent,
     OperacionFinancieraDetalleDialogComponent,
     DetallePagoDialogComponent,
+    GestionarAccesosCajaDialogComponent,
     ChequesDashboardComponent,
     EmitirChequeDialogComponent,
     EditChequeraDialogComponent,

--- a/src/app/modules/financiero/financiero.module.ts
+++ b/src/app/modules/financiero/financiero.module.ts
@@ -74,6 +74,7 @@ import { AddEntradaVariaDialogComponent } from './entrada-varia/add-entrada-vari
 import { ListEntradasVariasDialogComponent } from './entrada-varia/list-entradas-varias-dialog/list-entradas-varias-dialog.component';
 import { AddOperacionFinancieraDialogComponent } from './operacion-financiera/add-operacion-financiera-dialog/add-operacion-financiera-dialog.component';
 import { OperacionFinancieraDetalleDialogComponent } from './operacion-financiera/operacion-financiera-detalle-dialog/operacion-financiera-detalle-dialog.component';
+import { DetallePagoDialogComponent } from './caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component';
 import { ChequesDashboardComponent } from './cheque/cheques-dashboard/cheques-dashboard.component';
 import { EmitirChequeDialogComponent } from './cheque/emitir-cheque-dialog/emitir-cheque-dialog.component';
 import { EditChequeraDialogComponent } from './chequera/edit-chequera-dialog/edit-chequera-dialog.component';
@@ -151,6 +152,7 @@ import { AddCuentaBancariaDialogComponent } from './cuenta-bancaria/add-cuenta-b
     ListEntradasVariasDialogComponent,
     AddOperacionFinancieraDialogComponent,
     OperacionFinancieraDetalleDialogComponent,
+    DetallePagoDialogComponent,
     ChequesDashboardComponent,
     EmitirChequeDialogComponent,
     EditChequeraDialogComponent,

--- a/src/app/modules/financiero/financiero.module.ts
+++ b/src/app/modules/financiero/financiero.module.ts
@@ -76,6 +76,7 @@ import { AddOperacionFinancieraDialogComponent } from './operacion-financiera/ad
 import { OperacionFinancieraDetalleDialogComponent } from './operacion-financiera/operacion-financiera-detalle-dialog/operacion-financiera-detalle-dialog.component';
 import { DetallePagoDialogComponent } from './caja-virtual/detalle-pago-dialog/detalle-pago-dialog.component';
 import { GestionarAccesosCajaDialogComponent } from './caja-virtual/gestionar-accesos-caja-dialog/gestionar-accesos-caja-dialog.component';
+import { AjustarSaldoCuentaDialogComponent } from './cuenta-bancaria/ajustar-saldo-cuenta-dialog/ajustar-saldo-cuenta-dialog.component';
 import { ChequesDashboardComponent } from './cheque/cheques-dashboard/cheques-dashboard.component';
 import { EmitirChequeDialogComponent } from './cheque/emitir-cheque-dialog/emitir-cheque-dialog.component';
 import { EditChequeraDialogComponent } from './chequera/edit-chequera-dialog/edit-chequera-dialog.component';
@@ -155,6 +156,7 @@ import { AddCuentaBancariaDialogComponent } from './cuenta-bancaria/add-cuenta-b
     OperacionFinancieraDetalleDialogComponent,
     DetallePagoDialogComponent,
     GestionarAccesosCajaDialogComponent,
+    AjustarSaldoCuentaDialogComponent,
     ChequesDashboardComponent,
     EmitirChequeDialogComponent,
     EditChequeraDialogComponent,


### PR DESCRIPTION
Lado desktop de **https://github.com/GabFrank/franco-system-backend-servidor/pull/228** — el detalle completo (qué entra, migraciones, backfill obligatorio, riesgos y qué se probó) está ahí.

**Se mergean juntos**: esto consume queries y campos que agrega ese PR.

## Qué cambia acá

- **Diálogo "Gestionar accesos"** en la lista de cajas: alta con buscador de usuario, toggle de escritura, revocar y transferir responsabilidad. Visible solo al responsable de la caja o a un ADMIN (el backend lo verifica igual — esconder la opción es comodidad, no seguridad).
- **Tres modos nuevos** en el diálogo genérico de pago: `LIQUIDACION`, `FINIQUITO`, `AGUINALDO`, con sus entradas en el hub de egresos. Reusan el builder de formas de pago tal cual; lo propio de cada modo es la fuente de datos y las columnas. Usan **selección simple** (la nómina no se paga en una sola operación) y monto no editable.
- **Diálogo "Detalle del pago"**: desglose de un evento que pagó N documentos, con el monto imputado a cada uno. Es lo que el movimiento consolidado no puede decir en su descripción.
- **Etiqueta del movimiento de caja desde `origenTipo`**: un pago de gasto ya no se muestra como "Compra". El color se sigue derivando del `tipoMovimiento`, que codifica la dirección de la plata y cuyas variantes están verificadas con contraste WCAG AA.
- **Ajuste de saldo de cuenta bancaria** desde la lista, con saldo resultante en vivo y motivo obligatorio.

## Correcciones de convenciones del repo

- **Tres lugares llamaban una función o un getter desde el template** (etiqueta del movimiento en historial y dashboard, flag de administración en la lista, plural del concepto en el diálogo de pago). Se re-evaluaban en cada ciclo de change detection. Ahora se precomputan al cargar las filas.
- **Tres lugares mutaban objetos devueltos por Apollo sin clonar** — Apollo los congela y en dev eso tira `TypeError`. El resto del módulo ya clonaba.
- Los diálogos nuevos pasan al patrón de cabecera del módulo (título centrado, subtítulo naranja debajo, acciones ancladas abajo).

## Probado

AOT en verde. Recorrido completo en Chrome contra el central local: hub → pagar liquidación y aguinaldo, selección simple, etiquetas del historial, detalle del pago con 1 y con 2 documentos, anulación desde la caja, gestión de accesos (otorgar / toggle / revocar) y ajuste bancario.

**Merge commit, no squash.**
