### PR TITLE
feat(financiero): saldos de caja en cards, conteo de efectivo y menu de tesoreria

### DIFF
--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.html
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.html
@@ -30,36 +30,27 @@
 
     <!-- Sidebar de saldos -->
     <aside class="saldos-sidebar">
-      <!-- Saldo en caja -->
-      <div class="sidebar-title">Saldo en Caja</div>
-      <div class="mini-card">
-        <div class="mini-card-header"><mat-icon>account_balance_wallet</mat-icon> Efectivo</div>
-        <div class="mini-row" *ngFor="let s of saldos">
-          <span>{{ s.moneda?.simbolo }} {{ s.moneda?.denominacion }}</span>
-          <strong [style.color]="s.saldo < 0 ? '#f44336' : null">{{ s.saldo | number:'1.0-2' }}</strong>
-        </div>
-        <div class="mini-row" *ngIf="saldos.length === 0"><span style="opacity: 0.6;">Sin saldos</span></div>
-      </div>
-
+      <!-- El saldo de efectivo por moneda vive arriba de la tabla, en cards clickeables. -->
       <!-- Cuentas bancarias -->
-      <ng-container *ngIf="resumenBancario.length > 0">
+      <ng-container *ngIf="bancoCards.length > 0">
         <div class="sidebar-title">Cuentas bancarias</div>
-        <div class="mini-card" *ngFor="let cb of resumenBancario">
+        <div class="mini-card banco-card" *ngFor="let b of bancoCards">
           <div class="mini-card-header">
             <mat-icon>account_balance</mat-icon>
-            {{ cb.cuentaBancaria?.banco?.nombre }} · {{ cb.cuentaBancaria?.numero }}
+            {{ b.resumen.cuentaBancaria?.banco?.nombre }} · {{ b.resumen.cuentaBancaria?.numero }}
           </div>
-          <div class="mini-row">
-            <span>Actual</span>
-            <strong [style.color]="cb.saldo < 0 ? '#f44336' : null">{{ cb.saldo | number:'1.0-2' }}</strong>
+          <!-- Saldo actual en grande: el sidebar quedó libre al mover los saldos de caja a cards. -->
+          <div class="banco-saldo" [style.color]="b.resumen.saldo < 0 ? '#ff8a80' : null">
+            {{ b.resumen.saldo | number:b.formato }}
+            <span class="banco-simbolo">{{ b.resumen.cuentaBancaria?.moneda?.simbolo }}</span>
           </div>
-          <div class="mini-row" *ngIf="cb.saldoReservado">
+          <div class="mini-row" *ngIf="b.resumen.saldoReservado">
             <span matTooltip="Cheques diferidos emitidos pendientes de cobro">Reservado</span>
-            <strong style="color: #ff9800;">{{ cb.saldoReservado | number:'1.0-2' }}</strong>
+            <strong style="color: #ff9800;">{{ b.resumen.saldoReservado | number:b.formato }}</strong>
           </div>
-          <div class="mini-row" *ngIf="cb.saldoFuturo">
+          <div class="mini-row" *ngIf="b.resumen.saldoFuturo">
             <span matTooltip="Acreditaciones POS pendientes">Futuro</span>
-            <strong style="color: #2196f3;">{{ cb.saldoFuturo | number:'1.0-2' }}</strong>
+            <strong style="color: #2196f3;">{{ b.resumen.saldoFuturo | number:b.formato }}</strong>
           </div>
         </div>
       </ng-container>
@@ -75,7 +66,32 @@
       </ng-container>
     </aside>
 
-    <!-- Panel principal: movimientos -->
+    <!-- Panel principal: cards de saldo + movimientos -->
+    <div class="main-panel">
+
+      <!-- Saldos por moneda. Click = filtra la tabla por esa moneda; el boton de conteo abre el arqueo. -->
+      <div class="saldo-cards" *ngIf="!fuenteEsBanco && saldoCards.length > 0">
+        <div class="saldo-card" *ngFor="let c of saldoCards"
+             [class.seleccionada]="c.seleccionada"
+             [style.border-color]="c.seleccionada ? c.color : null"
+             [style.box-shadow]="c.seleccionada ? ('inset 0 0 0 1px ' + c.color) : null"
+             (click)="onCardClick(c)"
+             [matTooltip]="c.seleccionada ? 'Quitar filtro de moneda' : 'Ver solo movimientos de esta moneda'">
+          <div class="saldo-card-top" [style.background-color]="c.color"></div>
+          <div class="saldo-card-label">{{ c.saldo.moneda?.denominacion }}</div>
+          <div class="saldo-card-valor" [style.color]="c.saldo.saldo < 0 ? '#ff8a80' : c.color">
+            {{ c.saldo.saldo | number:c.formato }}
+            <span class="saldo-card-simbolo">{{ c.saldo.moneda?.simbolo }}</span>
+          </div>
+          <button mat-icon-button class="saldo-card-conteo" (click)="onConteo(c, $event)"
+                  matTooltip="Conteo de efectivo">
+            <mat-icon>calculate</mat-icon>
+          </button>
+        </div>
+      </div>
+
+      <div class="sin-saldos" *ngIf="!fuenteEsBanco && saldoCards.length === 0">Sin saldos en caja</div>
+
     <mat-card class="section-card">
       <mat-card-header class="movimientos-header">
         <mat-card-title>Movimientos</mat-card-title>
@@ -259,5 +275,6 @@
         </mat-paginator>
       </mat-card-content>
     </mat-card>
