### PR TITLE
feat(rrhh): lote B — cargos, amonestaciones y operacion del item manual

### DIFF
--- a/src/app/modules/empresarial/cargo/cargo.model.ts
+++ b/src/app/modules/empresarial/cargo/cargo.model.ts
@@ -1,4 +1,3 @@
-import { Ciudad } from '../../general/ciudad/ciudad.model';
 import { Usuario } from '../../personas/usuarios/usuario.model';
 
 export class Cargo {
@@ -8,6 +7,26 @@ export class Cargo {
   supervisadoPor: Cargo;
   sueldoBase: number;
   creadoEn: Date;
-  subcargoList: Cargo[]
+  subcargoList: Cargo[];
   usuario: Usuario;
+
+  toInput(): CargoInput {
+    return {
+      id: this.id,
+      nombre: this.nombre,
+      descripcion: this.descripcion,
+      sueldoBase: this.sueldoBase,
+      supervisadoPorId: this.supervisadoPor?.id,
+      usuarioId: this.usuario?.id
+    };
+  }
+}
+
+export interface CargoInput {
+  id: number;
+  nombre: string;
+  descripcion: string;
+  sueldoBase: number;
+  supervisadoPorId: number;
+  usuarioId: number;
 }

--- a/src/app/modules/empresarial/cargo/cargo.service.ts
+++ b/src/app/modules/empresarial/cargo/cargo.service.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { CargosGQL } from './graphql/Cargos';
 import { CargosSearchGQL } from './graphql/CargosSearch';
+import { SaveCargoGQL } from './graphql/SaveCargo';
+import { DeleteCargoGQL } from './graphql/DeleteCargo';
 import { GenericCrudService } from '../../../generics/generic-crud.service';
+import { Cargo } from './cargo.model';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +15,9 @@ export class CargoService {
   constructor(
     private genericService: GenericCrudService,
     private getAllCargos: CargosGQL,
-    private cargosSearch: CargosSearchGQL
+    private cargosSearch: CargosSearchGQL,
+    private saveCargoGQL: SaveCargoGQL,
+    private deleteCargoGQL: DeleteCargoGQL
   ) { }
 
   onGetAll(servidor = true): Observable<any> {
@@ -21,5 +26,18 @@ export class CargoService {
 
   onSearch(texto, servidor = true): Observable<any> {
     return this.genericService.onGetByTexto(this.cargosSearch, texto, servidor);
+  }
+
+  onSave(input: any, servidor = true): Observable<Cargo> {
+    return this.genericService.onSave<Cargo>(this.saveCargoGQL, input, null, null, servidor);
+  }
+
+  /**
+   * El backend rechaza con GraphQLException si el cargo esta en uso (funcionarios,
+   * historico o subcargos) y ese mensaje llega solo al snackbar. Sin ese chequeo previo,
+   * CrudService.deleteById devolveria false en silencio y la UI diria "eliminado con exito".
+   */
+  onDelete(id: number, servidor = true): Observable<any> {
+    return this.genericService.onDelete(this.deleteCargoGQL, id, null, null, false, servidor);
   }
 }

--- a/src/app/modules/empresarial/cargo/edit-cargo-dialog/edit-cargo-dialog.component.html
+++ b/src/app/modules/empresarial/cargo/edit-cargo-dialog/edit-cargo-dialog.component.html
@@ -1,0 +1,34 @@
+<div class="dialog-container" fxLayout="column" fxLayoutGap="10px">
+  <h2 class="titulo-dialog">{{ selectedCargo.id ? 'Editar' : 'Nuevo' }} cargo</h2>
+  <div class="subtitulo-dialog" *ngIf="selectedCargo.id">{{ selectedCargo.nombre }}</div>
+
+  <form [formGroup]="formGroup" fxLayout="column" fxLayoutGap="12px">
+    <mat-form-field style="width: 100%">
+      <mat-label>Nombre</mat-label>
+      <input matInput [formControl]="nombreControl" required />
+      <mat-error *ngIf="nombreControl.hasError('required')">El nombre es obligatorio</mat-error>
+    </mat-form-field>
+    <mat-form-field style="width: 100%">
+      <mat-label>Descripción</mat-label>
+      <input matInput [formControl]="descripcionControl" />
+    </mat-form-field>
+    <mat-form-field style="width: 100%">
+      <mat-label>Sueldo base</mat-label>
+      <input matInput type="number" [formControl]="sueldoBaseControl" />
+      <mat-hint>Referencia del cargo; el sueldo real vive en el legajo del funcionario</mat-hint>
+    </mat-form-field>
+    <mat-form-field style="width: 100%">
+      <mat-label>Depende de</mat-label>
+      <mat-select [formControl]="supervisadoPorControl">
+        <mat-option [value]="null">Ninguno</mat-option>
+        <mat-option *ngFor="let c of cargosSupervisores" [value]="c.id">{{ c.nombre }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </form>
+
+  <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
+    <button mat-stroked-button (click)="onCancelar()">Cancelar</button>
+    <button *ngIf="!isEditting" mat-raised-button color="primary" (click)="onHabilitarEdicion()">Editar</button>
+    <button *ngIf="isEditting" mat-raised-button color="primary" [disabled]="formGroup.invalid" (click)="onGuardar()">Guardar</button>
+  </div>
+</div>

--- a/src/app/modules/empresarial/cargo/edit-cargo-dialog/edit-cargo-dialog.component.scss
+++ b/src/app/modules/empresarial/cargo/edit-cargo-dialog/edit-cargo-dialog.component.scss
@@ -1,0 +1,20 @@
+// Cabecera con el patron del resto de los dialogos del modulo.
+.dialog-container {
+  padding: 8px 16px 4px;
+  box-sizing: border-box;
+}
+
+.titulo-dialog {
+  text-align: center;
+  margin: 4px 0 2px;
+  font-weight: 500;
+  font-size: 20px;
+  color: #fff;
+}
+
+.subtitulo-dialog {
+  text-align: center;
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: #ff9800;
+}

--- a/src/app/modules/empresarial/cargo/edit-cargo-dialog/edit-cargo-dialog.component.ts
+++ b/src/app/modules/empresarial/cargo/edit-cargo-dialog/edit-cargo-dialog.component.ts
@@ -1,0 +1,93 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { MainService } from '../../../../main.service';
+import { Cargo } from '../cargo.model';
+import { CargoService } from '../cargo.service';
+
+export interface CargoDialogData {
+  cargo: Cargo;
+}
+
+@UntilDestroy()
+@Component({
+  selector: 'app-edit-cargo-dialog',
+  templateUrl: './edit-cargo-dialog.component.html',
+  styleUrls: ['./edit-cargo-dialog.component.scss']
+})
+export class EditCargoDialogComponent implements OnInit {
+
+  selectedCargo: Cargo;
+  formGroup: FormGroup;
+  isEditting = false;
+
+  nombreControl = new FormControl(null, [Validators.required]);
+  descripcionControl = new FormControl(null);
+  sueldoBaseControl = new FormControl(null);
+  supervisadoPorControl = new FormControl(null);
+
+  /** Opciones de "depende de". Excluye el propio cargo: nadie se supervisa a si mismo. */
+  cargosSupervisores: Cargo[] = [];
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) private data: CargoDialogData,
+    private dialogRef: MatDialogRef<EditCargoDialogComponent>,
+    private cargoService: CargoService,
+    private mainService: MainService
+  ) {
+    this.selectedCargo = data?.cargo != null ? data.cargo : new Cargo();
+  }
+
+  ngOnInit(): void {
+    this.formGroup = new FormGroup({
+      nombre: this.nombreControl,
+      descripcion: this.descripcionControl,
+      sueldoBase: this.sueldoBaseControl,
+      supervisadoPor: this.supervisadoPorControl
+    });
+
+    this.cargoService.onGetAll().pipe(untilDestroyed(this)).subscribe(res => {
+      // No hay validacion de ciclos en el backend, asi que al menos no ofrecemos el
+      // propio cargo como su supervisor.
+      this.cargosSupervisores = (res || []).filter(c => c.id !== this.selectedCargo.id);
+    });
+
+    if (this.selectedCargo.id) {
+      this.nombreControl.setValue(this.selectedCargo.nombre);
+      this.descripcionControl.setValue(this.selectedCargo.descripcion);
+      this.sueldoBaseControl.setValue(this.selectedCargo.sueldoBase);
+      this.supervisadoPorControl.setValue(this.selectedCargo.supervisadoPor?.id);
+      this.formGroup.disable();
+    } else {
+      this.isEditting = true;
+    }
+  }
+
+  onHabilitarEdicion() {
+    this.isEditting = true;
+    this.formGroup.enable();
+  }
+
+  onCancelar() {
+    this.dialogRef.close(null);
+  }
+
+  onGuardar() {
+    if (this.formGroup.invalid) { return; }
+    // Apollo congela los resultados: se clona antes de mutar.
+    const aux = new Cargo();
+    Object.assign(aux, this.selectedCargo);
+    aux.nombre = this.nombreControl.value?.toUpperCase();
+    aux.descripcion = this.descripcionControl.value ? this.descripcionControl.value.toUpperCase() : null;
+    aux.sueldoBase = this.sueldoBaseControl.value;
+    aux.supervisadoPor = this.supervisadoPorControl.value
+      ? this.cargosSupervisores.find(c => c.id === this.supervisadoPorControl.value)
+      : null;
+    aux.usuario = this.mainService.usuarioActual;
+
+    this.cargoService.onSave(aux.toInput())
+      .pipe(untilDestroyed(this))
+      .subscribe(res => { if (res != null) this.dialogRef.close(res); });
+  }
+}

--- a/src/app/modules/empresarial/cargo/graphql/DeleteCargo.ts
+++ b/src/app/modules/empresarial/cargo/graphql/DeleteCargo.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { deleteCargoQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class DeleteCargoGQL extends Mutation<Response> { document = deleteCargoQuery; }

--- a/src/app/modules/empresarial/cargo/graphql/SaveCargo.ts
+++ b/src/app/modules/empresarial/cargo/graphql/SaveCargo.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { saveCargoQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class SaveCargoGQL extends Mutation<Response> { document = saveCargoQuery; }

--- a/src/app/modules/empresarial/cargo/graphql/graphql-query.ts
+++ b/src/app/modules/empresarial/cargo/graphql/graphql-query.ts
@@ -1,44 +1,40 @@
 import gql from "graphql-tag";
 
+const CARGO_FIELDS = `
+  id
+  nombre
+  descripcion
+  sueldoBase
+  supervisadoPor { id nombre }
+  subcargoList { id nombre }
+`;
+
 export const cargosQuery = gql`
   {
-    data: cargos {
-      id
-      nombre
-      descripcion
-      sueldoBase
-      subcargoList {
-        id
-        nombre
-      }
-    }
+    data: cargos { ${CARGO_FIELDS} }
   }
 `;
 
 export const cargosSearch = gql`
   query ($texto: String) {
-    data: cargosSearch(texto: $texto) {
-      id
-      nombre
-      descripcion
-      subcargoList {
-        id
-        nombre
-      }
-    }
+    data: cargosSearch(texto: $texto) { ${CARGO_FIELDS} }
   }
 `;
 
 export const cargoQuery = gql`
   query ($id: ID!) {
-    data: cargo(id: $id) {
-      id
-      nombre
-      descripcion
-      subcargoList {
-        id
-        nombre
-      }
-    }
+    data: cargo(id: $id) { ${CARGO_FIELDS} }
+  }
+`;
+
+export const saveCargoQuery = gql`
+  mutation saveCargo($entity: CargoInput!) {
+    data: saveCargo(cargo: $entity) { ${CARGO_FIELDS} }
+  }
+`;
+
+export const deleteCargoQuery = gql`
+  mutation deleteCargo($id: ID!) {
+    data: deleteCargo(id: $id)
   }
 `;

--- a/src/app/modules/empresarial/cargo/list-cargo/list-cargo.component.html
+++ b/src/app/modules/empresarial/cargo/list-cargo/list-cargo.component.html
@@ -1,0 +1,49 @@
+<app-generic-list titulo="Cargos" style="height: 100%" [isAdicionar]="true" (adicionar)="onNuevo()"
+  (filtrar)="onFiltrar()" (resetFiltro)="onResetFiltro()">
+
+  <div filtros fxLayout="row wrap" fxLayoutGap="10px" style="width: 100%">
+    <mat-form-field fxFlex="320px">
+      <mat-label>Nombre o descripción</mat-label>
+      <input matInput [formControl]="textoControl" (keyup.enter)="onFiltrar()" />
+    </mat-form-field>
+  </div>
+
+  <div table style="height: 100%" fxLayout="column" fxLayoutAlign="space-between start">
+    <table mat-table [dataSource]="dataSource" class="mat-elevation-z2" style="width: 100%">
+      <ng-container matColumnDef="nombre">
+        <th mat-header-cell *matHeaderCellDef>Nombre</th>
+        <td mat-cell *matCellDef="let row">{{ row.nombre }}</td>
+      </ng-container>
+      <ng-container matColumnDef="descripcion">
+        <th mat-header-cell *matHeaderCellDef>Descripción</th>
+        <td mat-cell *matCellDef="let row">{{ row.descripcion }}</td>
+      </ng-container>
+      <ng-container matColumnDef="sueldoBase">
+        <th mat-header-cell *matHeaderCellDef>Sueldo base</th>
+        <td mat-cell *matCellDef="let row">{{ row.sueldoBase | number:'1.0-0' }}</td>
+      </ng-container>
+      <ng-container matColumnDef="supervisadoPor">
+        <th mat-header-cell *matHeaderCellDef>Depende de</th>
+        <td mat-cell *matCellDef="let row">{{ row.supervisadoPor?.nombre }}</td>
+      </ng-container>
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>Acciones</th>
+        <td mat-cell *matCellDef="let row">
+          <button mat-icon-button [matMenuTriggerFor]="menu" (click)="$event.stopPropagation()">
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #menu="matMenu">
+            <button mat-menu-item (click)="onEditar(row)">
+              <mat-icon>edit</mat-icon><span>Editar</span>
+            </button>
+            <button mat-menu-item (click)="onEliminar(row)">
+              <mat-icon>delete</mat-icon><span>Eliminar</span>
+            </button>
+          </mat-menu>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </div>
+</app-generic-list>

--- a/src/app/modules/empresarial/cargo/list-cargo/list-cargo.component.ts
+++ b/src/app/modules/empresarial/cargo/list-cargo/list-cargo.component.ts
@@ -1,0 +1,75 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatDialog } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { MainService } from '../../../../main.service';
+import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
+import { Cargo } from '../cargo.model';
+import { CargoService } from '../cargo.service';
+import { EditCargoDialogComponent } from '../edit-cargo-dialog/edit-cargo-dialog.component';
+
+/**
+ * ABM de cargos. El backend ya existia entero (CargoGraphQL); lo que faltaba era esta
+ * pantalla, asi que los cargos solo se podian crear tocando la base.
+ */
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'app-list-cargo',
+  templateUrl: './list-cargo.component.html',
+  styleUrls: ['./list-cargo.component.scss']
+})
+export class ListCargoComponent implements OnInit {
+
+  displayedColumns = ['nombre', 'descripcion', 'sueldoBase', 'supervisadoPor', 'acciones'];
+  dataSource = new MatTableDataSource<Cargo>([]);
+
+  textoControl = new FormControl(null);
+
+  constructor(
+    private cargoService: CargoService,
+    public mainService: MainService,
+    private dialog: MatDialog,
+    private dialogosService: DialogosService
+  ) { }
+
+  ngOnInit(): void {
+    this.onFiltrar();
+  }
+
+  onFiltrar() {
+    const texto = this.textoControl.value;
+    const obs = texto ? this.cargoService.onSearch(texto) : this.cargoService.onGetAll();
+    obs.pipe(untilDestroyed(this)).subscribe(res => {
+      if (res != null) { this.dataSource.data = res || []; }
+    });
+  }
+
+  onResetFiltro() {
+    this.textoControl.setValue(null);
+    this.onFiltrar();
+  }
+
+  onNuevo() {
+    this.dialog.open(EditCargoDialogComponent, { width: '520px', disableClose: true })
+      .afterClosed().pipe(untilDestroyed(this)).subscribe(res => { if (res != null) this.onFiltrar(); });
+  }
+
+  onEditar(cargo: Cargo) {
+    this.dialog.open(EditCargoDialogComponent, { data: { cargo }, width: '520px', disableClose: true })
+      .afterClosed().pipe(untilDestroyed(this)).subscribe(res => { if (res != null) this.onFiltrar(); });
+  }
+
+  onEliminar(cargo: Cargo) {
+    this.dialogosService.confirm(
+      'Eliminar cargo', '¿Desea eliminar el cargo ' + cargo.nombre + '?',
+      'Si hay funcionarios con este cargo, historico o subcargos, el backend lo rechaza y te lo dice.',
+      null, true, 'Sí', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(res => {
+      if (res === true) {
+        this.cargoService.onDelete(cargo.id)
+          .pipe(untilDestroyed(this)).subscribe(ok => { if (ok) this.onFiltrar(); });
+      }
+    });
+  }
+}

--- a/src/app/modules/empresarial/empresarial.module.ts
+++ b/src/app/modules/empresarial/empresarial.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ListSectorComponent } from './sector/list-sector/list-sector.component';
+import { ListCargoComponent } from './cargo/list-cargo/list-cargo.component';
+import { EditCargoDialogComponent } from './cargo/edit-cargo-dialog/edit-cargo-dialog.component';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MaterialModule } from '../../commons/core/material.module';
 import { SharedModule } from '../../shared/shared.module';
