### PR TITLE
feat(rrhh): revertir egreso y gate de confirmacion por nombre

### DIFF
--- a/src/app/modules/personas/funcionarios/funcionario.model.ts
+++ b/src/app/modules/personas/funcionarios/funcionario.model.ts
@@ -23,6 +23,10 @@ export class Funcionario {
   nickname: string;
   imagenPrincipal: string;
   horario: Horario;
+  // El egreso se escribia en la base pero no existia de este lado: por eso el legajo
+  // mostraba solo el badge INACTIVO, sin cuando ni por que.
+  fechaEgreso: Date;
+  motivoEgreso: string;
   // Campos agregados para InformacionGeneralComponent (legajo, tab "Información general").
   codigoInterno: string;
   ipsActivo: boolean;

--- a/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
+++ b/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
@@ -146,6 +146,8 @@ export const funcionarioQuery = gql`
       diarista
       sueldo
       fechaIngreso
+      fechaEgreso
+      motivoEgreso
       creadoEn
       fasePrueba
       activo

--- a/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.html
+++ b/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.html
@@ -2,6 +2,13 @@
   <h2 mat-dialog-title>Egresar funcionario</h2>
   <p class="aviso">Se marcará al funcionario <b>{{ data.nombre }}</b> como inactivo con la fecha y motivo indicados.</p>
 
+  <!-- Egresar hace más de lo que su nombre sugiere, y desde acá no se deshace. -->
+  <div class="consecuencias">
+    Además se le <b>quita el acceso al sistema</b>, se le pone el <b>crédito en cero</b> y su cliente
+    vuelve a <b>NORMAL</b>, también sin crédito. El crédito no queda guardado en ningún lado:
+    para restaurarlo hay que volver a cargarlo a mano.
+  </div>
+
   <mat-form-field style="width: 100%">
     <mat-label>Fecha de egreso</mat-label>
     <input matInput [matDatepicker]="picker" [formControl]="fechaControl" />
@@ -15,8 +22,21 @@
     <mat-error *ngIf="motivoControl.hasError('required')">Ingrese el motivo</mat-error>
   </mat-form-field>
 
+  <!-- Gate: escribir el nombre completo para habilitar el egreso. -->
+  <div class="gate" *ngIf="hayGate" fxLayout="column" fxLayoutGap="4px">
+    <span class="gate-instruccion">
+      Para confirmar, escribí el nombre completo del funcionario:
+    </span>
+    <span class="gate-nombre">{{ nombreEsperado }}</span>
+    <mat-form-field style="width: 100%">
+      <mat-label>Nombre completo</mat-label>
+      <input matInput [formControl]="confirmacionControl" autocomplete="off" />
+      <mat-icon matSuffix class="gate-ok" *ngIf="puedeEgresar">check_circle</mat-icon>
+    </mat-form-field>
+  </div>
+
   <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
     <button mat-stroked-button (click)="onCancelar()">Cancelar</button>
-    <button mat-raised-button color="warn" (click)="onEgresar()">Egresar</button>
+    <button mat-raised-button color="warn" [disabled]="!puedeEgresar" (click)="onEgresar()">Egresar</button>
   </div>
 </div>

--- a/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.scss
+++ b/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.scss
@@ -1,5 +1,25 @@
 .dialog-container {
-  min-width: 400px;
+  min-width: 440px;
   padding: 8px;
   .aviso { font-size: 13px; opacity: 0.85; }
+
+  .consecuencias {
+    font-size: 13px;
+    line-height: 1.45;
+    color: #ffb74d;
+    padding: 8px 10px;
+    border-left: 3px solid #ffb74d;
+  }
+
+  .gate {
+    .gate-instruccion { font-size: 12px; opacity: 0.75; }
+    .gate-nombre {
+      font-family: monospace;
+      font-size: 14px;
+      letter-spacing: 0.4px;
+      user-select: all;
+      padding: 4px 0;
+    }
+    .gate-ok { color: #66bb6a; }
+  }
 }

--- a/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.ts
+++ b/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.ts
@@ -19,16 +19,63 @@ export class EgresarFuncionarioDialogComponent {
   fechaControl = new FormControl(new Date());
   motivoControl = new FormControl(null, Validators.required);
 
+  /**
+   * Gate de confirmacion: hay que escribir el nombre completo del funcionario para
+   * habilitar el boton, como al borrar un repositorio.
+   *
+   * Egresar no es reversible desde la pantalla que lo dispara y hace mas dano del que
+   * anuncia: apaga el login, borra el credito del funcionario y el del cliente, y
+   * devuelve al cliente a NORMAL. Un click de mas en la fila equivocada le saca el
+   * acceso y el credito a alguien que sigue trabajando.
+   */
+  confirmacionControl = new FormControl('');
+  /** Nombre a escribir, ya normalizado en espacios, para mostrarlo en el dialogo. */
+  nombreEsperado = '';
+  /** Precalculado: el repo no llama funciones desde el HTML. */
+  puedeEgresar = false;
+  /** Si el funcionario no tiene nombre no hay nada que escribir; no se puede pedir el gate. */
+  hayGate = false;
+
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: EgresarFuncionarioDialogData,
     private dialogRef: MatDialogRef<EgresarFuncionarioDialogComponent>,
     private legajoService: LegajoService,
     private notificacion: NotificacionSnackbarService
-  ) { }
+  ) {
+    this.nombreEsperado = (this.data?.nombre || '').trim().replace(/\s+/g, ' ');
+    this.hayGate = this.nombreEsperado.length > 0;
+    this.puedeEgresar = !this.hayGate;
+    this.confirmacionControl.valueChanges.pipe(untilDestroyed(this)).subscribe(v => {
+      this.puedeEgresar = !this.hayGate
+        || this.normalizar(v) === this.normalizar(this.nombreEsperado);
+    });
+  }
+
+  /**
+   * Compara sin acentos, sin mayusculas y con los espacios colapsados.
+   *
+   * El objetivo del gate es obligar a mirar a quien se esta egresando, no a pelear con
+   * el teclado: varios nombres del padron tienen tildes y espacios de sobra al final
+   * (ej. "WILIAN ISMAEL MARTINEZ BENITEZ "). Aflojar eso no permite confundir a dos
+   * personas distintas.
+   */
+  private normalizar(v: string): string {
+    return (v || '')
+      .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+      .trim().replace(/\s+/g, ' ')
+      .toUpperCase();
+  }
 
   onEgresar() {
     if (this.motivoControl.invalid) {
       this.notificacion.notification$.next({ texto: 'Ingrese el motivo del egreso', color: NotificacionColor.warn, duracion: 3 });
+      return;
+    }
+    if (!this.puedeEgresar) {
+      this.notificacion.notification$.next({
+        texto: 'Escribí el nombre completo del funcionario para confirmar el egreso',
+        color: NotificacionColor.warn, duracion: 4
+      });
       return;
     }
     const motivo = this.motivoControl.value ? this.motivoControl.value.toUpperCase() : null;

--- a/src/app/modules/rrhh/legajo/graphql/EgresoVigente.ts
+++ b/src/app/modules/rrhh/legajo/graphql/EgresoVigente.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { egresoVigenteQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class EgresoVigenteGQL extends Query<Response> { document = egresoVigenteQuery; }

--- a/src/app/modules/rrhh/legajo/graphql/RevertirEgresoFuncionario.ts
+++ b/src/app/modules/rrhh/legajo/graphql/RevertirEgresoFuncionario.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { revertirEgresoFuncionarioMutation } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class RevertirEgresoFuncionarioGQL extends Mutation<Response> { document = revertirEgresoFuncionarioMutation; }

--- a/src/app/modules/rrhh/legajo/graphql/graphql-query.ts
+++ b/src/app/modules/rrhh/legajo/graphql/graphql-query.ts
@@ -4,7 +4,7 @@ const FUNC = `funcionario { id persona { id nombre } }`;
 const CARGO_HIST = `id ${FUNC} cargo { id nombre } fechaDesde fechaHasta motivo autorizadoPor { id } creadoEn`;
 const SALARIO_HIST = `id ${FUNC} salarioAnterior salarioNuevo moneda { id denominacion } fechaVigencia motivo autorizadoPor { id } creadoEn`;
 const DOC = `id ${FUNC} tipo nombreArchivo rutaRelativa mimeType tamanoBytes fechaSubida vencimiento observacion anulado creadoEn`;
-const FUNC_FULL = `id activo sueldo fechaEgreso motivoEgreso cargo { id nombre } persona { id nombre } moneda { id denominacion }`;
+const FUNC_FULL = `id activo sueldo credito fechaEgreso motivoEgreso cargo { id nombre } persona { id nombre } moneda { id denominacion }`;
 
 export const cargoHistoricosQuery = gql`
   query ($funcionarioId: ID!) { data: funcionarioCargoHistoricos(funcionarioId: $funcionarioId) { ${CARGO_HIST} } }
@@ -31,6 +31,11 @@ export const cambiarSalarioMutation = gql`
 export const egresarFuncionarioMutation = gql`
   mutation egresarFuncionario($funcionarioId: ID!, $fecha: String, $motivo: String) {
     data: egresarFuncionario(funcionarioId: $funcionarioId, fecha: $fecha, motivo: $motivo) { ${FUNC_FULL} }
+  }
+`;
+export const revertirEgresoFuncionarioMutation = gql`
+  mutation revertirEgresoFuncionario($funcionarioId: ID!, $credito: Float, $motivo: String) {
+    data: revertirEgresoFuncionario(funcionarioId: $funcionarioId, credito: $credito, motivo: $motivo) { ${FUNC_FULL} }
   }
 `;
 export const saveDocumentoMutation = gql`

--- a/src/app/modules/rrhh/legajo/graphql/graphql-query.ts
+++ b/src/app/modules/rrhh/legajo/graphql/graphql-query.ts
@@ -33,6 +33,10 @@ export const egresarFuncionarioMutation = gql`
     data: egresarFuncionario(funcionarioId: $funcionarioId, fecha: $fecha, motivo: $motivo) { ${FUNC_FULL} }
   }
 `;
+const EGRESO_SNAP = `id fechaEgreso motivoEgreso creditoAnterior clienteTipoAnterior clienteCreditoAnterior egresadoPor { id nickname }`;
+export const egresoVigenteQuery = gql`
+  query ($funcionarioId: ID!) { data: egresoVigenteFuncionario(funcionarioId: $funcionarioId) { ${EGRESO_SNAP} } }
+`;
 export const revertirEgresoFuncionarioMutation = gql`
   mutation revertirEgresoFuncionario($funcionarioId: ID!, $credito: Float, $motivo: String) {
     data: revertirEgresoFuncionario(funcionarioId: $funcionarioId, credito: $credito, motivo: $motivo) { ${FUNC_FULL} }

--- a/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.html
+++ b/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.html
@@ -15,6 +15,10 @@
           <span class="badge" [ngClass]="funcionario.activo ? 'activo' : 'inactivo'">
             {{ funcionario.activo ? 'ACTIVO' : 'INACTIVO' }}
           </span>
+          <!-- El egreso quedaba solo en la base: la pantalla no mostraba ni cuando ni por que. -->
+          <span class="egreso-info" *ngIf="!funcionario.activo && funcionario.fechaEgreso">
+            Egresado el {{ funcionario.fechaEgreso | date:'dd/MM/yyyy' }}<span *ngIf="funcionario.motivoEgreso"> — {{ funcionario.motivoEgreso }}</span>
+          </span>
         </div>
         <div class="basicos" fxLayout="row wrap" fxLayoutGap="18px">
           <span>Cargo: <b>{{ funcionario.cargo?.nombre || '—' }}</b></span>
@@ -43,6 +47,7 @@
       <dash-quick-action *ngIf="puedeCambiarSalario" icon="payments" title="Cambiar salario" color="#66bb6a" (action)="onCambiarSalario()"></dash-quick-action>
       <dash-quick-action icon="upload_file" title="Subir documento" color="#7e57c2" (action)="onSubirDocumento()"></dash-quick-action>
       <dash-quick-action *ngIf="funcionario.activo && puedeEgresar" icon="logout" title="Egresar" color="#ef5350" (action)="onEgresar()"></dash-quick-action>
+      <dash-quick-action *ngIf="!funcionario.activo && puedeEgresar" icon="undo" title="Revertir egreso" color="#26a69a" (action)="onRevertirEgreso()"></dash-quick-action>
       <dash-quick-action *ngIf="puedeLiquidar" icon="receipt_long" title="Liquidación final" color="#ffa726" (action)="onLiquidacionFinal()"></dash-quick-action>
     </div>
 

--- a/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.scss
+++ b/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.scss
@@ -37,6 +37,13 @@
       &.activo { background: rgba(102, 187, 106, 0.18); color: #66bb6a; }
       &.inactivo { background: rgba(239, 83, 80, 0.18); color: #ef5350; }
     }
+
+    .egreso-info {
+      display: inline-block;
+      margin-left: 10px;
+      font-size: 12px;
+      opacity: 0.75;
+    }
   }
 
   // stat-chip clickeable

--- a/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.ts
+++ b/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.ts
@@ -193,13 +193,21 @@ export class LegajoFuncionarioComponent implements OnInit {
    * alguien es quien puede volver a meterlo.
    */
   onRevertirEgreso() {
+    // El snapshot se pide ANTES de abrir: si existe, el diálogo precarga el crédito en
+    // vez de pedirlo. Un egreso anterior al histórico devuelve null y se carga a mano.
+    this.legajoService.onGetEgresoVigente(this.funcionario.id)
+      .pipe(untilDestroyed(this)).subscribe(snap => this.abrirReversa(snap));
+  }
+
+  private abrirReversa(snap: any) {
     this.dialog.open(RevertirEgresoDialogComponent, {
       data: {
         funcionarioId: this.funcionario.id,
         nombre: this.funcionario.persona?.nombre,
         fechaEgreso: this.funcionario.fechaEgreso,
         motivoEgreso: this.funcionario.motivoEgreso,
-        creditoActual: this.funcionario.credito
+        creditoActual: this.funcionario.credito,
+        snapshot: snap || null
       }, width: '480px', disableClose: true
     }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => {
       if (res != null) {

--- a/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.ts
+++ b/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.ts
@@ -14,6 +14,7 @@ import { FuncionarioCargoHistorico, FuncionarioSalarioHistorico, FuncionarioDocu
 import { CambioCargoDialogComponent } from '../cambio-cargo-dialog/cambio-cargo-dialog.component';
 import { CambioSalarioDialogComponent } from '../cambio-salario-dialog/cambio-salario-dialog.component';
 import { EgresarFuncionarioDialogComponent } from '../egresar-funcionario-dialog/egresar-funcionario-dialog.component';
+import { RevertirEgresoDialogComponent } from '../revertir-egreso-dialog/revertir-egreso-dialog.component';
 import { SubirDocumentoDialogComponent } from '../subir-documento-dialog/subir-documento-dialog.component';
 import { LiquidacionFinalDialogComponent } from '../../liquidacion-final/liquidacion-final-dialog/liquidacion-final-dialog.component';
 import { LiquidacionFinalGenerarDialogComponent } from '../../liquidacion-final/liquidacion-final-generar-dialog/liquidacion-final-generar-dialog.component';
@@ -183,6 +184,31 @@ export class LegajoFuncionarioComponent implements OnInit {
       if (res != null) {
         this.funcionario = res;
         this.notificacion.notification$.next({ texto: 'Funcionario egresado', color: NotificacionColor.success, duracion: 3 });
+      }
+    });
+  }
+
+  /**
+   * Deshace un egreso hecho por error. Mismo gating que egresar: quien puede sacar a
+   * alguien es quien puede volver a meterlo.
+   */
+  onRevertirEgreso() {
+    this.dialog.open(RevertirEgresoDialogComponent, {
+      data: {
+        funcionarioId: this.funcionario.id,
+        nombre: this.funcionario.persona?.nombre,
+        fechaEgreso: this.funcionario.fechaEgreso,
+        motivoEgreso: this.funcionario.motivoEgreso,
+        creditoActual: this.funcionario.credito
+      }, width: '480px', disableClose: true
+    }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => {
+      if (res != null) {
+        this.funcionario = res;
+        this.notificacion.notification$.next({
+          texto: 'Egreso revertido: el funcionario, su usuario y su cliente vuelven a estar activos',
+          color: NotificacionColor.success, duracion: 4
+        });
+        this.recargar();
       }
     });
   }

--- a/src/app/modules/rrhh/legajo/legajo.service.ts
+++ b/src/app/modules/rrhh/legajo/legajo.service.ts
@@ -8,6 +8,7 @@ import { DocumentoContenidoGQL } from './graphql/DocumentoContenido';
 import { CambiarCargoGQL } from './graphql/CambiarCargo';
 import { CambiarSalarioGQL } from './graphql/CambiarSalario';
 import { EgresarFuncionarioGQL } from './graphql/EgresarFuncionario';
+import { RevertirEgresoFuncionarioGQL } from './graphql/RevertirEgresoFuncionario';
 import { SaveDocumentoGQL } from './graphql/SaveDocumento';
 import { AnularDocumentoGQL } from './graphql/AnularDocumento';
 
@@ -23,6 +24,7 @@ export class LegajoService {
     private cambiarCargoGQL: CambiarCargoGQL,
     private cambiarSalarioGQL: CambiarSalarioGQL,
     private egresarFuncionarioGQL: EgresarFuncionarioGQL,
+    private revertirEgresoFuncionarioGQL: RevertirEgresoFuncionarioGQL,
     private saveDocumentoGQL: SaveDocumentoGQL,
     private anularDocumentoGQL: AnularDocumentoGQL
   ) { }
@@ -53,6 +55,14 @@ export class LegajoService {
 
   onEgresar(funcionarioId: number, fecha: string, motivo: string, servidor = true): Observable<any> {
     return this.genericService.onSaveCustom<any>(this.egresarFuncionarioGQL, { funcionarioId, fecha, motivo }, servidor);
+  }
+
+  /**
+   * Revierte un egreso. El credito viaja como parametro porque el egreso lo pone en cero
+   * y no queda guardado en ninguna tabla: sin el valor, el backend no puede recuperarlo.
+   */
+  onRevertirEgreso(funcionarioId: number, credito: number, motivo: string, servidor = true): Observable<any> {
+    return this.genericService.onSaveCustom<any>(this.revertirEgresoFuncionarioGQL, { funcionarioId, credito, motivo }, servidor);
   }
 
   onSaveDocumento(input: any, servidor = true): Observable<any> {

--- a/src/app/modules/rrhh/legajo/legajo.service.ts
+++ b/src/app/modules/rrhh/legajo/legajo.service.ts
@@ -9,6 +9,7 @@ import { CambiarCargoGQL } from './graphql/CambiarCargo';
 import { CambiarSalarioGQL } from './graphql/CambiarSalario';
 import { EgresarFuncionarioGQL } from './graphql/EgresarFuncionario';
 import { RevertirEgresoFuncionarioGQL } from './graphql/RevertirEgresoFuncionario';
+import { EgresoVigenteGQL } from './graphql/EgresoVigente';
 import { SaveDocumentoGQL } from './graphql/SaveDocumento';
 import { AnularDocumentoGQL } from './graphql/AnularDocumento';
 
@@ -25,6 +26,7 @@ export class LegajoService {
     private cambiarSalarioGQL: CambiarSalarioGQL,
     private egresarFuncionarioGQL: EgresarFuncionarioGQL,
     private revertirEgresoFuncionarioGQL: RevertirEgresoFuncionarioGQL,
+    private egresoVigenteGQL: EgresoVigenteGQL,
     private saveDocumentoGQL: SaveDocumentoGQL,
     private anularDocumentoGQL: AnularDocumentoGQL
   ) { }
@@ -55,6 +57,14 @@ export class LegajoService {
 
   onEgresar(funcionarioId: number, fecha: string, motivo: string, servidor = true): Observable<any> {
     return this.genericService.onSaveCustom<any>(this.egresarFuncionarioGQL, { funcionarioId, fecha, motivo }, servidor);
+  }
+
+  /**
+   * Snapshot del egreso vigente, para precargar el credito en la reversa. Devuelve null
+   * si el egreso es anterior al historico: ahi hay que cargarlo a mano.
+   */
+  onGetEgresoVigente(funcionarioId: number, servidor = true): Observable<any> {
+    return this.genericService.onCustomQuery(this.egresoVigenteGQL, { funcionarioId }, servidor);
   }
 
   /**

--- a/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.html
+++ b/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.html
@@ -10,15 +10,22 @@
     <div *ngIf="data.motivoEgreso"><span class="etiqueta">Motivo:</span> {{ data.motivoEgreso }}</div>
   </div>
 
-  <p class="alerta">
-    El egreso puso el crédito en <b>{{ creditoActualTexto }}</b> y ese valor no se guarda en
-    ningún lado: hay que volver a cargarlo a mano.
+  <!-- Con snapshot la reversa restaura; sin él hay que reconstruir el crédito a mano. -->
+  <p class="ok" *ngIf="haySnapshot">
+    El egreso guardó lo que borró, así que el crédito ya viene cargado.
+    <span *ngIf="tipoClienteAnterior">Su cliente vuelve a <b>{{ tipoClienteAnterior }}</b>.</span>
+    <span *ngIf="egresadoPorTexto"> Lo egresó <b>{{ egresadoPorTexto }}</b>.</span>
+  </p>
+  <p class="alerta" *ngIf="!haySnapshot">
+    Este egreso es anterior al histórico, así que no hay nada guardado: el crédito quedó en
+    <b>{{ creditoActualTexto }}</b> y hay que volver a cargarlo a mano.
   </p>
 
   <mat-form-field style="width: 100%">
     <mat-label>Crédito a restaurar</mat-label>
     <input matInput type="number" [formControl]="creditoControl" required />
-    <mat-hint>Si no corresponde restaurar crédito, dejar en 0.</mat-hint>
+    <mat-hint *ngIf="haySnapshot">Es el valor que tenía antes del egreso. Se puede cambiar.</mat-hint>
+    <mat-hint *ngIf="!haySnapshot">Si no corresponde restaurar crédito, dejar en 0.</mat-hint>
     <mat-error *ngIf="creditoControl.hasError('required')">Indique el crédito</mat-error>
     <mat-error *ngIf="creditoControl.hasError('min')">No puede ser negativo</mat-error>
   </mat-form-field>

--- a/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.html
+++ b/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.html
@@ -1,0 +1,36 @@
+<div class="dialog-container" fxLayout="column" fxLayoutGap="12px">
+  <h2 mat-dialog-title>Revertir egreso</h2>
+  <p class="aviso">
+    Se reactivará a <b>{{ data.nombre }}</b>, junto con su usuario y su cliente, y se le
+    limpiará la fecha y el motivo de egreso.
+  </p>
+
+  <div class="egreso-actual" *ngIf="data.fechaEgreso || data.motivoEgreso">
+    <div><span class="etiqueta">Egresado el:</span> {{ data.fechaEgreso | date:'dd/MM/yyyy' }}</div>
+    <div *ngIf="data.motivoEgreso"><span class="etiqueta">Motivo:</span> {{ data.motivoEgreso }}</div>
+  </div>
+
+  <p class="alerta">
+    El egreso puso el crédito en <b>{{ creditoActualTexto }}</b> y ese valor no se guarda en
+    ningún lado: hay que volver a cargarlo a mano.
+  </p>
+
+  <mat-form-field style="width: 100%">
+    <mat-label>Crédito a restaurar</mat-label>
+    <input matInput type="number" [formControl]="creditoControl" required />
+    <mat-hint>Si no corresponde restaurar crédito, dejar en 0.</mat-hint>
+    <mat-error *ngIf="creditoControl.hasError('required')">Indique el crédito</mat-error>
+    <mat-error *ngIf="creditoControl.hasError('min')">No puede ser negativo</mat-error>
+  </mat-form-field>
+
+  <mat-form-field style="width: 100%">
+    <mat-label>Motivo de la reversión</mat-label>
+    <input matInput [formControl]="motivoControl" required />
+    <mat-error *ngIf="motivoControl.hasError('required')">Ingrese el motivo</mat-error>
+  </mat-form-field>
+
+  <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
+    <button mat-stroked-button (click)="onCancelar()">Cancelar</button>
+    <button mat-raised-button color="primary" (click)="onRevertir()">Revertir egreso</button>
+  </div>
+</div>

--- a/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.scss
+++ b/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.scss
@@ -9,4 +9,5 @@
     .etiqueta { opacity: 0.7; }
   }
   .alerta { font-size: 13px; color: #ffb74d; }
+  .ok { font-size: 13px; color: #66bb6a; }
 }

--- a/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.scss
+++ b/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.scss
@@ -1,0 +1,12 @@
+.dialog-container {
+  min-width: 420px;
+  padding: 8px;
+  .aviso { font-size: 13px; opacity: 0.85; }
+  .egreso-actual {
+    font-size: 13px;
+    padding: 8px 10px;
+    border-left: 3px solid rgba(255, 255, 255, 0.25);
+    .etiqueta { opacity: 0.7; }
+  }
+  .alerta { font-size: 13px; color: #ffb74d; }
+}

--- a/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.ts
+++ b/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.ts
@@ -11,6 +11,8 @@ export interface RevertirEgresoDialogData {
   fechaEgreso?: any;
   motivoEgreso?: string;
   creditoActual?: number;
+  /** Snapshot que dejó el egreso, o null si es anterior al histórico. */
+  snapshot?: any;
 }
 
 /**
@@ -31,8 +33,12 @@ export class RevertirEgresoDialogComponent {
   creditoControl = new FormControl(0, [Validators.required, Validators.min(0)]);
   motivoControl = new FormControl(null, Validators.required);
 
-  /** Precalculado: el repo no llama funciones desde el HTML. */
+  /** Precalculados: el repo no llama funciones desde el HTML. */
   creditoActualTexto = '';
+  /** true cuando el egreso dejó snapshot: el crédito viene cargado y no hay que buscarlo. */
+  haySnapshot = false;
+  tipoClienteAnterior = '';
+  egresadoPorTexto = '';
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: RevertirEgresoDialogData,
@@ -41,6 +47,16 @@ export class RevertirEgresoDialogComponent {
     private notificacion: NotificacionSnackbarService
   ) {
     this.creditoActualTexto = (this.data?.creditoActual ?? 0).toLocaleString('es-PY');
+
+    const snap = this.data?.snapshot;
+    this.haySnapshot = snap != null;
+    if (this.haySnapshot) {
+      // El egreso guardó lo que destruyó: se precarga y queda editable, porque entre el
+      // egreso y la reversa el negocio pudo cambiar.
+      this.creditoControl.setValue(snap.creditoAnterior ?? 0);
+      this.tipoClienteAnterior = snap.clienteTipoAnterior || '';
+      this.egresadoPorTexto = snap.egresadoPor?.nickname || '';
+    }
   }
 
   onRevertir() {

--- a/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.ts
+++ b/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.ts
@@ -1,0 +1,66 @@
+import { Component, Inject } from '@angular/core';
+import { FormControl, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { NotificacionSnackbarService, NotificacionColor } from '../../../../notificacion-snackbar.service';
+import { LegajoService } from '../legajo.service';
+
+export interface RevertirEgresoDialogData {
+  funcionarioId: number;
+  nombre?: string;
+  fechaEgreso?: any;
+  motivoEgreso?: string;
+  creditoActual?: number;
+}
+
+/**
+ * Deshace un egreso hecho por error.
+ *
+ * Pide el crédito porque el egreso lo pone en cero y no queda guardado en ninguna tabla:
+ * el backend no puede recuperarlo solo. Por eso el diálogo muestra el valor actual (que
+ * después de un egreso es 0) y avisa de dónde sacar el anterior.
+ */
+@UntilDestroy()
+@Component({
+  selector: 'app-revertir-egreso-dialog',
+  templateUrl: './revertir-egreso-dialog.component.html',
+  styleUrls: ['./revertir-egreso-dialog.component.scss']
+})
+export class RevertirEgresoDialogComponent {
+
+  creditoControl = new FormControl(0, [Validators.required, Validators.min(0)]);
+  motivoControl = new FormControl(null, Validators.required);
+
+  /** Precalculado: el repo no llama funciones desde el HTML. */
+  creditoActualTexto = '';
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: RevertirEgresoDialogData,
+    private dialogRef: MatDialogRef<RevertirEgresoDialogComponent>,
+    private legajoService: LegajoService,
+    private notificacion: NotificacionSnackbarService
+  ) {
+    this.creditoActualTexto = (this.data?.creditoActual ?? 0).toLocaleString('es-PY');
+  }
+
+  onRevertir() {
+    if (this.motivoControl.invalid) {
+      this.notificacion.notification$.next({
+        texto: 'Ingrese el motivo de la reversión', color: NotificacionColor.warn, duracion: 3
+      });
+      return;
+    }
+    if (this.creditoControl.invalid) {
+      this.notificacion.notification$.next({
+        texto: 'El crédito a restaurar no puede quedar vacío ni ser negativo',
+        color: NotificacionColor.warn, duracion: 4
+      });
+      return;
+    }
+    const motivo = this.motivoControl.value ? this.motivoControl.value.toUpperCase() : null;
+    this.legajoService.onRevertirEgreso(this.data.funcionarioId, this.creditoControl.value, motivo)
+      .pipe(untilDestroyed(this)).subscribe(res => { if (res != null) { this.dialogRef.close(res); } });
+  }
+
+  onCancelar() { this.dialogRef.close(); }
+}

--- a/src/app/modules/rrhh/rrhh.module.ts
+++ b/src/app/modules/rrhh/rrhh.module.ts
@@ -44,6 +44,7 @@ import { DocumentoViewerDialogComponent } from './legajo/documento-viewer-dialog
 import { CambioCargoDialogComponent } from './legajo/cambio-cargo-dialog/cambio-cargo-dialog.component';
 import { CambioSalarioDialogComponent } from './legajo/cambio-salario-dialog/cambio-salario-dialog.component';
 import { EgresarFuncionarioDialogComponent } from './legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component';
+import { RevertirEgresoDialogComponent } from './legajo/revertir-egreso-dialog/revertir-egreso-dialog.component';
 import { SubirDocumentoDialogComponent } from './legajo/subir-documento-dialog/subir-documento-dialog.component';
 import { LiquidacionFinalDialogComponent } from './liquidacion-final/liquidacion-final-dialog/liquidacion-final-dialog.component';
 import { LiquidacionFinalGenerarDialogComponent } from './liquidacion-final/liquidacion-final-generar-dialog/liquidacion-final-generar-dialog.component';
@@ -93,6 +94,7 @@ import { ManualRrhhComponent } from './manual/manual-rrhh.component';
     CambioCargoDialogComponent,
     CambioSalarioDialogComponent,
     EgresarFuncionarioDialogComponent,
+    RevertirEgresoDialogComponent,
     SubirDocumentoDialogComponent,
     LiquidacionFinalDialogComponent,
     LiquidacionFinalGenerarDialogComponent,


### PR DESCRIPTION
Lado desktop de la reversa de egreso. **PR hermano: GabFrank/franco-system-backend-servidor#236**, que tiene el contexto completo, la migración y los tests.

## Qué entra

**Botón "Revertir egreso"** en el legajo, visible solo cuando el funcionario está inactivo y con el mismo gating de roles que Egresar.

El diálogo **pide el snapshot antes de abrirse**. Si existe, precarga el crédito que el funcionario tenía y avisa a qué tipo vuelve su cliente y quién lo egresó; el campo queda editable, porque entre el egreso y la reversa el negocio pudo cambiar. Si no existe —egresos anteriores al histórico— lo dice y pide el crédito a mano.

## Gate de confirmación al egresar

Hay que escribir el nombre completo del funcionario para habilitar el botón, como al borrar un repositorio.

La comparación **ignora acentos, mayúsculas y espacios de sobra**: varios nombres del padrón tienen tildes y espacios al final (`MIGUEL ÁNGEL FRANCO AREVALOS `, `WILIAN ISMAEL MARTINEZ BENÍTEZ `). El objetivo es obligar a mirar a quién se está egresando, no pelear con el teclado — y aflojar eso no permite confundir a dos personas distintas.

Aproveché para que el diálogo **diga lo que realmente hace**. Antes prometía solo "se marcará como inactivo"; ahora enumera que quita el acceso al sistema, pone el crédito en cero y devuelve el cliente a NORMAL, también sin crédito.

## Un hueco que apareció en el camino

`fechaEgreso` y `motivoEgreso` se escribían en la base pero **no existían en el modelo TS ni en la query del legajo**, así que la pantalla mostraba solo el badge INACTIVO — sin cuándo ni por qué. Ya se muestran al lado del badge.

## Cómo probarlo

1. **Gate**: abrir *Egresar* en cualquier funcionario. El botón arranca deshabilitado; con el nickname sigue deshabilitado; con el nombre completo aparece la tilde verde y se habilita. Probar uno con tilde escribiéndolo sin ella: tiene que aceptar.
2. **Reversa con snapshot**: egresar a alguien y revertirlo. El crédito viene cargado y el aviso es verde. Verificar en la base que el **cliente recuperó su tipo** — con un VIP es donde se nota.
3. **Reversa sin snapshot**: sobre un funcionario egresado de antes, el aviso es naranja y el crédito arranca en 0.
4. **Rechazo**: generar un finiquito y luego intentar revertir. Tiene que rechazar nombrando estado e id.

### Ya verificado

Ciclo completo por UI contra el central local con **MIGUEL ÁNGEL FRANCO AREVALOS** (VIP, 5.200.000): egresado escribiendo el nombre sin tilde, y revertido sin escribir el crédito. Volvieron crédito, usuario, cliente y **`tipo = VIP`**.

**Riesgo:** bajo. Sin cambios de contrato ni de build. `npm run check` (AOT) en verde, 0 errores.