+    </div>
   </div>
 </div>

--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.scss
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.scss
@@ -54,12 +54,100 @@
   min-height: 0;
 }
 
-.section-card {
+/* Columna principal: cards de saldo arriba, tabla de movimientos abajo. */
+.main-panel {
   grid-area: main;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.section-card {
+  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
+}
+
+.saldo-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+/* Card de saldo por moneda: clickeable (filtra la tabla) y con acceso al conteo. */
+.saldo-card {
+  position: relative;
+  flex: 1 1 200px;
+  min-width: 190px;
+  max-width: 320px;
+  padding: 14px 16px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  overflow: hidden;
+  transition: background 0.15s ease, transform 0.15s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.07);
+    transform: translateY(-1px);
+  }
+
+  &.seleccionada {
+    background: rgba(255, 255, 255, 0.09);
+  }
+}
+
+/* Franja de color: identifica la moneda de un vistazo sin depender del texto. */
+.saldo-card-top {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+}
+
+.saldo-card-label {
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.6;
+  margin-bottom: 4px;
+}
+
+.saldo-card-valor {
+  font-size: 30px;
+  font-weight: 600;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  .saldo-card-simbolo {
+    font-size: 14px;
+    font-weight: 400;
+    opacity: 0.75;
+    margin-left: 4px;
+  }
+}
+
+.saldo-card-conteo {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  opacity: 0.6;
+
+  &:hover { opacity: 1; }
+}
+
+.sin-saldos {
+  opacity: 0.55;
+  font-size: 13px;
+  padding: 4px 2px;
 }
 
 .sidebar-title {
@@ -102,6 +190,29 @@
   strong {
     font-weight: 600;
     font-variant-numeric: tabular-nums;
+  }
+}
+
+/* Cuenta bancaria: el saldo actual manda, reservado/futuro quedan como notas al pie. */
+.banco-card {
+  padding: 12px 14px;
+}
+
+.banco-saldo {
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 1.15;
+  font-variant-numeric: tabular-nums;
+  margin: 2px 0 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  .banco-simbolo {
+    font-size: 13px;
+    font-weight: 400;
+    opacity: 0.7;
+    margin-left: 3px;
   }
 }
 
