### PR TITLE
feat(financiero): cargar items de factura con el buscador de productos [FRC]

### DIFF
--- a/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.html
+++ b/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.html
@@ -166,14 +166,47 @@
     </div>
 
     <div class="section-card" fxLayout="column" fxFlex>
-      <div class="productos-header" fxLayout="row" fxLayoutAlign="space-between center">
+      <div
+        class="productos-header"
+        fxLayout="row"
+        fxLayout.lt-md="column"
+        fxLayoutAlign="space-between center"
+        fxLayoutAlign.lt-md="start stretch"
+        fxLayoutGap="12px"
+      >
         <h4 class="titulo-center">Lista de productos</h4>
-        <app-boton
-          nombre="+ Producto"
-          color="primary"
-          (clickEvent)="addItem(null, null)"
-          class="btn-agregar-producto"
-        ></app-boton>
+        <div
+          class="productos-header__acciones"
+          fxLayout="row"
+          fxLayoutAlign="end center"
+          fxLayoutGap="12px"
+        >
+          <app-boton
+            nombre="+ Producto"
+            color="primary"
+            (clickEvent)="addItem(null, null)"
+            class="btn-agregar-producto"
+          ></app-boton>
+          <app-boton
+            nombre="Cancelar"
+            color="primary"
+            (clickEvent)="onCancelar()"
+            class="btn-accion"
+          ></app-boton>
+          <app-boton
+            #imprimirBtb
+            (focusEvent)="guardarSub.asObservable()"
+            [nombre]="data?.ligarAVenta ? 'Finalizar venta' : 'Imprimir'"
+            color="accent"
+            [disableExpression]="
+              rucControl.invalid ||
+              clienteDescripcionControl.invalid ||
+              guardando
+            "
+            (clickEvent)="onGuardar()"
+            class="btn-accion"
+          ></app-boton>
+        </div>
       </div>
 
       <div class="productos-table-container" fxFlex>
@@ -331,27 +364,4 @@
     </div>
   </section>
 
-  <footer class="dialog-footer">
-    <div fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="center center" fxLayoutGap="16px">
-      <app-boton
-        nombre="Cancelar"
-        color="primary"
-        (clickEvent)="onCancelar()"
-        class="btn-accion"
-      ></app-boton>
-      <app-boton
-        #imprimirBtb
-        (focusEvent)="guardarSub.asObservable()"
-        [nombre]="data?.ligarAVenta ? 'Finalizar venta' : 'Imprimir'"
-        color="accent"
-        [disableExpression]="
-          rucControl.invalid ||
-          clienteDescripcionControl.invalid ||
-          guardando
-        "
-        (clickEvent)="onGuardar()"
-        class="btn-accion"
-      ></app-boton>
-    </div>
-  </footer>
 </div>

--- a/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.scss
+++ b/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.scss
@@ -74,6 +74,13 @@
   h4 {
     margin: 0;
   }
+
+  // Cancelar e Imprimir viven en esta fila junto a "+ Producto", no en un
+  // footer al pie: el min-width de 200px que usaban ahi es demasiado aca.
+  .btn-accion {
+    min-width: 130px;
+    height: 42px;
+  }
 }
 
 .productos-table-container {
@@ -135,18 +142,6 @@
   }
 }
 
-.dialog-footer {
-  padding: 16px 0 0;
-  display: flex;
-  justify-content: center;
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.btn-accion {
-  min-width: 200px;
-  height: 40px;
-}
-
 .btn-agregar-producto {
   height: 42px;
 }
@@ -166,9 +161,5 @@ input {
 
   .totales-grid {
     flex-direction: column;
-  }
-
-  .dialog-footer {
-    padding-top: 12px;
   }
 }

--- a/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
+++ b/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
@@ -657,7 +657,11 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
           moneda: this.selectedMoneda,
           tipoCambio: this.tipoCambioControl.value,
         },
