### PR TITLE
fix(rrhh): lote A — ajuste de salarios y edicion del borrador

### DIFF
--- a/src/app/modules/rrhh/configuracion-rrhh/ajuste-salario-minimo-dialog/ajuste-salario-minimo-dialog.component.html
+++ b/src/app/modules/rrhh/configuracion-rrhh/ajuste-salario-minimo-dialog/ajuste-salario-minimo-dialog.component.html
@@ -14,11 +14,16 @@
     Ningún funcionario quedó por debajo del nuevo mínimo.
   </div>
 
+  <p class="resumen-afectados" *ngIf="!cargando && totalAfectados > 0">
+    {{ totalAfectados }} funcionario/s afectado/s · {{ seleccion.selected.length }} seleccionado/s
+  </p>
+
   <div class="tabla" *ngIf="!cargando && dataSource.data.length > 0">
     <table mat-table [dataSource]="dataSource" class="mat-elevation-z2">
       <ng-container matColumnDef="seleccion">
         <th mat-header-cell *matHeaderCellDef>
-          <mat-checkbox [checked]="todosSeleccionados" (change)="onToggleTodos()"></mat-checkbox>
+          <mat-checkbox [checked]="todosSeleccionados" (change)="onToggleTodos()"
+            [matTooltip]="tooltipTodos"></mat-checkbox>
         </th>
         <td mat-cell *matCellDef="let row">
           <mat-checkbox [checked]="seleccion.isSelected(row)" (change)="onToggleFila(row)"></mat-checkbox>

--- a/src/app/modules/rrhh/configuracion-rrhh/ajuste-salario-minimo-dialog/ajuste-salario-minimo-dialog.component.scss
+++ b/src/app/modules/rrhh/configuracion-rrhh/ajuste-salario-minimo-dialog/ajuste-salario-minimo-dialog.component.scss
@@ -24,9 +24,23 @@
   color: #66bb6a;
 }
 
+// El alto tiene que dar para ver todas las filas sin scroll en el caso normal: el
+// checkbox de "seleccionar todos" del header sticky selecciona TAMBIEN lo que quedo
+// abajo del corte, y eso son cambios de sueldo con historico legal sobre gente que el
+// usuario nunca miro. El borde marca donde termina la lista cuando si hay scroll
+// (en Electron/macOS la scrollbar se auto-oculta y no queda ninguna pista).
 .tabla {
-  max-height: 45vh;
+  max-height: 62vh;
   overflow: auto;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+}
