### PR TITLE
feat(impresoras): registrar e instalar impresoras compartidas por una PC Windows (SMB)

### DIFF
--- a/src/app/modules/configuracion/impresoras/adicionar-impresora-dialog/adicionar-impresora-dialog.component.html
+++ b/src/app/modules/configuracion/impresoras/adicionar-impresora-dialog/adicionar-impresora-dialog.component.html
@@ -229,6 +229,88 @@
       </p>
     </div>
 
+    <!-- Impresora colgada de una PC Windows y compartida por SMB/Samba. El transporte lo hace
+         CUPS (backend smb -> smbspool); para el motor de impresion es una cola local mas. -->
+    <div class="instalar-panel">
+      <div class="deteccion-header" fxLayout="row" fxLayoutAlign="space-between center">
+        <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px">
+          <mat-icon>desktop_windows</mat-icon>
+          <span>Impresora de una PC Windows (Samba)</span>
+        </div>
+        <button
+          mat-stroked-button
+          type="button"
+          color="primary"
+          (click)="buscarRecursosSmb()"
+          [disabled]="buscandoSmb"
+        >
+          <mat-icon>search</mat-icon>
+          Buscar compartidas
+        </button>
+      </div>
+
+      <div fxLayout="row" fxLayoutGap="12px">
+        <mat-form-field fxFlex="30%" appearance="outline">
+          <mat-label>PC Windows (IP o nombre)</mat-label>
+          <input matInput formControlName="smbHost" autocomplete="off" placeholder="100.64.0.10" />
+        </mat-form-field>
+        <mat-form-field fxFlex="25%" appearance="outline">
+          <mat-label>Usuario de Windows</mat-label>
+          <input matInput formControlName="smbUsuario" autocomplete="off" />
+        </mat-form-field>
+        <mat-form-field fxFlex="20%" appearance="outline">
+          <mat-label>Dominio / grupo</mat-label>
+          <input matInput formControlName="smbDominio" autocomplete="off" placeholder="WORKGROUP" />
+        </mat-form-field>
+        <mat-form-field fxFlex="25%" appearance="outline">
+          <mat-label>Contraseña</mat-label>
+          <input
+            matInput
+            type="password"
+            [formControl]="smbPasswordControl"
+            autocomplete="new-password"
+          />
+        </mat-form-field>
+      </div>
+
+      <div *ngIf="buscandoSmb" class="deteccion-cargando">
+        <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+        <span>Consultando la PC Windows…</span>
+      </div>
+
+      <div *ngIf="!buscandoSmb && recursosSmb.length > 0" class="deteccion-lista">
+        <div
+          *ngFor="let r of recursosSmb"
+          class="item-dispositivo"
+          fxLayout="row"
+          fxLayoutAlign="space-between center"
+        >
+          <span class="item-text">
+            <span class="item-nombre">{{ r.nombre }}</span>
+            <span class="item-desc">{{ r.detalle }}</span>
+          </span>
+          <button
+            mat-stroked-button
+            type="button"
+            color="primary"
+            (click)="instalarRecursoSmb(r)"
+            [disabled]="instalandoSmb"
+          >
+            Instalar
+          </button>
+        </div>
+      </div>
+
+      <p *ngIf="mensajeSmb" class="deteccion-vacia">{{ mensajeSmb }}</p>
+
+      <p class="deteccion-vacia">
+        Para una impresora conectada a una PC con Windows: cargá la IP de esa PC y las credenciales,
+        tocá <b>Buscar compartidas</b> e <b>Instalar</b>. Se crea una cola en el servidor elegido en
+        <b>Buscar en</b> (arriba) que entrega los tickets por Samba. La contraseña se usa solo para
+        crear la cola y no se guarda en la base.
+      </p>
+    </div>
+
     <!-- Datos generales -->
     <div fxLayout="row" fxLayoutGap="16px">
       <mat-form-field fxFlex="50%" appearance="outline">

--- a/src/app/modules/configuracion/impresoras/adicionar-impresora-dialog/adicionar-impresora-dialog.component.ts
+++ b/src/app/modules/configuracion/impresoras/adicionar-impresora-dialog/adicionar-impresora-dialog.component.ts
@@ -54,6 +54,13 @@ interface DispositivoVista {
   puerto: number;
 }
 