@@ -194,6 +305,9 @@
 }
 
 @media (max-width: 1100px) {
+  .saldo-card {
+    max-width: none;
+  }
   .content-section {
     grid-template-columns: 1fr;
     grid-template-areas: "sidebar" "main";

--- a/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component.ts
@@ -12,6 +12,7 @@ import { CajaVirtual, CajaVirtualTipoMovimiento, MovimientoCajaVirtual,
          CajaVirtualSaldoItem, CuentaBancariaResumen, CajaVirtualConfiguracion,
          labelMovimiento } from '../caja-virtual.model';
 import { CajaVirtualService } from '../caja-virtual.service';
+import { Moneda } from '../../moneda/moneda.model';
 import { PageInfo } from '../../../../app.component';
 import { AddMovimientoCajaVirtualDialogComponent, MovimientoDialogData } from '../add-movimiento-caja-virtual-dialog/add-movimiento-caja-virtual-dialog.component';
 import { TransferenciaCajaVirtualDialogComponent } from '../transferencia-caja-virtual-dialog/transferencia-caja-virtual-dialog.component';
@@ -24,6 +25,7 @@ import { AddEntradaVariaDialogComponent, EntradaVariaDialogData } from '../../en
 import { ListEntradasVariasDialogComponent } from '../../entrada-varia/list-entradas-varias-dialog/list-entradas-varias-dialog.component';
 import { AddOperacionFinancieraDialogComponent } from '../../operacion-financiera/add-operacion-financiera-dialog/add-operacion-financiera-dialog.component';
 import { DetallePagoDialogComponent, DetallePagoDialogData } from '../detalle-pago-dialog/detalle-pago-dialog.component';
+import { ConteoCajaDialogComponent, ConteoCajaDialogData } from '../conteo-caja-dialog/conteo-caja-dialog.component';
 import { OperacionFinancieraDetalleDialogComponent } from '../../operacion-financiera/operacion-financiera-detalle-dialog/operacion-financiera-detalle-dialog.component';
 import { OperacionFinancieraService } from '../../operacion-financiera/operacion-financiera.service';
 import { PagarComprasService } from '../pagar-compras-dialog/pagar-compras.service';
@@ -49,6 +51,32 @@ interface MovimientoRow extends MovimientoCajaVirtual {
   _esGrupoMulti?: boolean;    // el grupo tiene 2+ filas consecutivas (par de cambio/transferencia)
 }
 
+/** Card de saldo por moneda que se muestra sobre la tabla de movimientos. */
+interface SaldoCard {
+  saldo: CajaVirtualSaldoItem;
+  color: string;        // color de acento de la card (fondo del borde/valor)
+  seleccionada: boolean;
+  formato: string;      // digitsInfo del pipe number, según los decimales de la moneda
+}
+
+/** Card de cuenta bancaria del sidebar, con el formato de su moneda precalculado. */
+interface BancoCard {
+  resumen: CuentaBancariaResumen;
+  formato: string;
+}
+
+/**
+ * digitsInfo para el pipe number, según la moneda. El fallback por denominación es el mismo
+ * patrón que usa el resto del módulo (pagar-compras-dialog): el guaraní no lleva fracción,
+ * las demás sí. Ver migración V207.5, que pobló `decimales` — estaba en 0 para todas.
+ */
+function formatoDe(moneda: Moneda): string {
+  const d = moneda?.decimales != null
+    ? moneda.decimales
+    : ((moneda?.denominacion || '').toUpperCase().includes('GUARAN') ? 0 : 2);
+  return `1.0-${d}`;
+}
+
 @UntilDestroy({ checkProperties: true })
 @Component({
   selector: 'app-caja-virtual-dashboard',
@@ -61,9 +89,18 @@ export class CajaVirtualDashboardComponent implements OnInit {
 
   cajaVirtual: CajaVirtual;
 
-  // Sidebar
+  // Saldos por moneda: cards sobre la tabla (antes iban en el sidebar).
   saldos: CajaVirtualSaldoItem[] = [];
+  saldoCards: SaldoCard[] = [];
+  /** Moneda por la que se está filtrando la tabla (null = todas). La activa el click en la card. */
+  monedaSelId: number = null;
+
+  // Paleta estable de las cards: se indexa por id de moneda, así el color no baila entre recargas.
+  private monedaPaleta = ['#26a69a', '#5c6bc0', '#ffa726', '#ab47bc', '#ef5350', '#42a5f5', '#8d6e63'];
+
+  // Sidebar
   resumenBancario: CuentaBancariaResumen[] = [];
+  bancoCards: BancoCard[] = [];
   config: CajaVirtualConfiguracion;
 
   // Movimientos (tabla)
@@ -174,8 +211,54 @@ export class CajaVirtualDashboardComponent implements OnInit {
     if (!this.cajaVirtual?.id) return;
     this.cajaVirtualService.onGetSaldos(this.cajaVirtual.id)
       .pipe(untilDestroyed(this)).subscribe(res => {
-        if (res) this.saldos = res;
+        if (res) {
+          this.saldos = res;
+          this.construirCards();
+        }
       });
+  }
+
+  /** Arma las cards de saldo por moneda con su color estable y el estado de selección. */
+  private construirCards() {
+    this.saldoCards = this.saldos.map(s => ({
+      saldo: s,
+      color: this.monedaPaleta[(s.moneda?.id || 0) % this.monedaPaleta.length],
+      seleccionada: this.monedaSelId != null && this.monedaSelId === s.moneda?.id,
+      formato: formatoDe(s.moneda),
+    }));
+    // Si la moneda filtrada dejó de tener saldo, el filtro quedaría colgado sin card visible.
+    if (this.monedaSelId != null && !this.saldoCards.some(c => c.seleccionada)) {
+      this.monedaSelId = null;
+    }
+  }
+
+  /** Click en una card: filtra la tabla por esa moneda; volver a clickear la misma quita el filtro. */
+  onCardClick(card: SaldoCard) {
+    const id = card.saldo?.moneda?.id;
+    if (id == null) return;
+    this.monedaSelId = this.monedaSelId === id ? null : id;
+    this.saldoCards.forEach(c => c.seleccionada = c.saldo?.moneda?.id === this.monedaSelId);
+    this.pageIndex = 0;
+    this.cargarMovimientos();
+  }
+
+  /**
+   * Conteo de efectivo de una moneda. El conteo vive en localStorage (no en el backend):
+   * es una herramienta de arqueo, y tiene que sobrevivir a que se cierre el diálogo sin ajustar.
+   * Solo se persiste en la caja un AJUSTE, y únicamente si el usuario lo pide.
+   */
+  onConteo(card: SaldoCard, event: MouseEvent) {
+    event.stopPropagation();   // el click del botón no debe además togglear el filtro de la card
+    const data: ConteoCajaDialogData = {
+      cajaVirtual: this.cajaVirtual,
+      moneda: card.saldo?.moneda,
+      saldoSistema: card.saldo?.saldo || 0,
+      color: card.color,
+    };
+    this.dialog.open(ConteoCajaDialogComponent, {
+      // Sin ancho fijo: la grilla de denominaciones define el tamaño (1 columna o varias).
+      maxWidth: '96vw', maxHeight: '92vh', autoFocus: false, data,
+    }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => { if (res) this.recargar(); });
   }
 
   cargarConfigYBancos() {
@@ -186,6 +269,10 @@ export class CajaVirtualDashboardComponent implements OnInit {
         this.cajaVirtualService.onGetResumenBancario(this.cajaVirtual.id)
           .pipe(untilDestroyed(this)).subscribe(res => {
             this.resumenBancario = res || [];
+            this.bancoCards = this.resumenBancario.map(r => ({
+              resumen: r,
+              formato: formatoDe(r.cuentaBancaria?.moneda),
+            }));
             this.construirFuentes();
           });
       });
@@ -220,6 +307,7 @@ export class CajaVirtualDashboardComponent implements OnInit {
       desde: this.desdeControl.value ? dateToString(this.desdeControl.value) : null,
       fin: this.hastaControl.value ? dateToString(this.hastaControl.value) : null,
       tipo: this.tipoControl.value || null,
+      monedaId: this.monedaSelId,
       soloActivos: !this.verAnulaciones,
     }, this.pageIndex, this.pageSize)
       .pipe(untilDestroyed(this))
@@ -311,6 +399,8 @@ export class CajaVirtualDashboardComponent implements OnInit {
     this.desdeControl.setValue(null);
     this.hastaControl.setValue(null);
     this.tipoControl.setValue(null);
+    this.monedaSelId = null;
+    this.saldoCards.forEach(c => c.seleccionada = false);
     this.pageIndex = 0;
     this.cargarMovimientos();
   }

--- a/src/app/modules/financiero/caja-virtual/caja-virtual.service.ts
+++ b/src/app/modules/financiero/caja-virtual/caja-virtual.service.ts
@@ -141,13 +141,14 @@ export class CajaVirtualService {
   }
 
   onGetMovimientosFilter(cajaVirtualId: number,
-                         filtros: { desde?: string; fin?: string; tipo?: CajaVirtualTipoMovimiento; soloActivos?: boolean },
+                         filtros: { desde?: string; fin?: string; tipo?: CajaVirtualTipoMovimiento; monedaId?: number; soloActivos?: boolean },
                          page = 0, size = 15): Observable<PageInfo<MovimientoCajaVirtual>> {
     return this.genericService.onCustomQuery(this.movimientosFilterGQL, {
       cajaVirtualId,
       desde: filtros.desde ?? null,
       fin: filtros.fin ?? null,
       tipo: filtros.tipo ?? null,
+      monedaId: filtros.monedaId ?? null,
       soloActivos: filtros.soloActivos ?? false,
       page, size
     });

--- a/src/app/modules/financiero/caja-virtual/conteo-caja-dialog/conteo-caja-dialog.component.html
+++ b/src/app/modules/financiero/caja-virtual/conteo-caja-dialog/conteo-caja-dialog.component.html
@@ -1,0 +1,66 @@
+<div class="conteo-dialog">
+
+  <div class="conteo-header" [style.border-left-color]="data.color || '#607d8b'">
+    <h2 mat-dialog-title>Conteo de efectivo</h2>
+    <div class="subtitulo">{{ data.moneda?.denominacion }} · {{ data.cajaVirtual?.nombre }}</div>
+  </div>
+
+  <mat-dialog-content class="conteo-content">
+
+    <div class="cargando" *ngIf="cargando">Cargando denominaciones...</div>
+
+    <div class="sin-billetes" *ngIf="!cargando && filas.length === 0">
+      Esta moneda no tiene denominaciones cargadas. Configurarlas en Monedas → Billetes.
+    </div>
+
+    <!-- Columnas de 10 denominaciones: la grilla crece a lo ancho, nunca a lo alto. -->
+    <div class="conteo-columnas" *ngIf="!cargando && filas.length > 0">
+      <div class="conteo-col" *ngFor="let col of columnas">
+        <div class="conteo-col-head">
+          <span class="col-valor">Denominación</span>
+          <span class="col-cantidad">Cantidad</span>
+        </div>
+        <div class="conteo-fila" *ngFor="let f of col" [class.cargada]="f.cantidad">
+          <span class="col-valor">{{ f.valor | number:formato }} {{ data.moneda?.simbolo }}</span>
+          <input type="number" min="0" step="1" class="cantidad-input"
+                 [value]="f.cantidad"
+                 (input)="onCantidadChange(f, $any($event.target).value)" />
+        </div>
+      </div>
+    </div>
+
+    <div class="resumen" *ngIf="!cargando">
+      <div class="resumen-row">
+        <span>Saldo del sistema</span>
+        <strong>{{ data.saldoSistema | number:formato }} {{ data.moneda?.simbolo }}</strong>
+      </div>
+      <div class="resumen-row total">
+        <span>Total contado</span>
+        <strong [style.color]="data.color || '#fff'">{{ total | number:formato }} {{ data.moneda?.simbolo }}</strong>
+      </div>
+      <div class="resumen-row">
+        <span>{{ diferenciaLabel }}</span>
+        <strong [style.color]="diferenciaColor">{{ diferencia | number:formato }} {{ data.moneda?.simbolo }}</strong>
+      </div>
+      <div class="guardado-hint" *ngIf="actualizadoEn">
+        Guardado localmente el {{ actualizadoEn | date:'dd/MM/yy HH:mm' }}
+      </div>
+    </div>
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="conteo-actions">
+    <button mat-button (click)="onCancelar()">Cancelar</button>
+    <span class="spacer"></span>
+    <button mat-stroked-button (click)="onLimpiar()" [disabled]="cargando || !total">
+      <mat-icon>backspace</mat-icon> Limpiar conteo
+    </button>
+    <button mat-stroked-button (click)="onCopiarTotal()" [disabled]="cargando">
+      <mat-icon>content_copy</mat-icon> Copiar valor total
+    </button>
+    <button mat-raised-button color="primary" (click)="onCrearAjuste()"
+            [disabled]="!hayDiferencia || !puedeGestionar || guardando"
+            [matTooltip]="!puedeGestionar ? 'Requiere rol TESORERIA GESTIONAR' : (!hayDiferencia ? 'No hay diferencia para ajustar' : '')">
+      <mat-icon>tune</mat-icon> Crear ajuste
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/modules/financiero/caja-virtual/conteo-caja-dialog/conteo-caja-dialog.component.scss
+++ b/src/app/modules/financiero/caja-virtual/conteo-caja-dialog/conteo-caja-dialog.component.scss
@@ -1,0 +1,136 @@
+.conteo-dialog {
+  display: flex;
+  flex-direction: column;
+}
+
+.conteo-header {
+  padding: 4px 0 10px 12px;
+  border-left: 4px solid #607d8b;
+
+  h2 {
+    color: #fff;
+    margin-bottom: 2px;
+  }
+
+  .subtitulo {
+    color: #ff9800;
+    font-size: 13px;
+  }
+}
+
+.conteo-content {
+  // Sin scroll propio: la grilla crece en columnas, no en alto.
+  overflow: visible;
+}
+
+.cargando,
+.sin-billetes {
+  opacity: 0.7;
+  padding: 24px 4px;
+  text-align: center;
+}
+
+/* Una columna por cada 10 denominaciones; el diálogo se ensancha en vez de scrollear. */
+.conteo-columnas {
+  display: flex;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.conteo-col {
+  flex: 0 0 auto;
+  min-width: 230px;
+}
+
+.conteo-col-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  opacity: 0.55;
+  padding: 0 2px 6px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.conteo-fila {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 3px 2px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+
+  .col-valor {
+    font-variant-numeric: tabular-nums;
+    opacity: 0.8;
+  }
+
+  &.cargada .col-valor {
+    opacity: 1;
+    font-weight: 500;
+  }
+}
+
+.cantidad-input {
+  width: 86px;
+  padding: 5px 8px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 15px;
+
+  &:focus {
+    outline: none;
+    border-color: #ff9800;
+  }
+
+  // El spinner nativo roba ancho y no aporta nada al conteo rápido.
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}
+
+.resumen {
+  margin-top: 18px;
+  padding: 12px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.05);
+
+  .resumen-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 32px;
+    padding: 4px 0;
+
+    span { opacity: 0.75; font-size: 13px; }
+
+    strong { font-variant-numeric: tabular-nums; }
+  }
+
+  .resumen-row.total strong {
+    font-size: 24px;
+    font-weight: 600;
+  }
+
+  .guardado-hint {
+    margin-top: 8px;
+    font-size: 11px;
+    opacity: 0.5;
+    text-align: right;
+  }
+}
+
+.conteo-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 12px;
+
+  .spacer { flex: 1; }
+}

--- a/src/app/modules/financiero/caja-virtual/conteo-caja-dialog/conteo-caja-dialog.component.ts
+++ b/src/app/modules/financiero/caja-virtual/conteo-caja-dialog/conteo-caja-dialog.component.ts
@@ -1,0 +1,268 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { CajaVirtual, CajaVirtualTipoMovimiento, MovimientoCajaVirtual } from '../caja-virtual.model';
+import { CajaVirtualService } from '../caja-virtual.service';
+import { Moneda } from '../../moneda/moneda.model';
+import { MonedaBillete } from '../../moneda/moneda-billetes/moneda-billetes.model';
+import { MonedaBilletesService } from '../../moneda/moneda-billetes/moneda-billetes.service';
+import { MainService } from '../../../../main.service';
+import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
+import { NotificacionSnackbarService, NotificacionColor } from '../../../../notificacion-snackbar.service';
+import { ROLES } from '../../../personas/roles/roles.enum';
+
+export interface ConteoCajaDialogData {
+  cajaVirtual: CajaVirtual;
+  moneda: Moneda;
+  /** Saldo que el sistema tiene registrado para (caja, moneda) — contra esto se calcula la diferencia. */
+  saldoSistema: number;
+  /** Color de la card que abrió el diálogo, para que el diálogo se lea como continuación de ella. */
+  color?: string;
+}
+
+/** Fila del conteo: una denominación con su cantidad. El subtotal alimenta el total del footer
+ *  (no se muestra por fila: la suma ya se ve abajo y una columna menos angosta la grilla). */
+interface FilaConteo {
+  valor: number;
+  cantidad: number;
+  subtotal: number;
+}
+
+/** Denominaciones por columna. Fijo, para que la altura no dependa de la moneda y el
+ *  resumen del footer nunca quede fuera de vista: si sobran, se abre otra columna. */
+const FILAS_POR_COLUMNA = 10;
+
+/** Lo que se guarda en localStorage. Se indexa por VALOR y no por id de billete:
+ *  el id puede cambiar si se recrea la denominación, el valor no. */
+interface ConteoGuardado {
+  cantidades: { [valor: string]: number };
+  actualizadoEn: string;
+}
+
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'app-conteo-caja-dialog',
+  templateUrl: './conteo-caja-dialog.component.html',
+  styleUrls: ['./conteo-caja-dialog.component.scss']
+})
+export class ConteoCajaDialogComponent implements OnInit {
+
+  filas: FilaConteo[] = [];
+  /** Las mismas filas repartidas en columnas de FILAS_POR_COLUMNA (lo que renderiza el HTML). */
+  columnas: FilaConteo[][] = [];
+  /** digitsInfo del pipe number para los valores de denominación. */
+  formato = '1.0-2';
+  total = 0;
+  diferencia = 0;
+  /** Etiqueta y color de la diferencia, precalculados (no se llaman funciones desde el HTML). */
+  diferenciaLabel = '';
+  diferenciaColor = '#b0bec5';
+  hayDiferencia = false;
+
+  /** Decimales de la moneda: define el redondeo de la diferencia y el formato mostrado. */
+  private decimales = 2;
+
+  cargando = true;
+  guardando = false;
+  puedeGestionar = false;
+  actualizadoEn: string = null;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: ConteoCajaDialogData,
+    private dialogRef: MatDialogRef<ConteoCajaDialogComponent>,
+    private monedaBilletesService: MonedaBilletesService,
+    private cajaVirtualService: CajaVirtualService,
+    private dialogosService: DialogosService,
+    private notificacion: NotificacionSnackbarService,
+    public mainService: MainService
+  ) {}
+
+  ngOnInit(): void {
+    this.puedeGestionar = this.mainService.tieneAlgunRol([ROLES.TESORERIA_GESTIONAR]);
+    const m = this.data.moneda;
+    this.decimales = m?.decimales != null
+      ? m.decimales
+      : ((m?.denominacion || '').toUpperCase().includes('GUARAN') ? 0 : 2);
+    this.formato = `1.0-${this.decimales}`;
+    this.cargarDenominaciones();
+  }
+
+  /** Clave de persistencia local: una por (caja, moneda). */
+  private get storageKey(): string {
+    return `frc.conteo-caja-virtual.${this.data.cajaVirtual?.id}.${this.data.moneda?.id}`;
+  }
+
+  private cargarDenominaciones() {
+    const monedaId = this.data.moneda?.id;
+    if (!monedaId) { this.cargando = false; return; }
+    this.monedaBilletesService.onGetByMonedaId(monedaId)
+      .pipe(untilDestroyed(this))
+      .subscribe((res: MonedaBillete[]) => {
+        this.cargando = false;
+        const guardado = this.leerGuardado();
+        const activos = (res || []).filter(b => b?.activo !== false && b?.valor != null);
+        // Mayor a menor: es el orden en que se cuenta plata en la mano.
+        activos.sort((a, b) => b.valor - a.valor);
+        this.filas = activos.map(b => {
+          const cantidad = guardado?.cantidades?.[String(b.valor)] || 0;
+          return { valor: b.valor, cantidad, subtotal: cantidad * b.valor };
+        });
+        this.repartirEnColumnas();
+        this.actualizadoEn = guardado?.actualizadoEn || null;
+        this.recalcular();
+      });
+  }
+
+  private repartirEnColumnas() {
+    this.columnas = [];
+    for (let i = 0; i < this.filas.length; i += FILAS_POR_COLUMNA) {
+      this.columnas.push(this.filas.slice(i, i + FILAS_POR_COLUMNA));
+    }
+  }
+
+  private leerGuardado(): ConteoGuardado {
+    try {
+      const raw = localStorage.getItem(this.storageKey);
+      return raw ? JSON.parse(raw) as ConteoGuardado : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Persiste el conteo en cada cambio: cerrar el diálogo (o la app) no debe perderlo. */
+  private guardarLocal() {
+    const cantidades: { [valor: string]: number } = {};
+    this.filas.forEach(f => { if (f.cantidad) cantidades[String(f.valor)] = f.cantidad; });
+    const payload: ConteoGuardado = { cantidades, actualizadoEn: new Date().toISOString() };
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(payload));
+      this.actualizadoEn = payload.actualizadoEn;
+    } catch {
+      // Cuota llena / modo privado: el conteo sigue usable en memoria, solo no sobrevive al cierre.
+    }
+  }
+
+  onCantidadChange(fila: FilaConteo, valor: any) {
+    const n = Number(valor);
+    fila.cantidad = isNaN(n) || n < 0 ? 0 : Math.floor(n);
+    fila.subtotal = fila.cantidad * fila.valor;
+    this.recalcular();
+    this.guardarLocal();
+  }
+
+  private recalcular() {
+    this.total = this.filas.reduce((acc, f) => acc + f.subtotal, 0);
+    const sistema = this.data.saldoSistema || 0;
+    // Redondear a los decimales de la moneda: restar dos doubles deja basura binaria
+    // (3339.78 - 3300 = 39.780000000000002) que terminaría posteada como cantidad del AJUSTE.
+    const f = Math.pow(10, this.decimales);
+    this.diferencia = Math.round((this.total - sistema) * f) / f;
+    this.hayDiferencia = Math.abs(this.diferencia) > 0.005;
+    if (!this.hayDiferencia) {
+      this.diferenciaLabel = 'Sin diferencia';
+      this.diferenciaColor = '#81c784';
+    } else if (this.diferencia > 0) {
+      this.diferenciaLabel = 'Sobrante';
+      this.diferenciaColor = '#64b5f6';
+    } else {
+      this.diferenciaLabel = 'Faltante';
+      this.diferenciaColor = '#ff8a80';
+    }
+  }
+
+  onLimpiar() {
+    this.dialogosService.confirm(
+      'Limpiar conteo', '¿Borrar todas las cantidades cargadas?', null, null, true, 'Sí, limpiar', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(res => {
+      if (res !== true) return;
+      this.filas.forEach(f => { f.cantidad = 0; f.subtotal = 0; });
+      this.recalcular();
+      this.guardarLocal();
+    });
+  }
+
+  onCopiarTotal() {
+    const texto = String(this.total);
+    const ok = (msg: string) => this.notificacion.notification$.next(
+      { texto: msg, color: NotificacionColor.success, duracion: 2 });
+    if (navigator?.clipboard?.writeText) {
+      navigator.clipboard.writeText(texto)
+        .then(() => ok('Total copiado'))
+        .catch(() => this.copiarFallback(texto));
+    } else {
+      this.copiarFallback(texto);
+    }
+  }
+
+  /** Electron viejo / contexto sin permiso de clipboard: input temporal + execCommand. */
+  private copiarFallback(texto: string) {
+    try {
+      const el = document.createElement('textarea');
+      el.value = texto;
+      el.style.position = 'fixed';
+      el.style.opacity = '0';
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+      this.notificacion.notification$.next({ texto: 'Total copiado', color: NotificacionColor.success, duracion: 2 });
+    } catch {
+      this.notificacion.notification$.next({ texto: 'No se pudo copiar', color: NotificacionColor.warn, duracion: 3 });
+    }
+  }
+
+  /**
+   * Postea un AJUSTE firmado por la diferencia, dejando el saldo del sistema igual al contado.
+   * El AJUSTE conserva el signo de la cantidad en TesoreriaService.signedDelta, así que la
+   * diferencia va tal cual (negativa si falta plata).
+   */
+  onCrearAjuste() {
+    if (!this.hayDiferencia || this.guardando) return;
+    const simbolo = this.data.moneda?.simbolo || '';
+    const signo = this.diferencia > 0 ? '+' : '';
+    this.dialogosService.confirm(
+      'Crear ajuste por conteo',
+      `Se registrará un AJUSTE de ${signo}${this.fmt(this.diferencia)} ${simbolo} para dejar el saldo del sistema igual al conteo.`,
+      `Sistema: ${this.fmt(this.data.saldoSistema)} ${simbolo} · Contado: ${this.fmt(this.total)} ${simbolo}`,
+      null, true, 'Sí, ajustar', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(res => {
+      if (res !== true) return;
+      this.guardando = true;
+      const mov = new MovimientoCajaVirtual();
+      mov.cajaVirtual = this.data.cajaVirtual;
+      mov.tipoMovimiento = CajaVirtualTipoMovimiento.AJUSTE;
+      mov.cantidad = this.diferencia;
+      mov.moneda = this.data.moneda;
+      mov.usuario = this.mainService.usuarioActual;
+      mov.activo = true;
+      mov.descripcion = `AJUSTE POR CONTEO DE CAJA (SISTEMA ${this.fmt(this.data.saldoSistema)} / CONTADO ${this.fmt(this.total)})`;
+      this.cajaVirtualService.onSaveMovimiento(mov)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: r => {
+            this.guardando = false;
+            if (r == null) return;
+            // El snackbar de éxito lo emite GenericCrudService.onSaveCustom; no duplicarlo acá.
+            this.dialogRef.close(true);
+          },
+          error: err => {
+            this.guardando = false;
+            const msg = err?.graphQLErrors?.[0]?.message || err?.message || 'No se pudo crear el ajuste';
+            this.notificacion.notification$.next({ texto: msg, color: NotificacionColor.warn, duracion: 5 });
+          }
+        });
+    });
+  }
+
+  /** Formato es-PY con los decimales de la moneda (el mensaje de confirmación no pasa por pipes). */
+  private fmt(n: number): string {
+    return (n || 0).toLocaleString('es-PY', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: this.decimales,
+    });
+  }
+
+  onCancelar() {
+    this.dialogRef.close(false);
+  }
+}