+
+.resumen-afectados {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: #ffca28;
 }
 
 table {

--- a/src/app/modules/rrhh/configuracion-rrhh/ajuste-salario-minimo-dialog/ajuste-salario-minimo-dialog.component.ts
+++ b/src/app/modules/rrhh/configuracion-rrhh/ajuste-salario-minimo-dialog/ajuste-salario-minimo-dialog.component.ts
@@ -6,6 +6,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { MainService } from '../../../../main.service';
 import { NotificacionSnackbarService, NotificacionColor } from '../../../../notificacion-snackbar.service';
 import { ConfiguracionRrhhService } from '../configuracion-rrhh.service';
+import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
 
 export interface AjusteSalarioMinimoDialogData {
   /** Nuevo valor de SALARIO_MINIMO_LEGAL_PYG recien guardado. */
@@ -44,6 +45,7 @@ export class AjusteSalarioMinimoDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: AjusteSalarioMinimoDialogData,
     private dialogRef: MatDialogRef<AjusteSalarioMinimoDialogComponent>,
     private configuracionService: ConfiguracionRrhhService,
+    private dialogosService: DialogosService,
     public mainService: MainService,
     private notificacion: NotificacionSnackbarService
   ) { }
@@ -54,17 +56,28 @@ export class AjusteSalarioMinimoDialogComponent implements OnInit {
     this.puedeConfig = this.mainService.tieneAlgunRol(['RRHH CONFIG']);
     this.configuracionService.onGetFuncionariosBajoMinimo(this.data.minimo)
       .pipe(untilDestroyed(this))
-      .subscribe(res => {
-        this.cargando = false;
-        const filas = (res || []).map(f => ({
-          ...f,
-          diferencia: this.data.minimo - (f.sueldo || 0)
-        }));
-        this.dataSource.data = filas;
-        this.totalAfectados = filas.length;
-        this.tooltipTodos = 'Selecciona los ' + filas.length
-          + ' funcionarios de la lista, incluidos los que no entren en pantalla';
-        // Nada preseleccionado: ajustar un salario es una decision explicita.
+      .subscribe({
+        next: res => {
+          this.cargando = false;
+          const filas = (res || []).map(f => ({
+            ...f,
+            diferencia: this.data.minimo - (f.sueldo || 0)
+          }));
+          this.dataSource.data = filas;
+          this.totalAfectados = filas.length;
+          this.tooltipTodos = 'Selecciona los ' + filas.length
+            + ' funcionarios de la lista, incluidos los que no entren en pantalla';
+          // Nada preseleccionado: ajustar un salario es una decision explicita.
+        },
+        // Sin esto el dialogo se queda en "Buscando..." para siempre: onCustomQuery
+        // no emite cuando la query falla, solo muestra un snackbar.
+        error: () => {
+          this.cargando = false;
+          this.notificacion.notification$.next({
+            texto: 'No se pudo cargar la lista de funcionarios afectados',
+            color: NotificacionColor.warn, duracion: 5
+          });
+        }
       });
   }
 
@@ -95,16 +108,30 @@ export class AjusteSalarioMinimoDialogComponent implements OnInit {
       });
       return;
     }
-    // La moneda NO se manda: el backend usa la de cada funcionario. Mandar una sola
-    // estamparia la moneda del primer seleccionado en el historico de todos.
-    this.configuracionService.onAjustarSalariosAlMinimo(
-      ids, this.data.minimo, this.mainService.usuarioActual?.id
-    ).pipe(untilDestroyed(this)).subscribe(res => {
-      if (res == null) return;
-      this.notificacion.notification$.next({
-        texto: res + ' salario/s ajustado/s', color: NotificacionColor.success, duracion: 4
+    // Confirmacion con los nombres a la vista. La lista puede no entrar entera en
+    // pantalla y "seleccionar todos" alcanza igual a los que quedaron abajo del corte:
+    // esta es la unica pantalla donde el usuario ve, si o si, a quienes le va a tocar
+    // el sueldo. Son registros legales con historico, no se reescriben en silencio.
+    const nombres = this.seleccion.selected
+      .map(f => (f.persona?.nombre || '(sin nombre)') + ' — ' + (f.sueldo || 0) + ' → ' + this.data.minimo);
+    this.dialogosService.confirm(
+      'Confirmar ajuste de salarios',
+      '¿Ajustar el sueldo de ' + ids.length + ' funcionario/s al nuevo mínimo de ' + this.data.minimo + '?',
+      'Cada ajuste queda registrado en el histórico salarial y no se puede deshacer desde acá.',
+      nombres, true, 'Sí, ajustar', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(r => {
+      if (r !== true) return;
+      // La moneda NO se manda: el backend usa la de cada funcionario. Mandar una sola
+      // estamparia la moneda del primer seleccionado en el historico de todos.
+      this.configuracionService.onAjustarSalariosAlMinimo(
+        ids, this.data.minimo, this.mainService.usuarioActual?.id
+      ).pipe(untilDestroyed(this)).subscribe(res => {
+        if (res == null) return;
+        this.notificacion.notification$.next({
+          texto: res + ' salario/s ajustado/s', color: NotificacionColor.success, duracion: 4
+        });
+        this.dialogRef.close(res);
       });
-      this.dialogRef.close(res);
     });
   }
 }

--- a/src/app/modules/rrhh/configuracion-rrhh/ajuste-salario-minimo-dialog/ajuste-salario-minimo-dialog.component.ts
+++ b/src/app/modules/rrhh/configuracion-rrhh/ajuste-salario-minimo-dialog/ajuste-salario-minimo-dialog.component.ts
@@ -35,6 +35,11 @@ export class AjusteSalarioMinimoDialogComponent implements OnInit {
   cargando = true;
   todosSeleccionados = false;
 
+  /** Total real de afectados. Se muestra fijo para que no dependa de cuanto entre en pantalla. */
+  totalAfectados = 0;
+  /** Precalculado: el template no llama funciones (convencion del repo). */
+  tooltipTodos = 'Seleccionar todos';
+
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: AjusteSalarioMinimoDialogData,
     private dialogRef: MatDialogRef<AjusteSalarioMinimoDialogComponent>,
@@ -56,6 +61,9 @@ export class AjusteSalarioMinimoDialogComponent implements OnInit {
           diferencia: this.data.minimo - (f.sueldo || 0)
         }));
         this.dataSource.data = filas;
+        this.totalAfectados = filas.length;
+        this.tooltipTodos = 'Selecciona los ' + filas.length
+          + ' funcionarios de la lista, incluidos los que no entren en pantalla';
         // Nada preseleccionado: ajustar un salario es una decision explicita.
       });
   }

--- a/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.html
+++ b/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.html
@@ -63,7 +63,7 @@
           <button mat-icon-button color="primary" *ngIf="liq.estado === 'BORRADOR'" (click)="onEditarItemInit(row)" matTooltip="Editar">
             <mat-icon>edit</mat-icon>
           </button>
-          <button mat-icon-button color="warn" *ngIf="row.manual && liq.estado === 'BORRADOR'" (click)="onEliminarItem(row)" matTooltip="Eliminar">
+          <button mat-icon-button color="warn" *ngIf="liq.estado === 'BORRADOR'" (click)="onEliminarItem(row)" matTooltip="Eliminar">
             <mat-icon>delete</mat-icon>
           </button>
         </td>

