### PR TITLE
fix(rrhh): filtrar liquidaciones por nombre de funcionario y periodo mas agil

### DIFF
--- a/src/app/commons/core/utils/dateUtils.ts
+++ b/src/app/commons/core/utils/dateUtils.ts
@@ -262,6 +262,13 @@ export function parseShortDate(dateString: string | null): Date | null {
 }
 
 
+/** Completa "202608" a "2026-08" (formato YYYY-MM usado en filtros de período). Idempotente. */
+export function formatearPeriodo(valor: string): string {
+  if (!valor) return valor;
+  const digitos = valor.replace(/\D/g, "").slice(0, 6);
+  return digitos.length <= 4 ? digitos : `${digitos.slice(0, 4)}-${digitos.slice(4)}`;
+}
+
 export function formatearFecha(event: any): any {
   let input = event.target.value.replace(/\D/g, ""); // Remove any non-digit characters
 

--- a/src/app/modules/rrhh/liquidacion/graphql/graphql-query.ts
+++ b/src/app/modules/rrhh/liquidacion/graphql/graphql-query.ts
@@ -20,8 +20,8 @@ export const liquidacionItemsQuery = gql`
   query ($liquidacionId: ID!) { data: liquidacionItems(liquidacionId: $liquidacionId) { ${ITEM_FIELDS} } }
 `;
 export const liquidacionesPageQuery = gql`
-  query ($page: Int, $size: Int, $funcionarioId: ID, $periodo: String, $estado: LiquidacionSueldoEstado) {
-    data: liquidacionesPage(page: $page, size: $size, funcionarioId: $funcionarioId, periodo: $periodo, estado: $estado) {
+  query ($page: Int, $size: Int, $funcionarioId: ID, $funcionarioNombre: String, $periodo: String, $estado: LiquidacionSueldoEstado) {
+    data: liquidacionesPage(page: $page, size: $size, funcionarioId: $funcionarioId, funcionarioNombre: $funcionarioNombre, periodo: $periodo, estado: $estado) {
       getTotalPages
       getTotalElements
       getNumberOfElements

--- a/src/app/modules/rrhh/liquidacion/liquidacion.service.ts
+++ b/src/app/modules/rrhh/liquidacion/liquidacion.service.ts
@@ -58,10 +58,10 @@ export class LiquidacionService {
   }
 
   /** Padron del SaaS: lista paginada y filtrada en el backend. */
-  onGetPage(page: number, size: number, funcionarioId?: number, periodo?: string,
-            estado?: string, servidor = true): Observable<any> {
+  onGetPage(page: number, size: number, funcionarioId?: number, funcionarioNombre?: string,
+            periodo?: string, estado?: string, servidor = true): Observable<any> {
     return this.genericService.onCustomQuery(this.liquidacionesPageGQL,
-      { page, size, funcionarioId, periodo, estado }, servidor);
+      { page, size, funcionarioId, funcionarioNombre, periodo, estado }, servidor);
   }
 
   onGenerarBorrador(funcionarioId: number, periodo: string, monedaId: number, servidor = true): Observable<any> {

--- a/src/app/modules/rrhh/liquidacion/list-liquidacion/list-liquidacion.component.html
+++ b/src/app/modules/rrhh/liquidacion/list-liquidacion/list-liquidacion.component.html
@@ -3,12 +3,10 @@
   (filtrar)="onFiltrar()" (resetFiltro)="onResetFiltro()">
 
   <div filtros fxLayout="row wrap" fxLayoutGap="10px" style="width: 100%">
-    <div fxFlex="320px">
-      <app-select-funcionario
-        [funcionarioId]="funcionarioControl.value"
-        (idSelected)="funcionarioControl.setValue($event)">
-      </app-select-funcionario>
-    </div>
+    <mat-form-field fxFlex="425px">
+      <mat-label>Funcionario (nombre o apellido)</mat-label>
+      <input matInput [formControl]="funcionarioNombreControl" (keyup.enter)="onFiltrar()" />
+    </mat-form-field>
 
     <mat-form-field fxFlex="130px">
       <mat-label>Período</mat-label>

--- a/src/app/modules/rrhh/liquidacion/list-liquidacion/list-liquidacion.component.ts
+++ b/src/app/modules/rrhh/liquidacion/list-liquidacion/list-liquidacion.component.ts
@@ -16,6 +16,7 @@ import { TabData, TabService } from '../../../../layouts/tab/tab.service';
 import { ReporteService } from '../../../reportes/reporte.service';
 import { ReportesComponent } from '../../../reportes/reportes/reportes.component';
 import { ImpresionService } from '../../../../shared/components/imprimir/impresion.service';
+import { formatearPeriodo } from '../../../../commons/core/utils/dateUtils';
 
 
 @UntilDestroy({ checkProperties: true })
@@ -31,7 +32,7 @@ export class ListLiquidacionComponent implements OnInit {
   displayedColumns = ['periodo', 'funcionario', 'totalHaberes', 'totalDescuentos', 'totalNeto', 'estado', 'acciones'];
   dataSource = new MatTableDataSource<LiquidacionSueldo>([]);
 
-  funcionarioControl = new FormControl(null);
+  funcionarioNombreControl = new FormControl(null);
   periodoControl = new FormControl(null);
   estadoControl = new FormControl(null);
 
@@ -54,6 +55,13 @@ export class ListLiquidacionComponent implements OnInit {
   ngOnInit(): void {
     this.periodoControl.setValue(this.periodoActual());
     this.onFiltrar();
+
+    this.periodoControl.valueChanges.pipe(untilDestroyed(this)).subscribe(valor => {
+      const formateado = formatearPeriodo(valor);
+      if (formateado !== valor) {
+        this.periodoControl.setValue(formateado, { emitEvent: false });
+      }
+    });
   }
 
   private periodoActual(): string {
@@ -65,7 +73,8 @@ export class ListLiquidacionComponent implements OnInit {
     this.liquidacionService.onGetPage(
       this.pageIndex,
       this.pageSize,
-      this.funcionarioControl.value,
+      null,
+      this.funcionarioNombreControl.value,
       this.periodoControl.value,
       this.estadoControl.value
     ).pipe(untilDestroyed(this)).subscribe(res => {
@@ -77,7 +86,7 @@ export class ListLiquidacionComponent implements OnInit {
   }
 
   onResetFiltro() {
-    this.funcionarioControl.setValue(null);
+    this.funcionarioNombreControl.setValue(null);
     this.periodoControl.setValue(this.periodoActual());
     this.estadoControl.setValue(null);
     this.pageIndex = 0;


### PR DESCRIPTION
## Resumen
- Reemplaza el dialogo de seleccion de funcionario en `list-liquidacion` por un campo de texto libre (nombre o apellido, filtra con Enter), igual que en `list-funcioario`. El dialogo solo permitia elegir un funcionario exacto por vez.
- Completa automaticamente el guion del periodo: `202608` -> `2026-08` (nuevo utilitario `formatearPeriodo` en `dateUtils.ts`, reutilizable en otros componentes con filtro de periodo).
- Ensancha el campo de funcionario (320px -> 425px).
- Depende del PR de backend que agrega el parametro `funcionarioNombre` a `liquidacionesPage`: https://github.com/GabFrank/franco-system-backend-servidor/pull/new/feat/rrhh-liquidacion-filtro-nombre-funcionario

## Plan de pruebas
- [x] `npm run check` (build AOT) sin errores
- [x] Probado en vivo contra central local en `develop`: filtro por nombre/apellido con Enter funciona, y el campo periodo autocompleta el guion

🤖 Generated with [Claude Code](https://claude.com/claude-code)