--- a/src/app/modules/financiero/caja-virtual/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/caja-virtual/graphql/graphql-query.ts
@@ -104,6 +104,7 @@ export const cajaVirtualSaldosQuery = gql`
         id
         denominacion
         simbolo
+        decimales
       }
     }
   }
@@ -119,7 +120,7 @@ export const cajaVirtualResumenBancarioQuery = gql`
         id
         numero
         banco { id nombre }
-        moneda { id denominacion simbolo }
+        moneda { id denominacion simbolo decimales }
       }
     }
   }
@@ -229,8 +230,8 @@ export const movimientosCajaVirtualPorFechaQuery = gql`
 `;
 
 export const movimientosCajaVirtualFilterQuery = gql`
-  query ($cajaVirtualId: ID!, $desde: String, $fin: String, $tipo: CajaVirtualTipoMovimiento, $soloActivos: Boolean, $page: Int, $size: Int) {
-    data: movimientosCajaVirtualFilter(cajaVirtualId: $cajaVirtualId, desde: $desde, fin: $fin, tipo: $tipo, soloActivos: $soloActivos, page: $page, size: $size) {
+  query ($cajaVirtualId: ID!, $desde: String, $fin: String, $tipo: CajaVirtualTipoMovimiento, $monedaId: ID, $soloActivos: Boolean, $page: Int, $size: Int) {
+    data: movimientosCajaVirtualFilter(cajaVirtualId: $cajaVirtualId, desde: $desde, fin: $fin, tipo: $tipo, monedaId: $monedaId, soloActivos: $soloActivos, page: $page, size: $size) {
       getTotalPages
       getTotalElements
       getNumberOfElements

--- a/src/app/modules/financiero/financiero.module.ts
+++ b/src/app/modules/financiero/financiero.module.ts
@@ -62,6 +62,7 @@ import { AddCajaVirtualDialogComponent } from './caja-virtual/add-caja-virtual-d
 import { AddMovimientoCajaVirtualDialogComponent } from './caja-virtual/add-movimiento-caja-virtual-dialog/add-movimiento-caja-virtual-dialog.component';
 import { TransferenciaCajaVirtualDialogComponent } from './caja-virtual/transferencia-caja-virtual-dialog/transferencia-caja-virtual-dialog.component';
 import { CajaVirtualDashboardComponent } from './caja-virtual/caja-virtual-dashboard/caja-virtual-dashboard.component';
+import { ConteoCajaDialogComponent } from './caja-virtual/conteo-caja-dialog/conteo-caja-dialog.component';
 import { ConfigurarCajaVirtualDialogComponent } from './caja-virtual/configurar-caja-virtual-dialog/configurar-caja-virtual-dialog.component';
 import { RegistrarIngresoDialogComponent } from './caja-virtual/registrar-ingreso-dialog/registrar-ingreso-dialog.component';
 import { IngresarRetiroCajaMayorDialogComponent } from './caja-virtual/ingresar-retiro-caja-mayor-dialog/ingresar-retiro-caja-mayor-dialog.component';
@@ -142,6 +143,7 @@ import { AddCuentaBancariaDialogComponent } from './cuenta-bancaria/add-cuenta-b
     AddMovimientoCajaVirtualDialogComponent,
     TransferenciaCajaVirtualDialogComponent,
     CajaVirtualDashboardComponent,
+    ConteoCajaDialogComponent,
     ConfigurarCajaVirtualDialogComponent,
     RegistrarIngresoDialogComponent,
     IngresarRetiroCajaMayorDialogComponent,

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -430,6 +430,18 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
           visibilityRoles: [ROLES.TESORERIA_VER, ROLES.TESORERIA_GESTIONAR, ROLES.ANALISIS_DE_CAJA, ROLES.ADMIN],
           items: [
             {
+              name: 'Tesorería',
+              icon: 'account_balance_wallet',
+              action: 'list-caja-virtual',
+              visibilityRoles: [ROLES.TESORERIA_VER, ROLES.TESORERIA_GESTIONAR, ROLES.ADMIN]
+            },
+            {
+              name: 'Operaciones Financieras',
+              icon: 'swap_horiz',
+              action: 'list-operacion-financiera',
+              visibilityRoles: [ROLES.TESORERIA_VER, ROLES.TESORERIA_GESTIONAR, ROLES.ADMIN]
+            },
+            {
               name: 'Gastos',
               icon: 'money_off',
               action: 'gastos-dashboard',


### PR DESCRIPTION
## Qué resuelve

Pedido de la gente de tesorería: que los saldos de caja se vean como cards sobre la tabla de movimientos y no en la columna de la derecha, con el saldo en grande, filtrando por moneda al hacer click, y con acceso a un conteo de efectivo por moneda.

### Cards de saldo

Los saldos de efectivo salen del sidebar y pasan a ser cards sobre la tabla, una por moneda, con franja de color estable (indexada por `moneda.id`) para identificarla sin leer el texto. Click filtra la tabla por esa moneda, volver a clickear lo quita, y "Limpiar" también lo resetea. Se ocultan cuando la fuente seleccionada es un banco.

El sidebar queda con cuentas bancarias, CPP y CPC; como sobra lugar, el saldo actual de cada cuenta pasa a 24px y reservado/futuro quedan como notas al pie.

### Conteo de efectivo (`conteo-caja-dialog`)

Diálogo nuevo, uno por moneda, abierto desde el ícono de la card.

- Denominaciones de mayor a menor en **columnas de 10** que crecen a lo ancho, así el resumen (saldo del sistema / total contado / diferencia) **nunca queda fuera de vista**. Sin subtotal por fila: la suma ya se ve abajo.
- **El conteo se persiste en `localStorage`** por `(caja, moneda)` e indexado por **valor** de billete y no por id — el id cambia si se recrea la denominación, el valor no. Sobrevive a cerrar el diálogo, que es el punto: un arqueo se interrumpe.
- Footer: Cancelar · Limpiar conteo · Copiar valor total · Crear ajuste.
- **Crear ajuste** postea un `AJUSTE` firmado por la diferencia `contado − sistema`, que deja el saldo del sistema igual a lo contado. Requiere `TESORERIA GESTIONAR` y se deshabilita si no hay diferencia.

### Entradas de menú faltantes

El módulo de Tesorería **era inalcanzable desde el sidebar**. De las tres ediciones que pide agregar una entrada, faltaba la del medio: el `import` estaba (`:78`) y el `case "list-caja-virtual"` también (`:936`), pero ningún ítem del árbol tenía esa `action`. Se llegaba a las cajas virtuales solo abriendo el tab por consola. `list-operacion-financiera` estaba igual (ese sí era alcanzable por el botón del dashboard, pero no desde el menú).

## Cómo probarlo

1. Financiero → Caja y Operativa → **Tesorería** (antes no existía esta entrada) → abrir una caja con saldo en más de una moneda.
2. Click en una card → la tabla queda solo con movimientos de esa moneda; click de nuevo → sin filtro.
3. Ícono de conteo en la card → cargar cantidades → **cerrar con Cancelar y reabrir**: las cantidades tienen que seguir ahí.
4. "Copiar valor total" → el total al portapapeles.
5. "Crear ajuste" con diferencia → confirma, postea el `AJUSTE`, y al reabrir el conteo la diferencia queda en cero y el botón deshabilitado.

Probado punta a punta contra un central local, incluido el ajuste posteado.

## Impacto en DB

Ninguno de este lado. **Depende del PR de central** `GabFrank/franco-system-backend-servidor#237`, que agrega el argumento `monedaId` a `movimientosCajaVirtualFilter` y trae una migración que puebla `moneda.decimales`. **Mergear ese primero**: sin él, el filtro por moneda tira error de GraphQL por argumento desconocido.

## Impacto en auto-update

Ninguno. No toca `installer.nsh`, `electron-builder.json` ni manifests.

## Riesgo

**Medio-bajo.** El grueso es UI del dashboard de caja virtual. Los dos puntos a mirar en la review:

- **`Crear ajuste` mueve plata de verdad** — postea un movimiento en la caja mayor. Está detrás de confirmación y del rol `TESORERIA GESTIONAR`.
- La diferencia se **redondea a los decimales de la moneda** antes de postearse. Sin eso, restar dos doubles deja basura binaria (`3339.78 - 3300 = 39.780000000000002`) que terminaba guardada como la cantidad del movimiento. Se detectó probando y está corregido.

`npm run check` (AOT) en verde.
