### PR TITLE
fix(administracion): permitir marcar tributa al crear cliente desde el diálogo

### DIFF
--- a/src/app/modules/personas/clientes/add-cliente-dialog/add-cliente-dialog.component.html
+++ b/src/app/modules/personas/clientes/add-cliente-dialog/add-cliente-dialog.component.html
@@ -127,6 +127,16 @@
     </mat-form-field>
   </div>
   </div>
+
+  <div fxLayout="row" fxLayoutAlign="center center" style="text-align: center;">
+    <mat-checkbox [formControl]="tributaControl">Tributa (IVA)</mat-checkbox>
+    <mat-icon
+      class="icon"
+      style="margin-left: 6px; font-size: 18px; height: 18px; width: 18px; cursor: help;"
+      matTooltip="Marcar si el cliente es contribuyente activo ante la SET."
+      >info</mat-icon
+    >
+  </div>
   <br />
 
   <div

--- a/src/app/modules/personas/clientes/add-cliente-dialog/add-cliente-dialog.component.ts
+++ b/src/app/modules/personas/clientes/add-cliente-dialog/add-cliente-dialog.component.ts
@@ -36,6 +36,7 @@ export class AddClienteDialogComponent implements OnInit {
   personaControl = new FormControl()
   buscarControl = new FormControl()
   creditoControl = new FormControl(0, Validators.min(0));
+  tributaControl = new FormControl(false)
 
   //persona
   nombreControl = new FormControl(null, Validators.required)
@@ -68,6 +69,7 @@ export class AddClienteDialogComponent implements OnInit {
     this.formGroup = new FormGroup({
       'tipoControl': this.tipoControl,
       'creditoControl': this.creditoControl,
+      'tributaControl': this.tributaControl,
       'nombreControl': this.nombreControl,
       'apodoControl': this.apodoControl,
       'documentoControl': this.documentoControl,
@@ -92,6 +94,7 @@ export class AddClienteDialogComponent implements OnInit {
       this.selectedPersona = this.selectedCliente.persona;
       this.tipoControl.setValue(this.selectedCliente?.tipo)
       this.creditoControl.setValue(this.selectedCliente?.credito)
+      this.tributaControl.setValue(this.selectedCliente?.tributa ?? false)
       this.nombreControl.setValue(this.selectedPersona.nombre)
       this.apodoControl.setValue(this.selectedPersona?.apodo)
       this.documentoControl.setValue(this.selectedPersona?.documento)
@@ -124,7 +127,11 @@ export class AddClienteDialogComponent implements OnInit {
       titulo: 'Buscar persona',
       search: true,
       texto: this.nombreControl.value,
-      inicialSearch: true
+      // Solo autobuscar si ya hay texto cargado (ej. se tipeó el nombre antes de
+      // abrir el buscador). Sin texto, "buscar todo" carga la lista completa de
+      // personas de una — igual que en app-select-funcionario, se espera a que
+      // el usuario tipee.
+      inicialSearch: !!this.nombreControl.value
     }
     this.dialog.open(SearchListDialogComponent, {
       data: data,
@@ -140,6 +147,7 @@ export class AddClienteDialogComponent implements OnInit {
             this.selectedCliente = res2;
             this.tipoControl.setValue(this.selectedCliente?.tipo)
             this.creditoControl.setValue(this.selectedCliente?.credito)
+            this.tributaControl.setValue(this.selectedCliente?.tributa ?? false)
           })
         }
         this.nombreControl.setValue(this.selectedPersona.nombre)
@@ -179,18 +187,25 @@ export class AddClienteDialogComponent implements OnInit {
     this.personaService.onSavePersona(newPersona.toInput()).pipe(untilDestroyed(this)).subscribe((personaRes: Persona) => {
       if (personaRes != null) {
         this.selectedPersona = personaRes;
+        let esClienteNuevo = this.selectedCliente == null;
         let newCliente = new Cliente;
         if (this.selectedCliente != null) Object.assign(newCliente, this.selectedCliente)
-        
+
         // CRÍTICO: Actualizar los campos del Cliente con los valores de la Persona actualizada
         newCliente.persona = this.selectedPersona;
         newCliente.nombre = this.selectedPersona.nombre;  // ✅ Usar nombre actualizado
-        newCliente.direccion = this.selectedPersona.direccion;  // ✅ Usar dirección actualizada  
+        newCliente.direccion = this.selectedPersona.direccion;  // ✅ Usar dirección actualizada
         newCliente.documento = this.selectedPersona.documento;  // ✅ Usar documento actualizado
-        
+
         newCliente.tipo = this.tipoControl.value;
         newCliente.credito = this.creditoControl.value;
-        
+        newCliente.tributa = this.tributaControl.value;
+        // Cliente nuevo cargado a mano: no pasó por la consulta de la SET.
+        // Si es edición, se conserva el verificadoSet ya existente (copiado por Object.assign).
+        if (esClienteNuevo) {
+          newCliente.verificadoSet = false;
+        }
+
         this.clienteService.onSaveCliente(newCliente.toInput()).pipe(untilDestroyed(this)).subscribe((clienteRes: Cliente) => {
           if (clienteRes != null) {
             this.selectedCliente = clienteRes;


### PR DESCRIPTION
## Qué resuelve

El diálogo de "Nuevo Cliente" (`add-cliente-dialog`) no tenía ningún control para indicar si un cliente tributa, así que siempre guardaba `tributa = null` sin importar si se cargaba un RUC real. Eso hacía que el sistema tratara a esos clientes como no contribuyentes al facturar (`SifenReceptorHelper.tieneRucValido` trata `tributa == null` igual que `false`), aun cuando eran contribuyentes reales de la SET — es la primera de tres causas identificadas para el bug reportado de "el cliente no es contribuyente cuando sí lo es".

Este es el primero de varios PRs separados, uno por cada camino de creación de cliente que tenía el mismo síntoma con causas distintas.

## Cambios

- Se agrega `tributaControl` (checkbox "Tributa (IVA)") al formulario, con tooltip aclaratorio.
- Se popula al editar un cliente existente (desde `data.cliente` y desde la búsqueda por documento).
- Al guardar: se envía el valor del checkbox como `tributa`; si es un cliente **nuevo**, además se fuerza `verificadoSet=false` explícitamente (no pasó por consulta real a la SET). Si es edición, se respeta el `verificadoSet` que ya traía.
- Ajuste adicional: la búsqueda de "Buscar persona" dentro de este mismo diálogo autobuscaba con texto vacío al abrir, trayendo la lista completa de personas (lento). Ahora solo autobusca si ya hay texto cargado, igual que el patrón de `app-select-funcionario`.

## Cómo probarlo

1. Levantar central (8081, sin perfil dev) + filial (8082, perfil dev) + frontend (`npm start`).
2. Módulo Personas → Clientes → "Nuevo Cliente".
3. Verificar que aparece el checkbox "Tributa (IVA)".
4. Crear un cliente marcando el checkbox → debería guardar `tributa=true`.
5. Crear uno sin marcar → `tributa=false` (ya no `null`).
6. Editar un cliente existente → el checkbox debe reflejar su valor actual.
7. Abrir "Buscar persona" (ícono de lupa) sin tipear nada → ya no debería cargar toda la lista de personas de una.

Probado manualmente por el usuario en este flujo — confirmado que funciona.

## Impacto / riesgo

- Solo frontend, sin cambios de schema ni backend.
- Riesgo bajo: agrega un campo opcional al formulario y ajusta un flag de búsqueda; no cambia comportamiento de clientes ya creados salvo que se editen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)