+/** Share de impresora publicado por una PC Windows. */
+interface RecursoSmbVista {
+  ref: DispositivoDetectado;
+  nombre: string;
+  detalle: string;
+}
+
 interface RedVista {
   ref: NetworkPrinter;
   nombre: string;
@@ -98,6 +105,15 @@ export class AdicionarImpresoraDialogComponent implements OnInit {
   colaCupsControl = new FormControl(null);
   ipControl = new FormControl(null);
   puertoControl = new FormControl(9100);
+  smbHostControl = new FormControl(null);
+  smbRecursoControl = new FormControl(null);
+  smbUsuarioControl = new FormControl(null);
+  smbDominioControl = new FormControl(null);
+  /**
+   * Fuera del formGroup a proposito: la contrasena del share se manda solo en
+   * instalarImpresoraSmb y nunca se persiste (impresora se replica a todas las filiales).
+   */
+  smbPasswordControl = new FormControl(null);
   perfilPapelControl = new FormControl('MM_58');
   columnasControl = new FormControl(32);
   anchoMmControl = new FormControl(null);
@@ -122,6 +138,7 @@ export class AdicionarImpresoraDialogComponent implements OnInit {
     { value: 'CUPS', label: 'CUPS / cola del sistema' },
     { value: 'USB', label: 'USB (cola CUPS)' },
     { value: 'RED', label: 'Red / inalámbrica (IP)' },
+    { value: 'SMB', label: 'Windows compartida (Samba)' },
     { value: 'BLUETOOTH', label: 'Bluetooth (cola CUPS)' },
   ];
   perfiles: Opcion[] = [
@@ -151,6 +168,11 @@ export class AdicionarImpresoraDialogComponent implements OnInit {
   buscandoRed = false;
   instalando = false;
   esConexionRed = false;
+  esConexionSmb = false;
+  recursosSmb: RecursoSmbVista[] = [];
+  buscandoSmb = false;
+  instalandoSmb = false;
+  mensajeSmb: string = null;
   esPapelHoja = false;
   esWindows = false;
   etiquetaCola = 'Cola CUPS';
@@ -172,6 +194,10 @@ export class AdicionarImpresoraDialogComponent implements OnInit {
       colaCups: this.colaCupsControl,
       ip: this.ipControl,
       puerto: this.puertoControl,
+      smbHost: this.smbHostControl,
+      smbRecurso: this.smbRecursoControl,
+      smbUsuario: this.smbUsuarioControl,
+      smbDominio: this.smbDominioControl,
       perfilPapel: this.perfilPapelControl,
       columnas: this.columnasControl,
       anchoMm: this.anchoMmControl,
@@ -783,6 +809,88 @@ export class AdicionarImpresoraDialogComponent implements OnInit {
       });
   }
 
+  /**
+   * Lista los shares de impresora que publica una PC Windows. Lo hace el backend del host
+   * elegido en "Buscar en" (es el que despues va a hablar CIFS con Windows, no esta PC).
+   * Sin usuario/contrasena intenta login anonimo, que Windows suele rechazar.
+   */
+  buscarRecursosSmb(): void {
+    const host = (this.smbHostControl.value || '').trim();
+    if (!host) {
+      this.mensajeSmb = 'Cargá primero la IP o el nombre de la PC Windows.';
+      this.cdr.markForCheck();
+      return;
+    }
+    const enCentral = this.origenBusquedaControl.value === 'CENTRAL';
+    this.buscandoSmb = true;
+    this.mensajeSmb = null;
+    this.cdr.markForCheck();
+    this.impresoraService
+      .recursosSmb(host, this.smbUsuarioControl.value, this.smbDominioControl.value,
+        this.smbPasswordControl.value, enCentral)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (res) => {
+          this.recursosSmb = (res ?? []).map((d) => ({
+            ref: d,
+            nombre: d.nombre,
+            detalle: d.descripcion ? d.descripcion : d.uri,
+          }));
+          this.buscandoSmb = false;
+          this.mensajeSmb = this.recursosSmb.length === 0
+            ? 'No se encontraron impresoras compartidas. Revisá el usuario y la contraseña de Windows.'
+            : null;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.recursosSmb = [];
+          this.buscandoSmb = false;
+          this.mensajeSmb = 'No se pudo consultar la PC Windows (¿alcanzable? ¿smbclient instalado?).';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  /**
+   * Instala en el host elegido una cola CUPS que entrega a este share via smbspool, y deja el
+   * formulario apuntando a esa cola. La contrasena solo viaja en esta mutation.
+   */
+  instalarRecursoSmb(v: RecursoSmbVista): void {
+    if (!this.exigirNombreParaInstalar()) { return; }
+    const enCentral = this.origenBusquedaControl.value === 'CENTRAL';
+    const cola = this.sanearCola(this.nombreControl.value);
+    const esTermica = REGEX_TERMICA.test(`${v.nombre || ''} ${v.detalle || ''}`)
+      || this.tipoControl.value === 'TERMICA';
+    this.instalandoSmb = true;
+    this.mensajeSmb = null;
+    this.cdr.markForCheck();
+    this.impresoraService
+      .instalarSmb(cola, (this.smbHostControl.value || '').trim(), v.nombre,
+        this.smbUsuarioControl.value, this.smbDominioControl.value,
+        this.smbPasswordControl.value, esTermica, enCentral)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (ok) => {
+          this.instalandoSmb = false;
+          if (ok) {
+            this.conexionControl.setValue('SMB');
+            this.colaCupsControl.setValue(cola);
+            this.smbRecursoControl.setValue(v.nombre);
+            this.smbPasswordControl.setValue(null);
+            this.mensajeSmb = 'Cola instalada: ' + cola;
+          } else {
+            this.mensajeSmb = 'No se pudo instalar la cola (verificá permisos de CUPS del backend).';
+          }
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.instalandoSmb = false;
+          this.mensajeSmb = 'No se pudo instalar la cola.';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
   private cargarDatos(i: Impresora): void {
     this.impresoraId = i.id;
     this.nombreControl.setValue(i.nombre);
@@ -795,6 +903,10 @@ export class AdicionarImpresoraDialogComponent implements OnInit {
     this.colaCupsControl.setValue(i.colaCups);
     this.ipControl.setValue(i.ip);
     this.puertoControl.setValue(i.puerto ?? 9100);
+    this.smbHostControl.setValue(i.smbHost);
+    this.smbRecursoControl.setValue(i.smbRecurso);
+    this.smbUsuarioControl.setValue(i.smbUsuario);
+    this.smbDominioControl.setValue(i.smbDominio);
     this.perfilPapelControl.setValue(i.perfilPapel ?? 'MM_58');
     this.columnasControl.setValue(i.columnas);
     this.anchoMmControl.setValue(i.anchoMm);
@@ -806,6 +918,7 @@ export class AdicionarImpresoraDialogComponent implements OnInit {
 
   private actualizarVisibilidadConexion(conexion: string): void {
     this.esConexionRed = conexion === 'RED';
+    this.esConexionSmb = conexion === 'SMB';
     this.cdr.markForCheck();
   }
 
@@ -844,6 +957,10 @@ export class AdicionarImpresoraDialogComponent implements OnInit {
     modelo.colaCups = this.colaCupsControl.value;
     modelo.ip = this.ipControl.value;
     modelo.puerto = this.puertoControl.value;
+    modelo.smbHost = this.smbHostControl.value;
+    modelo.smbRecurso = this.smbRecursoControl.value;
+    modelo.smbUsuario = this.smbUsuarioControl.value;
+    modelo.smbDominio = this.smbDominioControl.value;
     modelo.perfilPapel = this.perfilPapelControl.value as PerfilPapel;
     modelo.columnas = this.columnasControl.value;
     modelo.anchoMm = this.anchoMmControl.value;

--- a/src/app/modules/configuracion/impresoras/graphql/estadoColas.ts
+++ b/src/app/modules/configuracion/impresoras/graphql/estadoColas.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { ColaEstado } from '../impresora.model';
+import { estadoColasQuery } from './graphql-query';
+
+export interface Response {
+  data: ColaEstado[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EstadoColasGQL extends Query<Response> {
+  document = estadoColasQuery;
+}

--- a/src/app/modules/configuracion/impresoras/graphql/graphql-query.ts
+++ b/src/app/modules/configuracion/impresoras/graphql/graphql-query.ts
@@ -15,6 +15,10 @@ const CAMPOS = `
   colaCups
   ip
   puerto
+  smbHost
+  smbRecurso
+  smbUsuario
+  smbDominio
   perfilPapel
   columnas
   anchoMm
@@ -95,5 +99,55 @@ export const instalarImpresoraCupsMutation = gql`
 export const imprimirPruebaEnImpresoraMutation = gql`
   mutation ($impresoraId: ID!) {
     data: imprimirPruebaEnImpresora(impresoraId: $impresoraId)
+  }
+`;
+
+export const recursosSmbQuery = gql`
+  query ($host: String!, $usuario: String, $dominio: String, $password: String) {
+    data: recursosSmb(host: $host, usuario: $usuario, dominio: $dominio, password: $password) {
+      clase
+      uri
+      nombre
+      descripcion
+    }
+  }
+`;
+
+export const estadoColasQuery = gql`
+  query {
+    data: estadoColas {
+      nombre
+      estado
+      razon
+      habilitada
+    }
+  }
+`;
+
+export const instalarImpresoraSmbMutation = gql`
+  mutation (
+    $nombreCola: String!
+    $host: String!
+    $recurso: String!
+    $usuario: String
+    $dominio: String
+    $password: String
+    $raw: Boolean
+  ) {
+    data: instalarImpresoraSmb(
+      nombreCola: $nombreCola
+      host: $host
+      recurso: $recurso
+      usuario: $usuario
+      dominio: $dominio
+      password: $password
+      raw: $raw
+    )
+  }
+`;
+
+export const reactivarColaMutation = gql`
+  mutation ($nombreCola: String!) {
+    data: reactivarCola(nombreCola: $nombreCola)
   }
 `;

--- a/src/app/modules/configuracion/impresoras/graphql/instalarImpresoraSmb.ts
+++ b/src/app/modules/configuracion/impresoras/graphql/instalarImpresoraSmb.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { instalarImpresoraSmbMutation } from './graphql-query';
+
+export interface Response {
+  data: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class InstalarImpresoraSmbGQL extends Mutation<Response> {
+  document = instalarImpresoraSmbMutation;
+}

--- a/src/app/modules/configuracion/impresoras/graphql/reactivarCola.ts
+++ b/src/app/modules/configuracion/impresoras/graphql/reactivarCola.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { reactivarColaMutation } from './graphql-query';
+
+export interface Response {
+  data: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ReactivarColaGQL extends Mutation<Response> {
+  document = reactivarColaMutation;
+}

--- a/src/app/modules/configuracion/impresoras/graphql/recursosSmb.ts
+++ b/src/app/modules/configuracion/impresoras/graphql/recursosSmb.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { DispositivoDetectado } from '../impresora.model';
+import { recursosSmbQuery } from './graphql-query';
+
+export interface Response {
+  data: DispositivoDetectado[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RecursosSmbGQL extends Query<Response> {
+  document = recursosSmbQuery;
+}

--- a/src/app/modules/configuracion/impresoras/impresora.model.ts
+++ b/src/app/modules/configuracion/impresoras/impresora.model.ts
@@ -8,9 +8,17 @@ export interface DispositivoDetectado {
   descripcion: string;
 }
 
+/** Estado real de una cola CUPS (lpstat -p), distinto del flag `activo` de la BD. */
+export interface ColaEstado {
+  nombre: string;
+  estado: "INACTIVA" | "IMPRIMIENDO" | "DESHABILITADA" | "DESCONOCIDA";
+  razon: string;
+  habilitada: boolean;
+}
+
 export type TipoImpresora = "TERMICA" | "NORMAL" | "ETIQUETA";
 export type UsoImpresora = "TICKET" | "FACTURA" | "REPORTE" | "ETIQUETA" | "COMANDA";
-export type TipoConexion = "CUPS" | "USB" | "RED" | "BLUETOOTH";
+export type TipoConexion = "CUPS" | "USB" | "RED" | "SMB" | "BLUETOOTH";
 export type PerfilPapel = "MM_48" | "MM_58" | "MM_72" | "MM_80" | "A4" | "CARTA" | "CUSTOM";
 
 export class Impresora {
@@ -25,6 +33,11 @@ export class Impresora {
   colaCups: string;
   ip: string;
   puerto: number;
+  /** Share de Windows (conexión SMB). Nunca incluye la contraseña. */
+  smbHost: string;
+  smbRecurso: string;
+  smbUsuario: string;
+  smbDominio: string;
   perfilPapel: PerfilPapel;
   columnas: number;
   anchoMm: number;
@@ -50,6 +63,10 @@ export class Impresora {
     input.colaCups = this?.colaCups;
     input.ip = this?.ip;
     input.puerto = this?.puerto;
+    input.smbHost = this?.smbHost;
+    input.smbRecurso = this?.smbRecurso;
+    input.smbUsuario = this?.smbUsuario;
+    input.smbDominio = this?.smbDominio;
     input.perfilPapel = this?.perfilPapel;
     input.columnas = this?.columnas;
     input.anchoMm = this?.anchoMm;
@@ -73,6 +90,10 @@ export class ImpresoraInput {
   colaCups?: string;
   ip?: string;
   puerto?: number;
+  smbHost?: string;
+  smbRecurso?: string;
+  smbUsuario?: string;
+  smbDominio?: string;
   perfilPapel?: PerfilPapel;
   columnas?: number;
   anchoMm?: number;

--- a/src/app/modules/configuracion/impresoras/impresora.service.ts
+++ b/src/app/modules/configuracion/impresoras/impresora.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { GenericCrudService } from '../../../generics/generic-crud.service';
-import { DispositivoDetectado, Impresora, ImpresoraInput } from './impresora.model';
+import { ColaEstado, DispositivoDetectado, Impresora, ImpresoraInput } from './impresora.model';
 import { DispositivosParaInstalarGQL } from './graphql/dispositivosParaInstalar';
 import { InstalarImpresoraCupsGQL } from './graphql/instalarImpresoraCups';
 import { ImpresorasGQL } from './graphql/impresorasQuery';
@@ -13,6 +13,10 @@ import { SaveImpresoraGQL } from './graphql/saveImpresora';
 import { DeleteImpresoraGQL } from './graphql/deleteImpresora';
 import { ImpresorasDelSistemaGQL } from './graphql/impresorasDelSistema';
 import { ImprimirPruebaEnImpresoraGQL } from './graphql/imprimirPruebaEnImpresora';
+import { RecursosSmbGQL } from './graphql/recursosSmb';
+import { EstadoColasGQL } from './graphql/estadoColas';
+import { InstalarImpresoraSmbGQL } from './graphql/instalarImpresoraSmb';
+import { ReactivarColaGQL } from './graphql/reactivarCola';
 
 @Injectable({
   providedIn: 'root'
@@ -31,6 +35,10 @@ export class ImpresoraService {
     private dispositivosParaInstalarGQL: DispositivosParaInstalarGQL,
     private instalarImpresoraCupsGQL: InstalarImpresoraCupsGQL,
     private imprimirPruebaEnImpresoraGQL: ImprimirPruebaEnImpresoraGQL,
+    private recursosSmbGQL: RecursosSmbGQL,
+    private estadoColasGQL: EstadoColasGQL,
+    private instalarImpresoraSmbGQL: InstalarImpresoraSmbGQL,
+    private reactivarColaGQL: ReactivarColaGQL,
   ) { }
 
   /** Registro de impresoras. Vive en el servidor central (administrativo). */
@@ -104,6 +112,84 @@ export class ImpresoraService {
       { impresoraId },
       servidor
     );
+  }
+
+  /**
+   * Shares de impresora publicados por una PC Windows, vistos desde el host del backend
+   * consultado (`smbclient -L`). La contraseña autentica la consulta y se descarta: las URIs
+   * que vuelven no la incluyen.
+   */
+  recursosSmb(
+    host: string,
+    usuario?: string,
+    dominio?: string,
+    password?: string,
+    servidor = false,
+  ): Observable<DispositivoDetectado[]> {
+    // Fetch directo en vez de genericService.onCustomQuery: ante un error GraphQL ese helper
+    // muestra un snackbar pero NO completa ni emite error, y el diálogo se quedaría con el
+    // spinner girando. Acá propagamos el error para que el llamador lo muestre y lo apague.
+    return this.recursosSmbGQL
+      .fetch({ host, usuario, dominio, password }, {
+        fetchPolicy: 'no-cache',
+        errorPolicy: 'all',
+        context: { clientName: servidor ? 'servidor' : null },
+      })
+      .pipe(
+        map((res) => {
+          if (res?.errors?.length) {
+            throw new Error(res.errors[0]?.message || 'Error GraphQL');
+          }
+          return res?.data?.data ?? [];
+        }),
+      );
+  }
+
+  /**
+   * Instala en el host del backend una cola CUPS que entrega a un share de Windows (backend smb
+   * de CUPS / smbspool). La contraseña viaja solo en esta mutation: el backend la usa para armar
+   * el device-uri y no la persiste en la BD (que se replica a todas las filiales).
+   */
+  instalarSmb(
+    nombreCola: string,
+    host: string,
+    recurso: string,
+    usuario?: string,
+    dominio?: string,
+    password?: string,
+    raw = true,
+    servidor = false,
+  ): Observable<boolean> {
+    return this.genericService.onCustomMutation(
+      this.instalarImpresoraSmbGQL,
+      { nombreCola, host, recurso, usuario, dominio, password, raw },
+      servidor,
+    );
+  }
+
+  /**
+   * Estado real de las colas CUPS del host consultado. La tarjeta mostraba `impresora.activo`
+   * (un flag de la BD) mientras CUPS podía tener la cola frenada hace días: CUPS deshabilita una
+   * cola ante un fallo del backend y no se recupera sola.
+   */
+  estadoColas(servidor = false): Observable<ColaEstado[]> {
+    // Lectura complementaria: si el host no responde o es una versión sin `estadoColas`, la
+    // pantalla debe seguir andando con el flag de la BD, sin snackbars de error.
+    return this.estadoColasGQL
+      .fetch({}, {
+        fetchPolicy: 'no-cache',
+        errorPolicy: 'all',
+        context: { clientName: servidor ? 'servidor' : null },
+      })
+      .pipe(
+        map((res) => (res?.errors?.length ? [] : res?.data?.data ?? [])),
+        catchError(() => of([] as ColaEstado[])),
+      );
+  }
+
+  /** Rehabilita una cola frenada por CUPS, libera los jobs retenidos y le fija el reintento. */
+  reactivarCola(nombreCola: string, servidor = false): Observable<boolean> {
+    return this.genericService.onCustomMutation(this.reactivarColaGQL, { nombreCola }, servidor);
   }
 
   /**

--- a/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.html
+++ b/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.html
@@ -67,8 +67,10 @@
           </div>
 
           <div class="card-estado">
-            <span class="chip-estado" [class.chip-activa]="imp.activo" [class.chip-inactiva]="!imp.activo">
-              {{ imp.activo ? 'Activa' : 'Inactiva' }}
+            <span class="chip-estado" [class.chip-activa]="imp.activo && !imp.estadoDetenida"
+              [class.chip-inactiva]="!imp.activo" [class.chip-detenida]="imp.estadoDetenida"
+              [title]="imp.razonDetencion">
+              {{ imp.estadoLabel }}
             </span>
           </div>
 
@@ -80,6 +82,10 @@
               Probar
             </button>
             <div>
+              <button *ngIf="imp.puedeReactivar" mat-icon-button color="accent" (click)="reactivar(imp.ref)"
+                aria-label="Reactivar cola" title="CUPS detuvo esta cola. Reactivar y liberar los trabajos pendientes.">
+                <mat-icon>restart_alt</mat-icon>
+              </button>
               <button mat-icon-button (click)="editarItem(imp.ref)" aria-label="Editar impresora" title="Editar">
                 <mat-icon>edit</mat-icon>
               </button>

--- a/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.scss
+++ b/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.scss
@@ -171,6 +171,12 @@
   color: #bdbdbd;
 }
 
+// CUPS freno la cola tras un fallo del backend: los trabajos quedan encolados sin salir.
+.chip-detenida {
+  background: rgba(244, 67, 54, 0.2);
+  color: #ef9a9a;
+}
+
 .card-acciones {
   margin-top: 8px;
 }

--- a/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.ts
+++ b/src/app/modules/configuracion/impresoras/list-impresoras/list-impresoras.component.ts
@@ -17,6 +17,7 @@ import {
   NotificacionSnackbarService,
 } from '../../../../notificacion-snackbar.service';
 import {
+  ColaEstado,
   Impresora,
   PerfilPapel,
   TipoConexion,
@@ -41,6 +42,11 @@ interface ImpresoraVista {
   sucursalNombre: string;
   colorIndex: number;
   compartidaEnCentral: boolean;
+  /** Texto y color del chip: estado real de CUPS si lo conocemos, si no el flag de la BD. */
+  estadoLabel: string;
+  estadoDetenida: boolean;
+  puedeReactivar: boolean;
+  razonDetencion: string;
 }
 
 const PERFIL_LABEL: Record<PerfilPapel, string> = {
@@ -69,7 +75,17 @@ const CONEXION_ICONO: Record<TipoConexion, string> = {
   CUPS: 'cable',
   USB: 'usb',
   RED: 'wifi',
+  SMB: 'desktop_windows',
   BLUETOOTH: 'bluetooth',
+};
+
+/** sucursalId del host donde corre el backend central (ver adicionar-impresora-dialog). */
+const HOST_SERVIDOR_CENTRAL_ID = 0;
+
+const ESTADO_LABEL: Record<string, string> = {
+  INACTIVA: 'Lista',
+  IMPRIMIENDO: 'Imprimiendo',
+  DESHABILITADA: 'Detenida',
 };
 
 @UntilDestroy()
@@ -101,6 +117,14 @@ export class ListImpresorasComponent implements OnInit {
   
   searchControl = new FormControl('');
 
+  /**
+   * Estado real de las colas por host, indexado por nombre de cola. Solo consultamos los dos
+   * backends que la app ya tiene configurados (central y local/filial); para impresoras de otra
+   * sucursal no tenemos lectura y la tarjeta cae al flag `activo` de la BD.
+   */
+  private colasCentral = new Map<string, ColaEstado>();
+  private colasLocal = new Map<string, ColaEstado>();
+
   ngOnInit(): void {
     this.calcularColumnas();
 
@@ -114,10 +138,12 @@ export class ListImpresorasComponent implements OnInit {
         this.recargar();
       });
 
+    this.cargarEstadoColas();
     this.cargar();
   }
 
   recargar(): void {
+    this.cargarEstadoColas();
     this.page = 0;
     this.impresoras = [];
     this.filas = [];
@@ -275,6 +301,102 @@ export class ListImpresorasComponent implements OnInit {
     });
   }
 
+  /**
+   * Lee el estado real de las colas CUPS del central y del servidor local/filial. La tarjeta
+   * mostraba `impresora.activo` (BD) mientras CUPS podia tener la cola frenada hace dias: CUPS
+   * deshabilita una cola ante un fallo del backend y no la vuelve a habilitar sola.
+   * Silencioso a proposito: es informacion complementaria, no puede bloquear la pantalla.
+   */
+  private cargarEstadoColas(): void {
+    // estadoColas() nunca falla: si el host no responde devuelve [] y la tarjeta cae al flag de la BD.
+    this.impresoraService.estadoColas(true)
+      .pipe(untilDestroyed(this))
+      .subscribe((colas) => {
+        this.colasCentral = this.indexar(colas);
+        this.refrescarEstados();
+      });
+    this.impresoraService.estadoColas(false)
+      .pipe(untilDestroyed(this))
+      .subscribe((colas) => {
+        this.colasLocal = this.indexar(colas);
+        this.refrescarEstados();
+      });
+  }
+
+  private indexar(colas: ColaEstado[]): Map<string, ColaEstado> {
+    const mapa = new Map<string, ColaEstado>();
+    (colas ?? []).forEach((c) => {
+      if (c?.nombre) {
+        mapa.set(c.nombre, c);
+      }
+    });
+    return mapa;
+  }
+
+  /** Recalcula el chip de cada tarjeta cuando llega la lectura de un host. */
+  private refrescarEstados(): void {
+    this.impresoras = this.impresoras.map((v) => ({ ...v, ...this.estadoDe(v.ref) }));
+    this.filas = this.chunkArray(this.impresoras, this.columnas);
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * Rehabilita la cola en el host dueno de la impresora y libera los jobs retenidos. Ademas le
+   * fija printer-error-policy=retry-current-job para que no se vuelva a frenar en el proximo corte.
+   */
+  reactivar(impresora: Impresora): void {
+    const enCentral = (impresora?.sucursal?.id ?? HOST_SERVIDOR_CENTRAL_ID) === HOST_SERVIDOR_CENTRAL_ID;
+    this.impresoraService.reactivarCola(impresora.colaCups, enCentral)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (ok) => {
+          this.notificacion.notification$.next({
+            texto: ok
+              ? 'Cola reactivada: ' + impresora.colaCups
+              : 'No se pudo reactivar la cola (verificá permisos de CUPS del backend).',
+            color: ok ? NotificacionColor.success : NotificacionColor.warn,
+            duracion: 4,
+          });
+          if (ok) {
+            this.cargarEstadoColas();
+          }
+        },
+        error: () => this.notificarFallo(impresora, 'no se pudo reactivar la cola'),
+      });
+  }
+
+  /**
+   * Chip de estado. Precedencia: si el admin la marco inactiva en la BD, eso manda; si no, el
+   * estado real de CUPS; si no lo conocemos (impresora de otra sucursal, o backend sin permisos),
+   * cae al flag `activo`.
+   */
+  private estadoDe(i: Impresora): Pick<ImpresoraVista, 'estadoLabel' | 'estadoDetenida' | 'puedeReactivar' | 'razonDetencion'> {
+    if (i?.activo !== true) {
+      return { estadoLabel: 'Inactiva', estadoDetenida: false, puedeReactivar: false, razonDetencion: '' };
+    }
+    const cola = this.colaDe(i);
+    if (cola == null) {
+      return { estadoLabel: 'Activa', estadoDetenida: false, puedeReactivar: false, razonDetencion: '' };
+    }
+    const detenida = cola.habilitada === false;
+    return {
+      estadoLabel: ESTADO_LABEL[cola.estado] ?? 'Activa',
+      estadoDetenida: detenida,
+      puedeReactivar: detenida,
+      razonDetencion: detenida ? (cola.razon || 'CUPS detuvo la cola tras un fallo') : '',
+    };
+  }
+
+  /** La conexion RED no pasa por CUPS: no hay cola que consultar. */
+  private colaDe(i: Impresora): ColaEstado {
+    if (!i?.colaCups || i?.conexion === 'RED') {
+      return null;
+    }
+    const enCentral = (i?.sucursal?.id ?? HOST_SERVIDOR_CENTRAL_ID) === HOST_SERVIDOR_CENTRAL_ID;
+    const mapa = enCentral ? this.colasCentral : this.colasLocal;
+    return mapa.get(i.colaCups) ?? null;
+  }
+
   private aVista(i: Impresora): ImpresoraVista {
     const sucursalId = i?.sucursal?.id ?? 0;
     return {
@@ -291,6 +413,7 @@ export class ListImpresorasComponent implements OnInit {
       sucursalNombre: i?.sucursal ? `${i.sucursal.id} - ${i.sucursal.nombre}` : 'Sin sucursal',
       colorIndex: sucursalId % 6,
       compartidaEnCentral: i?.compartidaEnCentral === true,
+      ...this.estadoDe(i),
     };
   }
 
@@ -298,6 +421,10 @@ export class ListImpresorasComponent implements OnInit {
     if (i?.conexion === 'RED') {
       const puerto = i?.puerto ?? 9100;
       return `${i?.ip ?? ''}:${puerto}`;
+    }
+    if (i?.conexion === 'SMB' && i?.smbHost) {
+      // La cola es local, pero lo util para el operador es a que PC Windows entrega.
+      return `${i.colaCups ?? ''} → \\\\${i.smbHost}\\${i.smbRecurso ?? ''}`;
     }
     return i?.colaCups ?? (i?.conexion ?? '');
   }


### PR DESCRIPTION
## Qué resuelve

Par del backend **GabFrank/franco-system-backend-servidor#235** — requiere ese PR mergeado para funcionar.

Hasta ahora una impresora colgada de una PC Windows solo se podía usar creando la cola CUPS a mano en el host. Desde la app no había forma de detectarla ni instalarla. Y el chip de estado mentía: mostraba el flag `activo` de la BD mientras CUPS podía tener la cola frenada hacía días.

### Alta de impresora SMB
Nueva sección "Impresora de una PC Windows (Samba)" en el diálogo de alta: IP de la PC Windows, usuario, dominio/grupo de trabajo y contraseña.

- **"Buscar compartidas"** (`recursosSmb`) lista los shares publicados por esa PC para elegir el correcto en vez de tipear la URI.
- **"Instalar"** (`instalarImpresoraSmb`) crea la cola en el servidor elegido.
- La contraseña **solo viaja en la mutation**: no se guarda en la BD (`impresora` se replica a todas las filiales) ni vuelve en ninguna query. Queda en `printers.conf` del host dueño.

### Estado real de la cola
El chip pasa a mostrar lo que dice CUPS — **Lista / Imprimiendo / Detenida** — leyendo `estadoColas` del central y del servidor local.

- Degradación silenciosa a propósito: si el host no responde, o es una versión del backend sin `estadoColas`, la lectura devuelve `[]` y la tarjeta cae al flag `activo` de siempre. Sin snackbars de error: es información complementaria, no puede bloquear la pantalla.
- La conexión `RED` no pasa por CUPS, así que no se le consulta cola.
- Precedencia del chip: si el admin la marcó inactiva en la BD, eso manda; si no, el estado de CUPS; si no lo conocemos (impresora de otra sucursal), el flag.

### Reactivar cola detenida
Botón sobre las colas que CUPS frenó, con el motivo en el tooltip. CUPS deshabilita una cola ante un fallo del backend y **no se recupera sola** — es lo que dejaba tickets sin salir sin ningún aviso. El botón la rehabilita, libera los jobs retenidos y le fija la política de reintento.

### Fix de paso
`recursosSmb` se lee por fetch directo en vez de `genericService.onCustomQuery`: ante un error GraphQL ese helper muestra el snackbar pero **no completa ni emite error**, y el diálogo se quedaba con el spinner girando para siempre. Acá el error se propaga para que el llamador lo muestre y apague el spinner.

## Cómo probarlo

1. Backend con el PR par desplegado, y `smbclient` + backend smb de CUPS instalados en su host.
2. Configuración → Impresoras → Agregar → sección "Impresora de una PC Windows (Samba)". Cargar IP de la PC Windows, usuario y `WORKGROUP`, tocar **Buscar compartidas** → deben listarse los shares.
3. Elegir uno, tocar **Instalar**, guardar la impresora con conexión SMB y tocar **Probar** → el ticket sale por la impresora de la Windows.
4. Credenciales mal puestas → el diálogo muestra el error y **apaga el spinner** (esto es lo que fallaba antes).
5. En el host del backend: `cupsdisable <cola>` → recargar la lista → el chip debe pasar a **Detenida** con el motivo en el tooltip y aparecer el botón de reactivar. Tocarlo → vuelve a **Lista** y los jobs pendientes salen.
6. Apagar el backend local (o probar contra uno viejo) → la pantalla debe seguir funcionando con el chip Activa/Inactiva de siempre, sin errores.

## Impacto en DB

Ninguno del lado del desktop. El backend agrega 4 columnas nullable (`V201.5`); acá solo se consumen los campos nuevos del schema GraphQL.

## Impacto en rollback

Bajo. Volver a la versión anterior del desktop deja de mostrar el estado real y el botón de reactivar, pero las impresoras SMB ya instaladas siguen imprimiendo: la cola vive en CUPS, no en la app.

## Riesgo

**Bajo.** Nada del camino de impresión existente cambia. Lo nuevo es una conexión adicional en el alta y dos lecturas que degradan a silencio si el backend no las soporta.

> ⚠️ Ordenar el merge: **primero el backend (#235)**. Si entra este solo, `estadoColas` falla contra el schema viejo — la app lo tolera (cae al flag de la BD), pero la sección SMB del alta no sirve.

## Verificación

`npm run check` (`ng build --configuration production`) → exit 0, solo los warnings de CommonJS preexistentes.

**Sin unit tests**: `npm test` no compila en este repo por el desajuste `@angular-devkit` v16 vs Angular 15.1.5 — es previo a este cambio, no lo introduce este PR.