-        width: "100%",
+        // Modal de ancho normal (como el resto de la app) en vez de ocupar el
+        // 100%: asi la tabla "Lista de productos" de atras sigue a la vista
+        // mientras se cargan items.
+        width: "620px",
+        maxWidth: "95vw",
       })
       .afterClosed()
       .subscribe((res) => {

--- a/src/app/modules/financiero/factura-legal/edit-factura-legal-item/edit-factura-legal-item.component.html
+++ b/src/app/modules/financiero/factura-legal/edit-factura-legal-item/edit-factura-legal-item.component.html
@@ -119,6 +119,14 @@
   <footer class="dialog-footer">
           <button
             mat-raised-button
+      color="warn"
+      class="btn-accion"
+            (click)="onCancel()"
+          >
+            Cancelar
+          </button>
+          <button
+            mat-raised-button
             [color]="isEditting ? 'accent' : 'primary'"
             [disabled]="isEditting ? !formGroup.valid : false"
       class="btn-accion"
@@ -129,14 +137,6 @@
             "
           >
             {{ isEditting ? "Guardar" : "Editar" }}
-          </button>
-          <button
-            mat-raised-button
-      color="warn"
-      class="btn-accion"
-            (click)="onCancel()"
-          >
-            Cancelar
           </button>
   </footer>
 </div>

--- a/src/app/modules/financiero/factura-legal/edit-factura-legal-item/edit-factura-legal-item.component.html
+++ b/src/app/modules/financiero/factura-legal/edit-factura-legal-item/edit-factura-legal-item.component.html
@@ -9,7 +9,7 @@
       <div class="form-section">
         <!-- Row 1: Cantidad y Precio -->
         <div fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="16px">
-          <div fxFlex="30" fxFlex.lt-sm="100">
+          <div [fxFlex]="mostrarMonedaExtranjera ? 30 : 50" fxFlex.lt-sm="100">
             <mat-form-field class="full-width">
               <mat-label>Cantidad</mat-label>
               <input 
@@ -22,7 +22,7 @@
               />
             </mat-form-field>
           </div>
-          <div fxFlex="35" fxFlex.lt-sm="100">
+          <div [fxFlex]="mostrarMonedaExtranjera ? 35 : 50" fxFlex.lt-sm="100">
             <mat-form-field class="full-width">
               <mat-label>Precio Unitario (Gs)</mat-label>
               <input 
@@ -61,7 +61,19 @@
               formControlName="descripcion"
               autocomplete="off"
               oninput="this.value == ' ' ? this.value = '': null"
+              (keydown.enter)="$event.preventDefault(); buscarProducto()"
+              (click)="buscarProductoSiVacio()"
             />
+            <button
+              mat-icon-button
+              matSuffix
+              type="button"
+              matTooltip="Buscar producto"
+              [disabled]="formGroup.disabled"
+              (click)="buscarProducto()"
+            >
+              <mat-icon>search</mat-icon>
+            </button>
           </mat-form-field>
         </div>
         

--- a/src/app/modules/financiero/factura-legal/edit-factura-legal-item/edit-factura-legal-item.component.ts
+++ b/src/app/modules/financiero/factura-legal/edit-factura-legal-item/edit-factura-legal-item.component.ts
@@ -1,10 +1,15 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { FacturaLegalItem } from '../factura-legal.model';
 import { Moneda } from '../../moneda/moneda.model';
 import { CurrencyMask } from '../../../../commons/core/utils/numbersUtils';
+import {
+  PdvSearchProductoData,
+  PdvSearchProductoDialogComponent,
+  PdvSearchProductoResponseData,
+} from '../../../productos/producto/pdv-search-producto-dialog/pdv-search-producto-dialog.component';
 
 export interface AdicionarFacturaLegalItemData {
   facturaItem: FacturaLegalItem;
@@ -57,6 +62,7 @@ export class EditFacturaLegalItemComponent implements OnInit {
   constructor(
     @Inject(MAT_DIALOG_DATA) private data: AdicionarFacturaLegalItemData,
     private dialogRef: MatDialogRef<EditFacturaLegalItemComponent>,
+    private matDialog: MatDialog,
   ) { }
 
   ngOnInit(): void {
@@ -165,6 +171,63 @@ export class EditFacturaLegalItemComponent implements OnInit {
   onEdit() {
     this.isEditting = true;
     this.formGroup.enable()
+  }
+
+  /**
+   * Abre el buscador generico de productos y autocompleta descripcion, iva y
+   * precio unitario. Los tres campos quedan editables: el buscador es un atajo
+   * para cargarlos, no un reemplazo. Si el usuario cancela, o si el producto no
+   * tiene iva/precio cargado, se conserva lo que ya estaba escrito — el item
+   * cargado a mano (servicios, conceptos libres) sigue funcionando igual.
+   */
+  /**
+   * Atajo: click sobre el campo vacio abre el buscador directo, sin pasar por
+   * la lupa. Una vez que hay texto, el click solo posiciona el cursor — asi la
+   * descripcion se sigue pudiendo corregir a mano; para volver a buscar esta
+   * la lupa o Enter.
+   */
+  buscarProductoSiVacio() {
+    const texto = this.descripcionControl.value;
+    if (texto == null || String(texto).trim() === '') {
+      this.buscarProducto();
+    }
+  }
+
+  buscarProducto() {
+    if (this.formGroup.disabled) return;
+
+    const texto = this.descripcionControl.value;
+    const data: PdvSearchProductoData = {
+      texto: texto != null ? String(texto).toUpperCase() : '',
+      mostrarStock: true,
+    };
+
+    this.matDialog
+      .open(PdvSearchProductoDialogComponent, {
+        data,
+        width: '100%',
+        height: '90%',
+      })
+      .afterClosed()
+      .pipe(untilDestroyed(this))
+      .subscribe((res: PdvSearchProductoResponseData) => {
+        if (res?.producto == null) return;
+
+        const descripcion = res.producto.descripcionFactura || res.producto.descripcion;
+        if (descripcion != null) {
+          this.descripcionControl.setValue(descripcion);
+        }
+        // Solo si el iva del producto es una de las opciones del select; de lo
+        // contrario el mat-select quedaria en blanco con el form marcado valido.
+        if (this.ivaOptions.includes(res.producto.iva)) {
+          this.ivaControl.setValue(res.producto.iva);
+        }
+        // setValue dispara la suscripcion que ya convierte a moneda extranjera
+        // y recalcula los totales; no hace falta tocar nada mas aca.
+        if (res.precio?.precio != null) {
+          this.precioUnitario.setValue(res.precio.precio);
+        }
+      });
   }
 
   onCancel() {

--- a/src/app/modules/financiero/factura-legal/factura-legal.service.ts
+++ b/src/app/modules/financiero/factura-legal/factura-legal.service.ts
@@ -206,8 +206,12 @@ export class FacturaLegalService {
     );
   }
 
-  onGetFacturaLegal(id, sucId, servidor: boolean = true): Observable<FacturaLegal> {
-    return this.genericService.onGetById(this.facturaLegalPorId, id, null, null, servidor, sucId);
+  // silentLoad evita el modal bloqueante de "Buscando...", para consultas que
+  // acompanan una interaccion liviana (ej. expandir una fila de la lista).
+  onGetFacturaLegal(id, sucId, servidor: boolean = true, silentLoad = false): Observable<FacturaLegal> {
+    return this.genericService.onGetById(
+      this.facturaLegalPorId, id, null, null, servidor, sucId, null, null, silentLoad
+    );
   }
 
   onGetFacturaLegalByCdc(cdc: string, servidor: boolean = true): Observable<FacturaLegal>{

--- a/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.html
+++ b/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.html
@@ -476,9 +476,12 @@
               fxLayoutGap="20px"
               fxLayoutAlign="center center"
             >
-              <mat-card appearance="outlined" fxFlex="40%">
-                <div style="text-align: center">
-                  <h4>Item</h4>
+              <mat-card appearance="outlined" fxFlex>
+                <div
+                  *ngIf="cargandoItems"
+                  style="text-align: center; padding: 16px"
+                >
+                  Cargando ítems...
                 </div>
                 <table
                   mat-table
@@ -534,28 +537,17 @@
                   ></tr>
                   <tr
                     mat-row
-                    *matRowDef="
-                      let row;
-                      columns: facturaItemColumnsToDisplay;
-                      let facturaItemIndex = index
-                    "
-                    (click)="onEditFacturaItem(row, facturaItemIndex)"
+                    *matRowDef="let row; columns: facturaItemColumnsToDisplay"
                   ></tr>
                 </table>
-                <br />
-                <div style="width: 100%; text-align: center">
-                  <button
-                    mat-fab
-                    color="primary"
-                    aria-label="adicionar facturaItem"
-                    (click)="
-                      selectedFacturaItem = null; onAddFacturaItem(factura, i)
-                    "
-                    type="button"
-                  >
-                    <mat-icon>add</mat-icon>
-                  </button>
-                </div>
+                <mat-paginator
+                  *ngIf="totalItemsFactura > facturaItemPageSize"
+                  [length]="totalItemsFactura"
+                  [pageSize]="facturaItemPageSize"
+                  [pageIndex]="facturaItemPageIndex"
+                  [hidePageSize]="true"
+                  (page)="onPageItems($event)"
+                ></mat-paginator>
               </mat-card>
             </div>
           </div>
@@ -569,10 +561,7 @@
         class="example-element-row"
         [class.example-expanded-row]="expandedElement === element"
         [class.heightLight]="expandedElement === element"
-        (click)="
-          expandedElement = expandedElement === element ? null : element;
-          facturaItemDataSource.data = element.facturaItemList
-        "
+        (click)="onToggleExpand(element)"
       ></tr>
       <tr
         mat-row
@@ -581,6 +570,7 @@
       ></tr>
     </table>
     <mat-paginator
+      #paginadorFacturas
       itemsPerPageLabel="Itens por pagina"
       [pageSizeOptions]="[15, 25, 50, 100]"
       (page)="handlePageEvent($event)"

--- a/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
+++ b/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
@@ -54,7 +54,10 @@ import { GestionDeDialogComponent } from "../gestion-de-dialog/gestion-de-dialog
   ],
 })
 export class ListFacturaLegalComponent implements OnInit {
-  @ViewChild(MatPaginator) paginator: MatPaginator;
+  // Por referencia y no por tipo: el detalle expandido tiene su propio
+  // mat-paginator y aparece antes en la vista, asi que @ViewChild(MatPaginator)
+  // pasaria a apuntar al de los items al abrir una factura larga.
+  @ViewChild("paginadorFacturas") paginator: MatPaginator;
 
   selectedSucursal: Sucursal;
   sucursalList: Sucursal[];
@@ -93,7 +96,6 @@ export class ListFacturaLegalComponent implements OnInit {
 
   allSucursales = false;
 
-  selectedFacturaItem: FacturaLegalItem;
   facturaList: FacturaLegal[];
   page = 0;
   size = 30;
@@ -121,6 +123,12 @@ export class ListFacturaLegalComponent implements OnInit {
     "precioUnitario",
     "total",
   ];
+
+  // Paginado en memoria de los items de la factura expandida.
+  facturaItemPageSize = 15;
+  facturaItemPageIndex = 0;
+  totalItemsFactura = 0;
+  cargandoItems = false;
 
   selectedResumenFacturas: ResumenFacturasDto;
 
@@ -379,36 +387,68 @@ export class ListFacturaLegalComponent implements OnInit {
     //   })
   }
 
-  onEditFacturaItem(facturaItem, i) {
-    // console.log(i);
-    // this.matDialog.open(AdicionarFacturaItemDialogComponent, {
-    //   data: {
-    //     factura: this.expandedElement,
-    //     facturaItem
-    //   }
-    //   ,
-    //   width: '50%'
-    // }).afterClosed().subscribe(res => {
-    //   if (res != null) {
-    //     this.facturaItemDataSource.data = updateDataSource(this.facturaItemDataSource.data, res, i)
-    //     // this.dataSource.data = updateDataSource(this.dataSource.data, this.facturaItemDataSource.data, i)
-    //   }
-    // })
+  /**
+   * Abre o cierra el detalle de una factura. Los items no vienen en la query de
+   * la lista a proposito: pedirlos ahi obligaria al backend a resolverlos para
+   * las 30 facturas de la pagina (el resolver los busca de a una) aunque no se
+   * expanda ninguna. Se consultan al abrir y quedan cacheados en la factura.
+   */
+  onToggleExpand(factura: FacturaLegal) {
+    if (this.expandedElement === factura) {
+      this.expandedElement = null;
+      return;
+    }
+
+    this.expandedElement = factura;
+    this.facturaItemPageIndex = 0;
+
+    if (factura.facturaLegalItemList != null) {
+      this.cargandoItems = false;
+      this.aplicarPaginaItems(factura);
+      return;
+    }
+
+    // Limpiar antes de pedir: si no, mientras carga se siguen viendo los items
+    // de la factura que estaba abierta.
+    this.cargandoItems = true;
+    this.totalItemsFactura = 0;
+    this.facturaItemDataSource.data = [];
+    this.facturaService
+      .onGetFacturaLegal(factura.id, factura.sucursalId, true, true)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (res) => {
+          factura.facturaLegalItemList = res?.facturaLegalItemList || [];
+          // La fila pudo cambiar mientras viajaba la consulta.
+          if (this.expandedElement === factura) {
+            this.cargandoItems = false;
+            this.aplicarPaginaItems(factura);
+          }
+        },
+        error: () => {
+          if (this.expandedElement === factura) this.cargandoItems = false;
+        },
+      });
   }
 
-  onAddFacturaItem(factura: FacturaLegalItem, i) {
-    // this.matDialog.open(AdicionarFacturaItemDialogComponent, {
-    //   data: {
-    //     factura
-    //   }
-    //   ,
-    //   width: '50%'
-    // }).afterClosed().subscribe(res => {
-    //   if (res != null) {
-    //     this.facturaItemDataSource.data = updateDataSource(this.facturaItemDataSource.data, res)
-    //     // this.dataSource.data = updateDataSource(this.dataSource.data, this.facturaItemDataSource.data, i)
-    //   }
-    // })
+  onPageItems(e: PageEvent) {
+    this.facturaItemPageIndex = e.pageIndex;
+    this.aplicarPaginaItems(this.expandedElement);
+  }
+
+  /**
+   * Corta la pagina en memoria: los items de una factura ya llegaron completos
+   * en la unica consulta, paginarlos es solo presentacion.
+   */
+  private aplicarPaginaItems(factura: FacturaLegal) {
+    const items: FacturaLegalItem[] = factura?.facturaLegalItemList || [];
+    // Campo y no getter: el template lo lee en cada change detection.
+    this.totalItemsFactura = items.length;
+    const desde = this.facturaItemPageIndex * this.facturaItemPageSize;
+    this.facturaItemDataSource.data = items.slice(
+      desde,
+      desde + this.facturaItemPageSize
+    );
   }
 
   resetFiltro() {

--- a/src/app/modules/productos/producto/graphql/graphql-query.ts
+++ b/src/app/modules/productos/producto/graphql/graphql-query.ts
@@ -84,6 +84,7 @@ export const productoSearchPdv = gql`
       balanza
       descripcion
       descripcionFactura
+      iva
       garantia
       vencimiento
       diasVencimiento
@@ -294,6 +295,7 @@ export const productoPorCodigoQuery = gql`
       balanza
       descripcion
       descripcionFactura
+      iva
       garantia
       vencimiento
       diasVencimiento


### PR DESCRIPTION
## Qué resuelve

Cargar un ítem en una factura legal obligaba a tipear la descripción del producto a mano y acordarse de su IVA y su precio. Ahora el campo Descripción abre el buscador genérico de productos y completa esos tres campos, que siguen siendo editables.

De paso quedaron arreglados dos problemas del módulo que aparecieron en el camino:

- **El desplegable de la lista de facturas nunca mostró los ítems.** El template leía `element.facturaItemList` y el campo del modelo se llama `facturaLegalItemList`; y aunque el nombre hubiera estado bien, la lista consulta con `full=false`, que usa `facturaLegalesQuery`, que no pide los ítems. El `+` del panel llamaba a `onAddFacturaItem()`, comentado por completo hace tiempo.
- El diálogo NUEVO ITEM se abría a `width: 100%` y tapaba toda la pantalla, incluida la tabla de productos de atrás.

**Backend: sin cambios.** `FacturaLegalItemInput` ya tenía `productoId`/`presentacionId`, el schema ya exponía `Producto.iva`, y `FacturaLegalResolver` ya resuelve los ítems por factura.

## Commits

| Commit | Qué hace |
|---|---|
| `96ee7e57` | `feat` — el campo Descripción del ítem abre el buscador genérico y autocompleta descripción, IVA y precio |
| `f305a6cd` | `style` — Cancelar e Imprimir pasan a la fila "Lista de productos", junto a "+ Producto" |
| `afe8b61a` | `fix` — el desplegable muestra los ítems, paginados de a 15 |

## Cómo probarlo

1. **Lista de facturas → + Adicionar.** Tocar "+ Producto": el diálogo abre como modal de 620px, con la tabla de atrás a la vista.
2. Click sobre el campo Descripción vacío → se abre el buscador solo. Elegir un producto: se completan descripción, IVA y precio unitario. Editarlos a mano y verificar que Total (Gs) recalcula.
3. Con el campo ya cargado, un click solo posiciona el cursor (la lupa y Enter vuelven a abrir el buscador).
4. Guardar el ítem y verificar que aparece en la tabla "Lista de productos".
5. **Lista de facturas:** desplegar una fila. Deben aparecer los ítems. Con más de 15, usar el paginador. Cerrar y reabrir la misma fila: no debe reconsultar.

## Riesgo

**Bajo.** El payload que sale al backend es idéntico al de hoy: el ítem sigue sin guardar `productoId`/`presentacionId`, y los ítems cargados a mano (servicios, conceptos libres) funcionan igual. Se agregó `iva` a `productoSearchPdv` y `productoPorCodigoQuery` — cambio aditivo, ningún consumidor cambia de comportamiento.

Tres puntos que se cuidaron y conviene mirar en el review:

- `@ViewChild(MatPaginator)` tomaba el primer paginator de la vista, y el del detalle queda antes en el DOM que el de la lista. Al abrir una factura de más de 15 ítems habría pasado a apuntar al equivocado. La query va ahora por referencia de template (`#paginadorFacturas`).
- Los ítems **no** se sumaron a la query de la lista a propósito: `FacturaLegalResolver` los resuelve de a una factura, así que pedirlos ahí serían 30 consultas extra por búsqueda aunque no se despliegue ninguna fila. Se consultan al abrir y quedan cacheados.
- El total de ítems es un campo y no un getter, por la regla del CLAUDE.md sobre llamadas desde el template.

**Efecto colateral asumido:** Cancelar e Imprimir estaban en un footer fuera del área scrolleable y ahora no, así que con muchos ítems se van de la vista al scrollear.

## Impacto en auto-update

Ninguno. No se tocaron `installer.nsh`, `electron-builder.json`, manifests ni nombres de artefactos.

## Verificación

`npm run check` (AOT build de producción) pasa sin errores — `Hash: ef4df5a3962c5ae4`.

No hay unit tests: Karma no compila en este repo por el desfasaje devkit v16 / Angular 15.1.5. La verificación es el AOT build más la prueba manual descrita arriba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)