@@ -15,6 +17,8 @@ import { EditSucursalDialogComponent } from './sucursal/edit-sucursal-dialog/edi
 @NgModule({
   declarations: [
     ListSectorComponent,
+    ListCargoComponent,
+    EditCargoDialogComponent,
     AdicionarZonaDialogComponent,
     AdicionarSectorDialogComponent,
     ListSucursalComponent,

--- a/src/app/modules/rrhh/configuracion-rrhh/configuracion-rrhh-catalogo.ts
+++ b/src/app/modules/rrhh/configuracion-rrhh/configuracion-rrhh-catalogo.ts
@@ -55,6 +55,7 @@ export const CONFIGURACION_RRHH_CAMPO_META: { [clave: string]: ConfigCampoMeta }
 
   // Tardanza y penalización
   PENALIZACION_AUTO_TARDANZA: { widget: 'toggle' },
+  LIQUIDACION_CONSOLIDAR_CUOTAS_CREDITO: { widget: 'toggle' },
   TOLERANCIA_TARDANZA_MIN: { widget: 'number', unidad: 'min', min: 0, step: 1 },
   PENALIZACION_MONTO_POR_MINUTO_TARDANZA: { widget: 'money' },
   PENALIZACION_MONTO_TARDANZA: { widget: 'money' },
@@ -109,6 +110,11 @@ export const CONFIGURACION_RRHH_SECCIONES: ConfigSeccion[] = [
     icono: 'schedule',
     claves: ['PENALIZACION_AUTO_TARDANZA', 'TOLERANCIA_TARDANZA_MIN',
       'PENALIZACION_MONTO_POR_MINUTO_TARDANZA', 'PENALIZACION_MONTO_TARDANZA']
+  },
+  {
+    titulo: 'Liquidación y recibo',
+    icono: 'receipt_long',
+    claves: ['LIQUIDACION_CONSOLIDAR_CUOTAS_CREDITO', 'EMPRESA_DIRECCION', 'EMPRESA_TELEFONO']
   },
   {
     titulo: 'General',

--- a/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.html
+++ b/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.html
@@ -35,6 +35,9 @@
         [value]="(puntuacionAsistencia | number:'1.1-1') + ' / 10'" label="Puntuación asistencia"></dash-stat-chip>
       <dash-stat-chip class="clickable" (click)="onVerMetas()" icon="flag" color="warning"
         [value]="metasLogradas + ' / ' + metasTotal" label="Metas y objetivos del mes"></dash-stat-chip>
+      <!-- A diferencia de los tres de arriba, este NO es placeholder: sale del backend. -->
+      <dash-stat-chip icon="gavel" [color]="advertencias > 0 ? 'danger' : 'success'"
+        [value]="advertencias" label="Amonestaciones"></dash-stat-chip>
     </div>
 
     <!-- Accesos rápidos -->

--- a/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.ts
+++ b/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.ts
@@ -17,6 +17,7 @@ import { EgresarFuncionarioDialogComponent } from '../egresar-funcionario-dialog
 import { SubirDocumentoDialogComponent } from '../subir-documento-dialog/subir-documento-dialog.component';
 import { LiquidacionFinalDialogComponent } from '../../liquidacion-final/liquidacion-final-dialog/liquidacion-final-dialog.component';
 import { LiquidacionFinalGenerarDialogComponent } from '../../liquidacion-final/liquidacion-final-generar-dialog/liquidacion-final-generar-dialog.component';
+import { PenalizacionService } from '../../penalizacion/penalizacion.service';
 import { LiquidacionFinalService } from '../../liquidacion-final/liquidacion-final.service';
 import { Tab } from '../../../../layouts/tab/tab.model';
 import { TabService, TabData } from '../../../../layouts/tab/tab.service';
@@ -48,6 +49,12 @@ export class LegajoFuncionarioComponent implements OnInit {
   metasLogradas = 4;
   metasTotal = 11;
 
+  /**
+   * Amonestaciones no anuladas del funcionario. A diferencia de los otros tres chips,
+   * este NO es placeholder: sale del backend.
+   */
+  advertencias = 0;
+
   antiguedadTexto = '—';   // calculado al cargar el funcionario (no en template, regla del proyecto)
 
   cargoColumns = ['cargo', 'fechaDesde', 'fechaHasta', 'motivo'];
@@ -72,6 +79,7 @@ export class LegajoFuncionarioComponent implements OnInit {
     private notificacion: NotificacionSnackbarService,
     private tabService: TabService,
     private liquidacionFinalService: LiquidacionFinalService,
+    private penalizacionService: PenalizacionService,
     public mainService: MainService
   ) { }
 
@@ -96,6 +104,8 @@ export class LegajoFuncionarioComponent implements OnInit {
         this.funcionario = f;
         this.antiguedadTexto = this.calcularAntiguedad(f?.fechaIngreso);
       });
+    this.penalizacionService.onContarAdvertencias(this.funcionarioControl.value)
+      .pipe(untilDestroyed(this)).subscribe(n => { this.advertencias = n ?? 0; });
     this.recargar();
   }
 

--- a/src/app/modules/rrhh/liquidacion/graphql/ConceptosParaItemManual.ts
+++ b/src/app/modules/rrhh/liquidacion/graphql/ConceptosParaItemManual.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { conceptosParaItemManualQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class ConceptosParaItemManualGQL extends Query<Response> { document = conceptosParaItemManualQuery; }

--- a/src/app/modules/rrhh/liquidacion/graphql/graphql-query.ts
+++ b/src/app/modules/rrhh/liquidacion/graphql/graphql-query.ts
@@ -42,8 +42,15 @@ export const generarMesMutation = gql`
   mutation generarLiquidacionesMes($periodo: String!, $monedaId: ID) { data: generarLiquidacionesMes(periodo: $periodo, monedaId: $monedaId) }
 `;
 export const agregarItemMutation = gql`
-  mutation agregarItemLiquidacion($liquidacionId: ID!, $descripcion: String, $monto: Float, $tipo: LiquidacionItemTipo) {
-    data: agregarItemLiquidacion(liquidacionId: $liquidacionId, descripcion: $descripcion, monto: $monto, tipo: $tipo) { ${ITEM_FIELDS} }
+  mutation agregarItemLiquidacion($liquidacionId: ID!, $descripcion: String, $monto: Float, $tipo: LiquidacionItemTipo, $liquidacionConceptoId: ID) {
+    data: agregarItemLiquidacion(liquidacionId: $liquidacionId, descripcion: $descripcion, monto: $monto, tipo: $tipo, liquidacionConceptoId: $liquidacionConceptoId) { ${ITEM_FIELDS} }
+  }
+`;
+// Operaciones elegibles al cargar un item a mano. El backend deriva el signo de esHaber,
+// asi que la UI no pide tipo por separado.
+export const conceptosParaItemManualQuery = gql`
+  query liquidacionConceptosParaItemManual {
+    data: liquidacionConceptosParaItemManual { id codigo descripcion esHaber }
   }
 `;
 export const editarItemMutation = gql`

--- a/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.html
+++ b/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.html
@@ -7,15 +7,22 @@
   <!-- Alta de item manual: sobre la tabla, oculta hasta que se presiona Agregar Item -->
   <div class="agregar-panel" *ngIf="mostrarAgregar && liq.estado === 'BORRADOR'"
     fxLayout="row" fxLayout.lt-md="column" fxLayoutGap="10px" fxLayoutAlign="start center">
+    <mat-form-field fxFlex="220px" *ngIf="!editandoItemId">
+      <mat-label>Operación</mat-label>
+      <mat-select [formControl]="conceptoControl" (selectionChange)="onConceptoChange()">
+        <mat-option *ngFor="let c of conceptos" [value]="c.id">{{ c.descripcion }}</mat-option>
+      </mat-select>
+      <mat-hint>{{ signoConcepto }}</mat-hint>
+    </mat-form-field>
     <mat-form-field fxFlex>
-      <mat-label>Concepto</mat-label>
-      <input matInput [formControl]="descripcionControl" />
+      <mat-label>Observación</mat-label>
+      <input matInput [formControl]="descripcionControl" placeholder="Opcional: detalle del ítem" />
     </mat-form-field>
     <mat-form-field fxFlex="160px">
       <mat-label>Monto</mat-label>
       <input matInput type="number" [formControl]="montoControl" />
     </mat-form-field>
-    <mat-form-field fxFlex="160px">
+    <mat-form-field fxFlex="160px" *ngIf="editandoItemId">
       <mat-label>Tipo</mat-label>
       <mat-select [formControl]="tipoControl">
         <mat-option *ngFor="let t of tipoOptions" [value]="t">{{ t }}</mat-option>

--- a/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.html
+++ b/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.html
@@ -7,12 +7,13 @@
   <!-- Alta de item manual: sobre la tabla, oculta hasta que se presiona Agregar Item -->
   <div class="agregar-panel" *ngIf="mostrarAgregar && liq.estado === 'BORRADOR'"
     fxLayout="row" fxLayout.lt-md="column" fxLayoutGap="10px" fxLayoutAlign="start center">
-    <mat-form-field fxFlex="220px" *ngIf="!editandoItemId">
+    <mat-form-field fxFlex="220px" *ngIf="!editandoItemId && !sinCatalogo">
       <mat-label>Operación</mat-label>
-      <mat-select [formControl]="conceptoControl" (selectionChange)="onConceptoChange()">
+      <mat-select [formControl]="conceptoControl" (selectionChange)="onConceptoChange()" required>
         <mat-option *ngFor="let c of conceptos" [value]="c.id">{{ c.descripcion }}</mat-option>
       </mat-select>
       <mat-hint>{{ signoConcepto }}</mat-hint>
+      <mat-error *ngIf="conceptoControl.hasError('required')">Elegí la operación</mat-error>
     </mat-form-field>
     <mat-form-field fxFlex>
       <mat-label>Observación</mat-label>
@@ -22,7 +23,8 @@
       <mat-label>Monto</mat-label>
       <input matInput type="number" [formControl]="montoControl" />
     </mat-form-field>
-    <mat-form-field fxFlex="160px" *ngIf="editandoItemId">
+    <!-- Fallback: sin catalogo cargado hay que poder elegir el signo a mano. -->
+    <mat-form-field fxFlex="160px" *ngIf="editandoItemId || sinCatalogo">
       <mat-label>Tipo</mat-label>
       <mat-select [formControl]="tipoControl">
         <mat-option *ngFor="let t of tipoOptions" [value]="t">{{ t }}</mat-option>

--- a/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.ts
+++ b/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.ts
@@ -43,6 +43,16 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
   tipoControl = new FormControl('DESCUENTO');
   tipoOptions = ['HABER', 'DESCUENTO'];
 
+  /**
+   * Operaciones elegibles al cargar un item a mano. El backend deriva el signo de
+   * esHaber del catalogo, asi que la UI no pide el tipo por separado: elegir
+   * "Bonificacion" ya implica HABER y "Faltante de caja" ya implica DESCUENTO.
+   */
+  conceptos: any[] = [];
+  conceptoControl = new FormControl(null);
+  /** Precalculado para el template (el repo no llama funciones desde el HTML). */
+  signoConcepto = '';
+
   // Gating por rol (UX; el backend valida de todas formas). ADMIN por rol o nickname.
   puedeLiquidar = false;
   puedeAprobar = false;
@@ -61,6 +71,9 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
   ngOnInit(): void {
     const roles = this.mainService.usuarioActual?.roles || [];
     const esAdmin = this.mainService.usuarioActual?.nickname === 'ADMIN' || roles.includes('ADMIN');
+    this.liquidacionService.onGetConceptosParaItemManual()
+      .pipe(untilDestroyed(this))
+      .subscribe(res => { this.conceptos = res || []; });
     this.puedeLiquidar = esAdmin || roles.includes('RRHH LIQUIDAR');
     this.puedeAprobar = esAdmin || roles.includes('RRHH APROBAR');
     this.puedePagar = esAdmin || roles.includes('RRHH PAGAR');
@@ -118,14 +131,20 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
       ? this.liquidacionService.onEditarItem(this.editandoItemId, this.descripcionControl.value,
           this.montoControl.value, this.tipoControl.value, this.mainService.usuarioActual?.id)
       : this.liquidacionService.onAgregarItem(this.liq.id, this.descripcionControl.value,
-          this.montoControl.value, this.tipoControl.value);
+          this.montoControl.value, this.tipoControl.value, this.conceptoControl.value);
     obs.pipe(untilDestroyed(this)).subscribe(res => {
       if (res != null) {
         this.editandoItemId = null;
-        this.descripcionControl.reset(); this.montoControl.setValue(0); this.mostrarAgregar = false;
+        this.descripcionControl.reset(); this.montoControl.setValue(0);
+        this.conceptoControl.reset(); this.signoConcepto = ''; this.mostrarAgregar = false;
         this.recargar();
       }
     });
+  }
+
+  onConceptoChange() {
+    const c = this.conceptos.find(x => x.id === this.conceptoControl.value);
+    this.signoConcepto = c ? (c.esHaber ? 'Suma al total (HABER)' : 'Resta del total (DESCUENTO)') : '';
   }
 
   onEliminarItem(it: LiquidacionItem) {
@@ -203,7 +222,8 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
   onToggleAgregar() {
     this.mostrarAgregar = !this.mostrarAgregar;
     if (!this.mostrarAgregar) { this.editandoItemId = null; this.descripcionControl.reset(); this.montoControl.setValue(0); }
-    else { this.editandoItemId = null; this.descripcionControl.reset(); this.montoControl.setValue(0); this.tipoControl.setValue('DESCUENTO'); }
+    else { this.editandoItemId = null; this.descripcionControl.reset(); this.montoControl.setValue(0);
+      this.tipoControl.setValue('DESCUENTO'); this.conceptoControl.reset(); this.signoConcepto = ''; }
   }
 
   onCerrar() {

--- a/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.ts
+++ b/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { FormControl, Validators } from '@angular/forms';
 import { MatTableDataSource } from '@angular/material/table';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Tab } from '../../../../layouts/tab/tab.model';
@@ -49,7 +49,13 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
    * "Bonificacion" ya implica HABER y "Faltante de caja" ya implica DESCUENTO.
    */
   conceptos: any[] = [];
-  conceptoControl = new FormControl(null);
+  /**
+   * Si el catalogo no cargo (query fallida o instancia sin seedear), se vuelve a pedir el
+   * tipo a mano. Sin esto no habria forma de crear un item HABER: el selector de tipo esta
+   * oculto en alta y quedaria clavado en DESCUENTO.
+   */
+  sinCatalogo = false;
+  conceptoControl = new FormControl(null, [Validators.required]);
   /** Precalculado para el template (el repo no llama funciones desde el HTML). */
   signoConcepto = '';
 
@@ -73,7 +79,12 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
     const esAdmin = this.mainService.usuarioActual?.nickname === 'ADMIN' || roles.includes('ADMIN');
     this.liquidacionService.onGetConceptosParaItemManual()
       .pipe(untilDestroyed(this))
-      .subscribe(res => { this.conceptos = res || []; });
+      .subscribe(res => {
+        this.conceptos = res || [];
+        this.sinCatalogo = this.conceptos.length === 0;
+        if (this.sinCatalogo) { this.conceptoControl.clearValidators(); }
+        this.conceptoControl.updateValueAndValidity();
+      });
     this.puedeLiquidar = esAdmin || roles.includes('RRHH LIQUIDAR');
     this.puedeAprobar = esAdmin || roles.includes('RRHH APROBAR');
     this.puedePagar = esAdmin || roles.includes('RRHH PAGAR');
@@ -127,6 +138,16 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
   /** Guarda el panel: edición si hay editandoItemId, alta si no. */
   onGuardarItem() {
     if (this.montoControl.value == null || this.montoControl.value < 0) { return; }
+    // En alta, la operacion define el signo. Sin ella el backend cae al camino viejo y
+    // confia en el tipo que mande el cliente, que en alta esta clavado en DESCUENTO: un
+    // bono cargado sin elegir operacion se restaria del sueldo en vez de sumarse.
+    if (this.editandoItemId == null && !this.sinCatalogo && this.conceptoControl.value == null) {
+      this.notificacion.notification$.next({
+        texto: 'Elegí la operación: define si el ítem suma o resta',
+        color: NotificacionColor.warn, duracion: 4
+      });
+      return;
+    }
     const obs = this.editandoItemId != null
       ? this.liquidacionService.onEditarItem(this.editandoItemId, this.descripcionControl.value,
           this.montoControl.value, this.tipoControl.value, this.mainService.usuarioActual?.id)

--- a/src/app/modules/rrhh/liquidacion/liquidacion.service.ts
+++ b/src/app/modules/rrhh/liquidacion/liquidacion.service.ts
@@ -9,6 +9,7 @@ import { LiquidacionItemsGQL } from './graphql/LiquidacionItems';
 import { GenerarBorradorGQL } from './graphql/GenerarBorrador';
 import { GenerarMesGQL } from './graphql/GenerarMes';
 import { GenerarLoteGQL } from './graphql/GenerarLote';
+import { ConceptosParaItemManualGQL } from './graphql/ConceptosParaItemManual';
 import { AgregarItemGQL } from './graphql/AgregarItem';
 import { EditarItemGQL } from './graphql/EditarItem';
 import { EliminarItemGQL } from './graphql/EliminarItem';
@@ -32,6 +33,7 @@ export class LiquidacionService {
     private generarMesGQL: GenerarMesGQL,
     private generarLoteGQL: GenerarLoteGQL,
     private agregarItemGQL: AgregarItemGQL,
+    private conceptosParaItemManualGQL: ConceptosParaItemManualGQL,
     private editarItemGQL: EditarItemGQL,
     private eliminarItemGQL: EliminarItemGQL,
     private aprobarLiquidacionGQL: AprobarLiquidacionGQL,
@@ -77,8 +79,21 @@ export class LiquidacionService {
     return this.genericService.onSaveCustom<any>(this.generarLoteGQL, { funcionarioIds, periodo, monedaId }, servidor);
   }
 
-  onAgregarItem(liquidacionId: number, descripcion: string, monto: number, tipo: string, servidor = true): Observable<any> {
-    return this.genericService.onSaveCustom<any>(this.agregarItemGQL, { liquidacionId, descripcion, monto, tipo }, servidor);
+  onAgregarItem(liquidacionId: number, descripcion: string, monto: number, tipo: string,
+                liquidacionConceptoId: number = null, servidor = true): Observable<any> {
+    return this.genericService.onSaveCustom<any>(this.agregarItemGQL,
+      { liquidacionId, descripcion, monto, tipo, liquidacionConceptoId }, servidor);
+  }
+
+  /**
+   * Catalogo de operaciones para el item manual.
+   *
+   * servidor=true es obligatorio: ese flag elige el cliente Apollo, y con false la query
+   * sale por el cliente por defecto en vez del central. silentLoad evita el dialogo de
+   * "Buscando..." — es una carga de fondo, no una accion del usuario.
+   */
+  onGetConceptosParaItemManual(servidor = true): Observable<any> {
+    return this.genericService.onCustomQuery(this.conceptosParaItemManualGQL, {}, servidor, null, true);
   }
 
   onEditarItem(itemId: number, descripcion: string, monto: number, tipo: string, usuarioId: number, servidor = true): Observable<any> {

--- a/src/app/modules/rrhh/penalizacion/edit-penalizacion-dialog/edit-penalizacion-dialog.component.html
+++ b/src/app/modules/rrhh/penalizacion/edit-penalizacion-dialog/edit-penalizacion-dialog.component.html
@@ -25,10 +25,15 @@
       </mat-form-field>
     </div>
 
-    <mat-form-field style="width: 100%">
+    <mat-form-field style="width: 100%" *ngIf="!esAdvertencia">
       <mat-label>Monto</mat-label>
       <input matInput type="number" [formControl]="montoControl" />
     </mat-form-field>
+
+    <p class="aviso-advertencia" *ngIf="esAdvertencia">
+      Una amonestación no descuenta dinero: queda registrada, suma al contador del
+      funcionario y se puede imprimir como acta firmable.
+    </p>
 
     <mat-form-field style="width: 100%">
       <mat-label>Descripción</mat-label>

--- a/src/app/modules/rrhh/penalizacion/edit-penalizacion-dialog/edit-penalizacion-dialog.component.scss
+++ b/src/app/modules/rrhh/penalizacion/edit-penalizacion-dialog/edit-penalizacion-dialog.component.scss
@@ -2,3 +2,10 @@
   min-width: 460px;
   padding: 8px;
 }
+
+.aviso-advertencia {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #ffca28;
+}

--- a/src/app/modules/rrhh/penalizacion/edit-penalizacion-dialog/edit-penalizacion-dialog.component.ts
+++ b/src/app/modules/rrhh/penalizacion/edit-penalizacion-dialog/edit-penalizacion-dialog.component.ts
@@ -25,8 +25,16 @@ export class EditPenalizacionDialogComponent implements OnInit {
 
   tipoOptions: PenalizacionTipo[] = [
     'TARDANZA', 'AUSENCIA', 'QUEJA_CLIENTE', 'AMBIENTE_LABORAL',
-    'DANIO_MATERIAL', 'COMISION_DESCUENTO', 'OTRO'
+    'DANIO_MATERIAL', 'COMISION_DESCUENTO', 'ADVERTENCIA', 'OTRO'
   ];
+
+  /**
+   * Una amonestacion no descuenta plata: se registra, se cuenta y se imprime como acta.
+   * Con el tipo en ADVERTENCIA el monto se oculta y se fuerza a 0, para que nadie cargue
+   * un importe que despues quedaria fuera de la liquidacion sin explicacion.
+   * Precalculado: el template no llama funciones (convencion del repo).
+   */
+  esAdvertencia = false;
 
 
   funcionarioControl = new FormControl(null, [Validators.required]);
@@ -54,6 +62,13 @@ export class EditPenalizacionDialogComponent implements OnInit {
     if (this.data?.funcionarioId != null) {
       this.funcionarioControl.setValue(this.data.funcionarioId);
     }
+    this.tipoControl.valueChanges.pipe(untilDestroyed(this)).subscribe(() => this.onTipoChange());
+    this.onTipoChange();
+  }
+
+  onTipoChange() {
+    this.esAdvertencia = this.tipoControl.value === 'ADVERTENCIA';
+    if (this.esAdvertencia) { this.montoControl.setValue(0); }
   }
 
   onCancelar() {
@@ -70,7 +85,8 @@ export class EditPenalizacionDialogComponent implements OnInit {
     p.funcionario = func;
     p.tipo = this.tipoControl.value as PenalizacionTipo;
     p.fecha = dateToString(this.fechaControl.value);
-    p.monto = this.montoControl.value ?? 0;
+    // Una amonestacion nunca lleva monto, aunque el campo hubiese quedado con un valor.
+    p.monto = this.esAdvertencia ? 0 : (this.montoControl.value ?? 0);
     p.descripcion = this.descripcionControl.value ? this.descripcionControl.value.toUpperCase() : null;
     p.autoGenerada = false;
     p.anulada = false;

--- a/src/app/modules/rrhh/penalizacion/generar-penalizaciones-dialog/generar-penalizaciones-dialog.component.html
+++ b/src/app/modules/rrhh/penalizacion/generar-penalizaciones-dialog/generar-penalizaciones-dialog.component.html
@@ -2,22 +2,36 @@
   <h2 mat-dialog-title>Generar penalizaciones automáticas</h2>
 
   <p class="aviso">
-    Se revisan las jornadas de la fecha elegida y se penaliza a quienes superaron la
+    Se revisan las jornadas del rango elegido y se penaliza a quienes superaron la
     tolerancia de tardanza. Las jornadas con un justificativo que evita la penalización
     se saltean, y no se duplica si ya se generó antes para esa jornada.
   </p>
 
-  <mat-form-field style="width: 100%">
-    <mat-label>Fecha a procesar</mat-label>
-    <input matInput [matDatepicker]="picker" [formControl]="fechaControl" [max]="hoy" required />
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-datepicker #picker></mat-datepicker>
-    <mat-hint>Por defecto el día anterior</mat-hint>
-  </mat-form-field>
+  <div fxLayout="row" fxLayoutGap="10px">
+    <mat-form-field fxFlex>
+      <mat-label>Desde</mat-label>
+      <input matInput [matDatepicker]="pickerD" [formControl]="desdeControl" [max]="hoy" required />
+      <mat-datepicker-toggle matSuffix [for]="pickerD"></mat-datepicker-toggle>
+      <mat-datepicker #pickerD></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field fxFlex>
+      <mat-label>Hasta</mat-label>
+      <input matInput [matDatepicker]="pickerH" [formControl]="hastaControl" [max]="hoy" required />
+      <mat-datepicker-toggle matSuffix [for]="pickerH"></mat-datepicker-toggle>
+      <mat-datepicker #pickerH></mat-datepicker>
+    </mat-form-field>
+  </div>
+
+  <p class="aviso" *ngIf="!error && cantidadDias > 0">
+    Se procesarán {{ cantidadDias }} día/s.
+  </p>
+  <p class="error-rango" *ngIf="error">{{ error }}</p>
 
   <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
     <button mat-stroked-button (click)="onCancelar()">Cancelar</button>
-    <button mat-raised-button color="primary" [disabled]="fechaControl.invalid" (click)="onGenerar()">
+    <button mat-raised-button color="primary"
+      [disabled]="desdeControl.invalid || hastaControl.invalid || error" (click)="onGenerar()">
       Generar
     </button>
   </div>

--- a/src/app/modules/rrhh/penalizacion/generar-penalizaciones-dialog/generar-penalizaciones-dialog.component.scss
+++ b/src/app/modules/rrhh/penalizacion/generar-penalizaciones-dialog/generar-penalizaciones-dialog.component.scss
@@ -9,3 +9,9 @@
   line-height: 1.5;
   color: #9e9e9e;
 }
+
+.error-rango {
+  margin: 0;
+  font-size: 13px;
+  color: #ef5350;
+}

--- a/src/app/modules/rrhh/penalizacion/generar-penalizaciones-dialog/generar-penalizaciones-dialog.component.ts
+++ b/src/app/modules/rrhh/penalizacion/generar-penalizaciones-dialog/generar-penalizaciones-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
 /** Rango elegido, devuelto al cerrar. */
 export interface RangoPenalizaciones {
@@ -15,6 +16,7 @@ export interface RangoPenalizaciones {
  * pasadas manuales. La generacion es idempotente por jornada, no por fecha: re-correr un
  * rango que se solapa con otro ya procesado no duplica nada.
  */
+@UntilDestroy()
 @Component({
   selector: 'app-generar-penalizaciones-dialog',
   templateUrl: './generar-penalizaciones-dialog.component.html',
@@ -31,7 +33,7 @@ export class GenerarPenalizacionesDialogComponent {
 
   /** Precalculado: el template no llama funciones (convencion del repo). */
   error = '';
-  cantidadDias = 1;
+  cantidadDias = 0;
 
   constructor(private dialogRef: MatDialogRef<GenerarPenalizacionesDialogComponent>) {
     // Por defecto el dia anterior en ambos extremos: lo normal sigue siendo procesar la
@@ -40,8 +42,11 @@ export class GenerarPenalizacionesDialogComponent {
     const ayer = new Date(h.getFullYear(), h.getMonth(), h.getDate() - 1);
     this.desdeControl.setValue(ayer);
     this.hastaControl.setValue(ayer);
-    this.desdeControl.valueChanges.subscribe(() => this.recalcular());
-    this.hastaControl.valueChanges.subscribe(() => this.recalcular());
+    this.desdeControl.valueChanges.pipe(untilDestroyed(this)).subscribe(() => this.recalcular());
+    this.hastaControl.valueChanges.pipe(untilDestroyed(this)).subscribe(() => this.recalcular());
+    // Se calcula al abrir y no se deja hardcodeado: si manana cambia el rango por defecto,
+    // el cartel diria "1 dia" sobre un rango de siete hasta que el usuario toque una fecha.
+    this.recalcular();
   }
 
   private recalcular() {

--- a/src/app/modules/rrhh/penalizacion/generar-penalizaciones-dialog/generar-penalizaciones-dialog.component.ts
+++ b/src/app/modules/rrhh/penalizacion/generar-penalizaciones-dialog/generar-penalizaciones-dialog.component.ts
@@ -2,12 +2,18 @@ import { Component } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 
+/** Rango elegido, devuelto al cerrar. */
+export interface RangoPenalizaciones {
+  desde: Date;
+  hasta: Date;
+}
+
 /**
- * Pide la fecha a procesar para la generacion automatica de penalizaciones.
+ * Pide el rango a procesar para la generacion automatica de penalizaciones.
  *
- * Antes este campo vivia suelto entre los filtros de la lista, con el label cortado:
- * parecia un filtro mas y no el parametro de la accion, asi que se generaba sobre una
- * fecha equivocada sin entender por que no salia nada.
+ * Antes solo permitia un dia, asi que ponerse al dia con una semana atrasada eran siete
+ * pasadas manuales. La generacion es idempotente por jornada, no por fecha: re-correr un
+ * rango que se solapa con otro ya procesado no duplica nada.
  */
 @Component({
   selector: 'app-generar-penalizaciones-dialog',
@@ -16,13 +22,44 @@ import { MatDialogRef } from '@angular/material/dialog';
 })
 export class GenerarPenalizacionesDialogComponent {
 
-  fechaControl = new FormControl(null, [Validators.required]);
+  /** Igual al tope del backend (PenalizacionService.RANGO_MAX_DIAS). */
+  static readonly MAX_DIAS = 62;
+
+  desdeControl = new FormControl(null, [Validators.required]);
+  hastaControl = new FormControl(null, [Validators.required]);
   hoy = new Date();
 
+  /** Precalculado: el template no llama funciones (convencion del repo). */
+  error = '';
+  cantidadDias = 1;
+
   constructor(private dialogRef: MatDialogRef<GenerarPenalizacionesDialogComponent>) {
-    // por defecto el dia anterior: lo normal es procesar la jornada ya cerrada
+    // Por defecto el dia anterior en ambos extremos: lo normal sigue siendo procesar la
+    // jornada ya cerrada, y quien necesite mas corre el "hasta".
     const h = new Date();
-    this.fechaControl.setValue(new Date(h.getFullYear(), h.getMonth(), h.getDate() - 1));
+    const ayer = new Date(h.getFullYear(), h.getMonth(), h.getDate() - 1);
+    this.desdeControl.setValue(ayer);
+    this.hastaControl.setValue(ayer);
+    this.desdeControl.valueChanges.subscribe(() => this.recalcular());
+    this.hastaControl.valueChanges.subscribe(() => this.recalcular());
+  }
+
+  private recalcular() {
+    const d: Date = this.desdeControl.value;
+    const h: Date = this.hastaControl.value;
+    this.error = '';
+    this.cantidadDias = 0;
+    if (d == null || h == null) { return; }
+    if (h < d) {
+      this.error = 'La fecha final no puede ser anterior a la inicial';
+      return;
+    }
+    const ms = h.getTime() - d.getTime();
+    this.cantidadDias = Math.round(ms / (1000 * 60 * 60 * 24)) + 1;
+    if (this.cantidadDias > GenerarPenalizacionesDialogComponent.MAX_DIAS) {
+      this.error = 'El rango no puede superar ' + GenerarPenalizacionesDialogComponent.MAX_DIAS
+        + ' días (elegiste ' + this.cantidadDias + ')';
+    }
   }
 
   onCancelar() {
@@ -30,7 +67,7 @@ export class GenerarPenalizacionesDialogComponent {
   }
 
   onGenerar() {
-    if (this.fechaControl.invalid) return;
-    this.dialogRef.close(this.fechaControl.value);
+    if (this.desdeControl.invalid || this.hastaControl.invalid || this.error) { return; }
+    this.dialogRef.close({ desde: this.desdeControl.value, hasta: this.hastaControl.value });
   }
 }

--- a/src/app/modules/rrhh/penalizacion/graphql/ActaAdvertencia.ts
+++ b/src/app/modules/rrhh/penalizacion/graphql/ActaAdvertencia.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { actaAdvertenciaQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class ActaAdvertenciaGQL extends Query<Response> { document = actaAdvertenciaQuery; }

--- a/src/app/modules/rrhh/penalizacion/graphql/ContarAdvertencias.ts
+++ b/src/app/modules/rrhh/penalizacion/graphql/ContarAdvertencias.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { contarAdvertenciasQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class ContarAdvertenciasGQL extends Query<Response> { document = contarAdvertenciasQuery; }

--- a/src/app/modules/rrhh/penalizacion/graphql/GenerarPenalizacionesAutoRango.ts
+++ b/src/app/modules/rrhh/penalizacion/graphql/GenerarPenalizacionesAutoRango.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { generarPenalizacionesAutoRangoMutation } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class GenerarPenalizacionesAutoRangoGQL extends Mutation<Response> {
+  document = generarPenalizacionesAutoRangoMutation;
+}

--- a/src/app/modules/rrhh/penalizacion/graphql/graphql-query.ts
+++ b/src/app/modules/rrhh/penalizacion/graphql/graphql-query.ts
@@ -53,6 +53,21 @@ export const anularPenalizacionMutation = gql`
   }
 `;
 
+export const contarAdvertenciasQuery = gql`
+  query contarAdvertencias($funcionarioId: ID!) {
+    data: contarAdvertencias(funcionarioId: $funcionarioId)
+  }
+`;
+export const actaAdvertenciaQuery = gql`
+  query imprimirActaAdvertencia($id: ID!) {
+    data: imprimirActaAdvertencia(id: $id)
+  }
+`;
+export const generarPenalizacionesAutoRangoMutation = gql`
+  mutation generarPenalizacionesAutoRango($desde: String, $hasta: String) {
+    data: generarPenalizacionesAutoRango(desde: $desde, hasta: $hasta)
+  }
+`;
 export const generarPenalizacionesAutoMutation = gql`
   mutation generarPenalizacionesAuto($fecha: String) {
     data: generarPenalizacionesAuto(fecha: $fecha)

--- a/src/app/modules/rrhh/penalizacion/list-penalizacion/list-penalizacion.component.html
+++ b/src/app/modules/rrhh/penalizacion/list-penalizacion/list-penalizacion.component.html
@@ -79,8 +79,11 @@
             <button mat-menu-item (click)="onAnular(row)" [disabled]="row.anulada">
               <mat-icon>block</mat-icon><span>Anular</span>
             </button>
-            <button mat-menu-item (click)="onVerRecibo(row)">
+            <button mat-menu-item (click)="onVerRecibo(row)" *ngIf="row.tipo !== 'ADVERTENCIA'">
               <mat-icon>print</mat-icon><span>Imprimir recibo</span>
+            </button>
+            <button mat-menu-item (click)="onVerActa(row)" *ngIf="row.tipo === 'ADVERTENCIA'">
+              <mat-icon>gavel</mat-icon><span>Imprimir acta</span>
             </button>
           </mat-menu>
         </td>

--- a/src/app/modules/rrhh/penalizacion/list-penalizacion/list-penalizacion.component.ts
+++ b/src/app/modules/rrhh/penalizacion/list-penalizacion/list-penalizacion.component.ts
@@ -14,7 +14,7 @@ import { ImpresionService } from '../../../../shared/components/imprimir/impresi
 import { Penalizacion, PenalizacionTipo } from '../penalizacion.model';
 import { PenalizacionService } from '../penalizacion.service';
 import { EditPenalizacionDialogComponent } from '../edit-penalizacion-dialog/edit-penalizacion-dialog.component';
-import { GenerarPenalizacionesDialogComponent } from '../generar-penalizaciones-dialog/generar-penalizaciones-dialog.component';
+import { GenerarPenalizacionesDialogComponent, RangoPenalizaciones } from '../generar-penalizaciones-dialog/generar-penalizaciones-dialog.component';
 
 
 @UntilDestroy({ checkProperties: true })
@@ -57,6 +57,15 @@ export class ListPenalizacionComponent implements OnInit {
   onVerRecibo(row: Penalizacion) {
     this.impresionService.imprimir('Recibo penalización ' + row.id,
       (anchoMm, escpos) => this.reportesRrhhService.onReciboPenalizacion(row.id, anchoMm, escpos));
+  }
+
+  /**
+   * Acta de amonestacion. soloPdf porque lleva dos firmas (funcionario y empresa) y no
+   * entran legibles en las 32/48 columnas de una termica.
+   */
+  onVerActa(row: Penalizacion) {
+    this.impresionService.imprimir('Acta de amonestación ' + row.id,
+      () => this.penalizacionService.onGetActaAdvertencia(row.id), true);
   }
 
   ngOnInit(): void {
@@ -122,18 +131,19 @@ export class ListPenalizacionComponent implements OnInit {
   }
 
   onGenerarAuto() {
-    // La fecha es parametro de la accion, no un filtro: se pide en el dialogo.
-    this.dialog.open(GenerarPenalizacionesDialogComponent, { width: '460px', disableClose: true })
-      .afterClosed().pipe(untilDestroyed(this)).subscribe((fecha: Date) => {
-        if (fecha == null) return;
-        this.penalizacionService.onGenerarAuto(dateToString(fecha, 'yyyy-MM-dd'))
+    // El rango es parametro de la accion, no un filtro: se pide en el dialogo.
+    this.dialog.open(GenerarPenalizacionesDialogComponent, { width: '520px', disableClose: true })
+      .afterClosed().pipe(untilDestroyed(this)).subscribe((rango: RangoPenalizaciones) => {
+        if (rango == null) return;
+        this.penalizacionService.onGenerarAutoRango(
+          dateToString(rango.desde, 'yyyy-MM-dd'), dateToString(rango.hasta, 'yyyy-MM-dd'))
           .pipe(untilDestroyed(this))
           .subscribe((cant: number) => {
             const generadas = cant ?? 0;
             this.notificacion.notification$.next({
               texto: generadas > 0
                 ? 'Penalizaciones automáticas generadas: ' + generadas
-                : 'No se generó ninguna penalización para esa fecha',
+                : 'No se generó ninguna penalización para ese rango',
               color: generadas > 0 ? NotificacionColor.success : NotificacionColor.warn,
               duracion: 4
             });

--- a/src/app/modules/rrhh/penalizacion/penalizacion.model.ts
+++ b/src/app/modules/rrhh/penalizacion/penalizacion.model.ts
@@ -3,7 +3,13 @@ import { Usuario } from '../../personas/usuarios/usuario.model';
 
 export type PenalizacionTipo =
   'TARDANZA' | 'AUSENCIA' | 'QUEJA_CLIENTE' | 'AMBIENTE_LABORAL' |
-  'DANIO_MATERIAL' | 'COMISION_DESCUENTO' | 'OTRO';
+  'DANIO_MATERIAL' | 'COMISION_DESCUENTO' | 'ADVERTENCIA' | 'OTRO';
+
+/**
+ * Amonestacion: no descuenta plata. Se registra, se cuenta y se imprime como acta
+ * firmable, pero queda fuera de la liquidacion y de los KPIs de penalizaciones.
+ */
+export const TIPO_ADVERTENCIA: PenalizacionTipo = 'ADVERTENCIA';
 
 export class Penalizacion {
   id: number;
@@ -17,6 +23,9 @@ export class Penalizacion {
   autoGenerada: boolean;
   anulada: boolean;
   registradoPor: Usuario;
+  numeroAdvertencia: number;
+  firmada: boolean;
+  fechaHecho: string;
 
   toInput(): any {
     return {
@@ -30,7 +39,10 @@ export class Penalizacion {
       fecha: this.fecha,
       autoGenerada: this.autoGenerada,
       anulada: this.anulada,
-      registradoPorId: this.registradoPor?.id
+      registradoPorId: this.registradoPor?.id,
+      numeroAdvertencia: this.numeroAdvertencia,
+      firmada: this.firmada,
+      fechaHecho: this.fechaHecho
     };
   }
 }

--- a/src/app/modules/rrhh/penalizacion/penalizacion.service.ts
+++ b/src/app/modules/rrhh/penalizacion/penalizacion.service.ts
@@ -5,6 +5,9 @@ import { PenalizacionesPorFuncionarioYRangoGQL } from './graphql/PenalizacionesP
 import { PenalizacionesPageGQL } from './graphql/PenalizacionesPage';
 import { SavePenalizacionGQL } from './graphql/SavePenalizacion';
 import { AnularPenalizacionGQL } from './graphql/AnularPenalizacion';
+import { GenerarPenalizacionesAutoRangoGQL } from './graphql/GenerarPenalizacionesAutoRango';
+import { ContarAdvertenciasGQL } from './graphql/ContarAdvertencias';
+import { ActaAdvertenciaGQL } from './graphql/ActaAdvertencia';
 import { GenerarPenalizacionesAutoGQL } from './graphql/GenerarPenalizacionesAuto';
 import { Penalizacion } from './penalizacion.model';
 
@@ -17,7 +20,10 @@ export class PenalizacionService {
     private penalizacionesPageGQL: PenalizacionesPageGQL,
     private savePenalizacionGQL: SavePenalizacionGQL,
     private anularPenalizacionGQL: AnularPenalizacionGQL,
-    private generarPenalizacionesAutoGQL: GenerarPenalizacionesAutoGQL
+    private generarPenalizacionesAutoGQL: GenerarPenalizacionesAutoGQL,
+    private generarPenalizacionesAutoRangoGQL: GenerarPenalizacionesAutoRangoGQL,
+    private contarAdvertenciasGQL: ContarAdvertenciasGQL,
+    private actaAdvertenciaGQL: ActaAdvertenciaGQL
   ) { }
 
   onGetPorFuncionarioYRango(funcionarioId: number, desde: string, hasta: string, servidor = true): Observable<any> {
@@ -45,5 +51,22 @@ export class PenalizacionService {
 
   onGenerarAuto(fecha: string, servidor = true): Observable<number> {
     return this.genericService.onSaveCustom<number>(this.generarPenalizacionesAutoGQL, { fecha }, servidor);
+  }
+
+  /** Genera de un tiron todo un rango. Idempotente por jornada: re-correr no duplica. */
+  onGenerarAutoRango(desde: string, hasta: string, servidor = true): Observable<number> {
+    return this.genericService.onSaveCustom<number>(
+      this.generarPenalizacionesAutoRangoGQL, { desde, hasta }, servidor);
+  }
+
+  /** Amonestaciones no anuladas del funcionario. Alimenta el chip del legajo. */
+  onContarAdvertencias(funcionarioId: number, servidor = true): Observable<number> {
+    return this.genericService.onCustomQuery(
+      this.contarAdvertenciasGQL, { funcionarioId }, servidor, null, true);
+  }
+
+  /** Acta de amonestacion en PDF A4 (base64). No hay version ticket: lleva dos firmas. */
+  onGetActaAdvertencia(id: number, servidor = true): Observable<string> {
+    return this.genericService.onCustomQuery(this.actaAdvertenciaGQL, { id }, servidor);
   }
 }

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -63,6 +63,7 @@ import { ListHoraExtraComponent } from '../../../modules/rrhh/hora-extra/list-ho
 import { ListJustificativoComponent } from '../../../modules/rrhh/justificativo/list-justificativo/list-justificativo.component';
 import { ListTipoJustificativoComponent } from '../../../modules/rrhh/tipo-justificativo/list-tipo-justificativo/list-tipo-justificativo.component';
 import { ListMotivoValeComponent } from '../../../modules/rrhh/motivo-vale/list-motivo-vale/list-motivo-vale.component';
+import { ListCargoComponent } from '../../../modules/empresarial/cargo/list-cargo/list-cargo.component';
 import { ListValeComponent } from '../../../modules/rrhh/vale/list-vale/list-vale.component';
 import { ListPrestamoComponent } from '../../../modules/rrhh/prestamo/list-prestamo/list-prestamo.component';
 import { ListVacacionComponent } from '../../../modules/rrhh/vacacion/list-vacacion/list-vacacion.component';
@@ -313,6 +314,12 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
               icon: 'label',
               action: 'list-motivo-vale',
               visibilityRoles: [ROLES.RRHH_GESTIONAR, ROLES.ADMIN]
+            },
+            {
+              name: 'Cargos',
+              icon: 'work',
+              action: 'list-cargo',
+              visibilityRoles: [ROLES.RRHH_GESTIONAR, ROLES.RRHH_CONFIG, ROLES.ADMIN]
             },
             {
               name: 'Configuración RRHH',
@@ -1024,6 +1031,9 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
         break;
       case "list-motivo-vale":
         this.openTabIfAuthorized(ROLES.RRHH_GESTIONAR, ListMotivoValeComponent, "Motivos de vale");
+        break;
+      case "list-cargo":
+        this.openTabIfAuthorized(ROLES.RRHH_GESTIONAR, ListCargoComponent, "Cargos");
         break;
       case "list-prestamo":
         this.openTabIfAuthorized(ROLES.RRHH_VER, ListPrestamoComponent, "Préstamos");

--- a/src/app/shared/widgets/search-bar-dialog/search-bar.service.ts
+++ b/src/app/shared/widgets/search-bar-dialog/search-bar.service.ts
@@ -16,6 +16,7 @@ import { FuncionarioDashboardComponent } from '../../../modules/personas/funcion
 import { ListActualizacionComponent } from '../../../modules/configuracion/actualizacion/list-actualizacion/list-actualizacion.component';
 import { ListCajaComponent } from '../../../modules/financiero/pdv/caja/list-caja/list-caja.component';
 import { ListSectorComponent } from '../../../modules/empresarial/sector/list-sector/list-sector.component';
+import { ListCargoComponent } from '../../../modules/empresarial/cargo/list-cargo/list-cargo.component';
 import { SolicitarRecursosDialogComponent } from '../../../modules/configuracion/solicitar-recursos-dialog/solicitar-recursos-dialog.component';
 import { ROLES } from '../../../modules/personas/roles/roles.enum';
 import { PrecioDeliveryComponent } from '../../../modules/operaciones/delivery/precio-delivery/precio-delivery.component';
@@ -55,6 +56,7 @@ export const componenteList: SearchData[] =
     { title: 'Actualizacion', component: ListActualizacionComponent, visibilityRoles: [ROLES.ADMIN] },
     { title: 'Lista de cajas', component: ListCajaComponent, visibilityRoles: [ROLES.ANALISIS_DE_CAJA] },
     { title: 'Lista de sectores', component: ListSectorComponent, visibilityRoles: [ROLES.ADMIN] },
+    { title: 'Lista de cargos', component: ListCargoComponent, visibilityRoles: [ROLES.ADMIN] },
     { title: 'Solicitar Recursos', component: SolicitarRecursosDialogComponent, visibilityRoles: [ROLES.SOPORTE] },
     { title: 'Precio del Delivery', component: PrecioDeliveryComponent, visibilityRoles: [ROLES.ADMIN] },
     { title: 'Lista de clientes', component: ListClientesComponent, visibilityRoles: [ROLES.VER_PERSONAS] },


### PR DESCRIPTION
Lado desktop del lote B. **PR hermano: GabFrank/franco-system-backend-servidor#231**, que tiene el contexto completo, las migraciones y el plan.

> **Sale del lote A, no de `develop`** — comparten archivos en el módulo de liquidación. Mergear GabFrank/frc-sistemas-integrados-angular#239 primero.

## Qué entra

**B12 — select de operación en el ítem manual.** Se elige una operación del catálogo y el backend deriva el signo de `esHaber`; la UI ya no pide HABER/DESCUENTO por separado. El campo de texto libre pasa a llamarse **Observación**, que es lo que siempre fue: la columna Operación del recibo sale del concepto, no de ese texto. Por eso antes todo figuraba como "AJUSTE".

**B4 — ABM de cargos.** Era lo único que faltaba: el backend ya existía entero. Registrado en el menú (*R.R.H.H. → Configuración*) **y** en el buscador global, que es justo lo que pide la issue #235. El selector de "depende de" excluye el propio cargo, porque no hay validación de ciclos del lado del servidor.

**B10 — rango de fechas** en la generación automática de penalizaciones, con el mismo tope de 62 días que valida el backend y el conteo de días a la vista antes de confirmar.

**B11 — amonestaciones.** Al elegir el tipo `ADVERTENCIA` el campo de monto desaparece y se fuerza a cero, con un aviso de que no descuenta dinero. El menú de la fila ofrece *Imprimir acta* en lugar de *Imprimir recibo*, y el legajo suma un chip con el contador — que, a diferencia de los otros tres de esa fila, **no es placeholder**: sale del backend.

**B16 — toggle de consolidación** en Configuración RRHH, junto con los datos de empresa del recibo.

## Dos bugs de signo que aparecieron en el camino

Los dos son de la misma familia: **el síntoma no es un error visible, sino algo que no pasa.**

**La operación no era obligatoria.** Sin elegirla, el backend caía al camino viejo y confiaba en el `tipo` que mandaba el cliente — que en alta quedaba clavado en `DESCUENTO`, porque el selector de tipo está oculto. Cargar un bono a mano sin tocar el select **se lo restaba del sueldo al funcionario**, sin error y sin ninguna pista. Ahora es requerida y se valida antes de guardar; y si el catálogo no cargó, vuelve a aparecer el selector de tipo, porque si no no habría forma de crear un ítem HABER.

**`servidor = false` en la query del catálogo.** Ese flag elige el cliente Apollo:

```ts
clientName: servidor == null || servidor ? "servidor" : null
```

Con `false` la query salía por el cliente por defecto en vez del central. Y como `onCustomQuery` **no emite** cuando la respuesta trae `errors` —solo muestra un snackbar—, el observable quedaba colgado y su diálogo de carga se pisaba con el de `addTab`: la pantalla de detalle no abría. Es el mismo modo de falla que la auditoría del lote A marcó para el diálogo de ajuste de salarios.

## Cómo probarlo

1. **B12** — en un borrador, *Agregar Item*. Sin elegir operación no deja guardar. Al elegir una de descuento, el hint dice "Resta del total" y no se pide el tipo.
2. **B4** — *R.R.H.H. → Configuración → Cargos*. Crear, editar, y borrar uno con funcionarios asignados (tiene que rechazar diciendo cuántos). Buscá "cargos" en el buscador global: tiene que aparecer.
3. **B10** — *Penalizaciones → Generar automáticas*: dos fechas, el conteo de días a la vista, y rechazo si el rango supera 62.
4. **B11** — cargá una penalización tipo `ADVERTENCIA`: el monto desaparece. En el menú de la fila, *Imprimir acta*. El legajo muestra el contador.

### Ya verificado con Claude in Chrome

**B12 end-to-end** contra el central local: el select cargó las 9 operaciones ordenadas con los haberes primero, el hint mostró el signo derivado, y el ítem se guardó con `codigo = DESCUENTO_JUDICIAL` en vez de `DESCUENTO_MANUAL`. En el recibo, la columna Operación imprimió `DESCUENTO JUDICIAL` donde antes decía `AJUSTE`.

**AOT (`ng build --configuration production`): 0 errores**, `Initial Total 15.74 MB`.

> Al correrlo: `"check"` no lleva el `NODE_OPTIONS=--max_old_space_size=8192` que sí tiene `"ng:serve"`, y en una máquina cargada muere sin escribir una línea de error. Además el proceso **no sale** al terminar — hay que mirar el log o `dist/`, no el CPU.

## Impacto

Sin cambios de contrato GraphQL más allá de los campos nuevos, que son aditivos. Sin impacto en auto-update.

**Riesgo: bajo-medio.** Todo es UI de RRHH. Lo más sensible es el flujo del ítem manual, que ahora exige elegir la operación — un cambio de UX deliberado, y el motivo está arriba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