--- a/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.ts
+++ b/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.ts
@@ -129,8 +129,22 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
   }
 
   onEliminarItem(it: LiquidacionItem) {
-    this.liquidacionService.onEliminarItem(it.id)
-      .pipe(untilDestroyed(this)).subscribe(res => { if (res != null) { this.recargar(); } });
+    // Los items automaticos tambien se pueden eliminar (el backend nunca lo impidio,
+    // solo exige BORRADOR). Ojo: "Regenerar" los vuelve a crear, porque generarBorrador
+    // solo preserva los manuales — igual que ya pasa con la edicion de un automatico.
+    const aviso = it.manual
+      ? null
+      : 'Es un item automatico: si volvés a generar el borrador, se recalcula y reaparece.';
+    this.dialogosService.confirm(
+      'Eliminar item',
+      '¿Eliminar "' + (it.descripcion || '') + '" de la liquidación?',
+      aviso, null, true, 'Sí', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(r => {
+      if (r === true) {
+        this.liquidacionService.onEliminarItem(it.id)
+          .pipe(untilDestroyed(this)).subscribe(res => { if (res != null) { this.recargar(); } });
+      }
+    });
   }
 
   onAprobar() {


### PR DESCRIPTION
Lado desktop del lote A. **PR hermano: GabFrank/franco-system-backend-servidor#230**, que tiene el contexto completo y el plan.

## B3 — se ajustaban sueldos de gente que el usuario nunca vio

En el diálogo *"Funcionarios por debajo del nuevo mínimo"*, de 15 afectados se veían ~10. No era paginación ni filtro: la tabla tenía `max-height: 45vh` con el header `sticky: true`. Los 15 `<tr>` estaban en el DOM y el resto quedaba abajo del corte, sin ninguna pista — en Electron/macOS la scrollbar se auto-oculta.

El checkbox de "seleccionar todos" vive en ese header siempre visible y hace `dataSource.data.forEach(...)` sobre el array **completo**, y `onConfirmar()` manda esa selección tal cual. Son cambios de sueldo con histórico legal.

Hoy no ocurría solo porque B1 hacía explotar el mutation antes de persistir. **Al arreglar B1, el flujo quedaba armado para hacerlo** — por eso los dos van juntos.

**Lo que faltaba de verdad**: la acción no tenía **ninguna confirmación**. Subir el alto ayuda pero no cierra nada — sigue siendo un límite fijo sobre una lista de tamaño variable, y un contador informa, no impide. Ahora confirma listando nombre, sueldo actual y sueldo nuevo de cada seleccionado. Es la única pantalla donde el usuario ve sí o sí a quiénes les va a tocar el sueldo, entre en pantalla la tabla o no.

También va el handler de error que faltaba: `onCustomQuery` no emite cuando la query falla, solo muestra un snackbar, así que el diálogo se quedaba en *"Buscando…"* para siempre.

## B6 — el botón de eliminar estaba escondido de más

El backend **ya lo permitía**: `eliminarItem` solo exige `BORRADOR` y no filtra por `manual`. El mutation, el servicio y el handler estaban todos conectados. El bug era una condición de más en el `*ngIf`, que el botón de **editar** al lado no tiene:

```html
*ngIf="row.manual && liq.estado === 'BORRADOR'"
```

Borrar en `BORRADOR` es seguro: `aplicarEfectosCruzados` se invoca solo desde `pagar`, `anular` y `sincronizarDesdeSolicitudPago` (verificado, no hay más call-sites), así que todavía no hay ningún efecto aplicado sobre el vale o la cuota de origen que quede colgado.

Agrega la confirmación que no había, con un aviso condicional para automáticos: *"si volvés a generar el borrador, se recalcula y reaparece"*. Es una limitación real — `generarBorrador` solo preserva `manual=true` — pero no es nueva: la **edición** de automáticos ya se comporta igual.

## Cómo probarlo

1. Configuración RRHH → subí el salario mínimo → en el diálogo, "seleccionar todos" → **Ajustar**. Tiene que pedir confirmación listando a cada uno con su sueldo actual y el nuevo.
2. Liquidaciones → una en `BORRADOR` → **Detalle**. Los ítems `Origen: AUTO` tienen que mostrar el tacho. Al borrar, pide confirmación con el aviso, y los totales se recalculan.

### Ya verificado con Claude in Chrome

Contra el central local: los ítems `AUTO` muestran el botón, la confirmación sale con el aviso condicional, y al confirmar el ítem se borra con los totales recalculados (descuentos 1.000.000 → 0, neto 2.044.000 → 3.044.000).

`npm run check` (AOT): **0 errores**, `Initial Total 15.72 MB`.

> Ojo al correrlo: `"check"` no lleva el `NODE_OPTIONS=--max_old_space_size=8192` que sí tiene `"ng:serve"`, y en una máquina cargada muere sin escribir una línea de error. Además el proceso **no sale** al terminar — hay que mirar el log o `dist/`, no el CPU. Va como `chore` aparte.

## Impacto

Sin cambios de API ni de contrato GraphQL. Sin impacto en auto-update.

**Riesgo: bajo.** Todo es UI de RRHH; la lógica de `SelectionModel` no se tocó.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
