### PR TITLE
feat(venta): elegir el lote en el POS en vez de dejarlo a FEFO [3.0.9]

### DIFF
--- a/src/app/modules/operaciones/lote/list-stock-lote/list-stock-lote.component.ts
+++ b/src/app/modules/operaciones/lote/list-stock-lote/list-stock-lote.component.ts
@@ -96,14 +96,6 @@ type FiltroVencimiento = 'VENCIDO' | 'POR_VENCER';
 const DIAS_POR_VENCER = 30;
 
 /**
- * Ventana con la que se abre la pantalla, precargada en el rango "Vence o se retira entre".
- *
- * Va como valor del rango y no como un atajo más: así el operador VE en el campo por qué el
- * listado viene recortado, y lo corrige o lo borra desde el mismo control con el que ya trabaja.
- */
-const DIAS_VENCIMIENTO_POR_DEFECTO = 7;
-
-/**
  * Pantalla "Stock por lotes": responde "¿dónde tengo qué?".
  *
  * El saldo se deriva del ledger operaciones.movimiento_stock_lote y se resuelve contra el maestro
@@ -235,29 +227,7 @@ export class ListStockLoteComponent implements OnInit {
       .pipe(debounceTime(400), distinctUntilChanged(), untilDestroyed(this))
       .subscribe(() => this.onFiltrar(true));
 
-    this.precargarVencimientoPorDefecto();
     this.onBuscar();
-  }
-
-  /**
-   * Abre la pantalla con el rango "Vence o se retira entre" cargado de hoy a hoy + 7 días.
-   *
-   * Se cargan las DOS puntas y no solo el tope: con el piso vacío el campo muestra su placeholder
-   * ("DESDE – 15/8/2026") en vez de un rango legible.
-   *
-   * Efecto lateral de cerrar el rango: lo que YA venció queda afuera del listado inicial, porque
-   * su fecha es anterior al piso. Para eso está el atajo "Vencido", que limpia el rango y trae
-   * exactamente ese conjunto.
-   *
-   * Se hace acá y no en la construcción del FormGroup para no evaluar la fecha al instanciar el
-   * componente: la pantalla vive en una tab que puede quedar abierta de un día para el otro.
-   */
-  private precargarVencimientoPorDefecto(): void {
-    const desde = new Date();
-    const hasta = new Date();
-    hasta.setDate(hasta.getDate() + DIAS_VENCIMIENTO_POR_DEFECTO);
-    this.vencimiento.get('desde').setValue(desde);
-    this.vencimiento.get('hasta').setValue(hasta);
   }
 
   /**
@@ -333,10 +303,9 @@ export class ListStockLoteComponent implements OnInit {
     this.filtros.reset();
     this.proveedorSeleccionado = null;
     this.filtroVencimiento = null;
-    // El rango no cuelga de `filtros`, así que no lo alcanza el reset de arriba. Se recarga con el
-    // valor por defecto en vez de vaciarse: "Limpiar Filtro" deja la pantalla como recién abierta,
-    // no en un estado que no se puede alcanzar de ninguna otra forma.
-    this.precargarVencimientoPorDefecto();
+    // El rango no cuelga de `filtros`, así que no lo alcanza el reset de arriba. Se vacía a mano
+    // para que "Limpiar Filtro" deje la pantalla como recién abierta: sin ningún corte por fecha.
+    this.vencimiento.reset();
     this.onFiltrar();
   }
 

--- a/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.html
+++ b/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.html
@@ -9,44 +9,10 @@
     <span class="resumen-unidad">unid.</span>
   </div>
 
-  <div
-    class="modo"
-    fxLayout="row"
-    fxLayoutAlign="start center"
-    fxLayoutGap="12px"
-  >
-    <div
-      role="radiogroup"
-      aria-label="Modo de asignación de lote"
-      fxLayout="row"
-      fxLayoutGap="8px"
-    >
-      <button
-        mat-raised-button
-        type="button"
-        role="radio"
-        [attr.aria-checked]="modoFefo"
-        [color]="modoFefo ? 'primary' : null"
-        (click)="activarFefo()"
-      >
-        FEFO automático
-      </button>
-      <button
-        mat-raised-button
-        type="button"
-        role="radio"
-        [attr.aria-checked]="!modoFefo"
-        [color]="!modoFefo ? 'primary' : null"
-        [disabled]="sinLotes"
-        (click)="activarManual()"
-      >
-        Elegir lote
-      </button>
-    </div>
-
+  <div class="modo">
     <mat-form-field
       class="campo-busqueda"
-      *ngIf="!modoFefo && !cargandoInicial && !sinLotes"
+      *ngIf="!cargandoInicial && !sinLotes"
     >
       <mat-label>Nº de lote</mat-label>
       <input
@@ -61,10 +27,6 @@
       <mat-icon matSuffix>search</mat-icon>
     </mat-form-field>
   </div>
-
-  <p class="ayuda" *ngIf="modoFefo">
-    Se saca primero lo que vence antes. No hace falta elegir nada.
-  </p>
 
   <mat-spinner
     *ngIf="cargandoInicial"
@@ -81,7 +43,7 @@
     {{ mensajeSinLotes }}
   </div>
 
-  <ng-container *ngIf="!modoFefo && !cargandoInicial && !sinLotes">
+  <ng-container *ngIf="!cargandoInicial && !sinLotes">
 
     <div
       class="mensaje-estado"

--- a/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.html
+++ b/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.html
@@ -75,6 +75,7 @@
           <td mat-cell *matCellDef="let fila" style="width: 8%">
             <mat-checkbox
               [checked]="fila.seleccionado"
+              [disabled]="fila.deshabilitado"
               [attr.aria-label]="'Usar lote ' + fila.numeroLote"
               (change)="alternarLote(fila)"
             ></mat-checkbox>
@@ -179,6 +180,10 @@
   <div class="faltante" *ngIf="hayFaltante">
     {{ faltanteLabel }}
   </div>
+
+  <div class="cubierto" *ngIf="mostrarCubierto" role="status" aria-live="polite">
+    Ya cubriste las {{ cantidadRequerida }} unid. Destildá un lote para cambiar de dónde sale.
+  </div>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
@@ -189,15 +194,18 @@
   >
     Cancelar
   </button>
-  <button
-    mat-raised-button
-    color="primary"
-    type="button"
-    cdkFocusInitial
-    #botonConfirmar
-    [disabled]="!puedeConfirmar"
-    (click)="confirmar()"
-  >
-    Confirmar
-  </button>
+  <!-- El tooltip cuelga del span: un boton deshabilitado no emite los eventos que lo abren. -->
+  <span [matTooltip]="motivoBloqueo" [matTooltipDisabled]="puedeConfirmar">
+    <button
+      mat-raised-button
+      color="primary"
+      type="button"
+      cdkFocusInitial
+      #botonConfirmar
+      [disabled]="!puedeConfirmar"
+      (click)="confirmar()"
+    >
+      Confirmar
+    </button>
+  </span>
 </mat-dialog-actions>

--- a/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.scss
+++ b/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.scss
@@ -131,3 +131,10 @@
   margin-top: 10px;
   color: #ffca28;
 }
+
+// Explica por qué los demás checkbox quedaron apagados: sin esto, "no me deja marcar" se lee como
+// que la pantalla se colgó.
+.cubierto {
+  margin-top: 10px;
+  color: rgba(255, 255, 255, 0.7);
+}

--- a/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.scss
+++ b/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.scss
@@ -25,15 +25,10 @@
   }
 }
 
+// El campo de búsqueda aparece recién cuando llega la lista; sin alto fijo la fila salta.
 .modo {
   margin-bottom: 12px;
-  // El campo de búsqueda es más alto que los botones; sin esto la fila salta al aparecer.
   min-height: 56px;
-}
-
-.ayuda {
-  color: rgba(255, 255, 255, 0.7);
-  margin: 0 0 8px;
 }
 
 .spinner {
@@ -47,8 +42,8 @@
   margin-bottom: 8px;
 }
 
-// Corto y en la misma fila que los botones de modo: es un filtro puntual por número, no un campo
-// de carga. A lo ancho competía visualmente con la tabla, que es lo que el cajero tiene que mirar.
+// Corto a propósito: es un filtro puntual por número, no un campo de carga. A lo ancho competía
+// visualmente con la tabla, que es lo que el cajero tiene que mirar.
 .campo-busqueda {
   width: 220px;
 

--- a/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.ts
@@ -23,6 +23,15 @@ import { VentaItemLoteInput } from '../../../../operaciones/venta/venta-item.mod
 /** Tolerancia al comparar cantidades en punto flotante. */
 const EPSILON = 0.0001;
 
+/**
+ * Tamaño con el que se pide el universo de lotes: uno solo, grande, para traerlos todos.
+ *
+ * El backend arma la lista entera en memoria y recién después la corta, así que pedir todo no le
+ * cuesta más que pedir una página. Un producto con más lotes vendibles que esto no existe en el
+ * catálogo, y si apareciera el peor caso es que el diálogo crea que ya no queda de dónde elegir.
+ */
+const TAMANIO_UNIVERSO = 500;
+
 export interface SeleccionarLoteVentaDialogData {
   productoId: number;
   productoDescripcion: string;
@@ -76,6 +85,11 @@ interface LoteRow {
   cantidad: number;
   cantidadLabel: string;
   seleccionado: boolean;
+  /**
+   * Precalculado para el template: un lote que no puede llevar nada no se puede marcar. Es lo que
+   * impide tildar un segundo lote cuando lo pedido ya sale entero del primero.
+   */
+  deshabilitado: boolean;
   /** Precalculado para resaltar lo que hay que sacar antes, sin lógica en el template. */
   clase: string;
 }
@@ -83,9 +97,12 @@ interface LoteRow {
 /**
  * Selector de lote para la venta.
  *
- * Abre directo en la lista de lotes, con el buscador enfocado. Confirmar sin marcar nada sigue
- * siendo la venta normal: no se manda ningún lote y el backend descuenta por FEFO. Lo que se marca
- * es una preferencia, que el backend recorta al saldo real y completa por FEFO si no alcanza.
+ * Abre directo en la lista de lotes, con el buscador enfocado. El cajero marca de dónde sale la
+ * mercadería que tiene en la mano: mientras quede un lote sin marcar y falte cubrir, el confirmar
+ * espera. Lo que se marca es una preferencia, que el backend recorta al saldo real.
+ *
+ * FEFO queda como último recurso y no como camino normal: solo cubre lo que ya no tiene lote de
+ * dónde salir, y en ese caso la pantalla lo dice antes de dejar confirmar.
  *
  * La lista se busca y se pagina contra el backend, porque con el tiempo un producto acumula
  * muchos lotes y filtrar solo la página visible dejaría lotes invisibles sin que el cajero se
@@ -150,6 +167,26 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
   totalSeleccionadoLabel = '0';
   faltanteLabel = '';
   hayFaltante = false;
+  /** Unidades que todavía no tienen lote. Manda sobre qué filas se pueden marcar. */
+  pendiente = 0;
+  /** Lo pedido ya sale entero de lo marcado: no queda nada para darle a otro lote. */
+  todoCubierto = false;
+  /** El aviso de "ya está cubierto" solo tiene sentido después de marcar algo. */
+  mostrarCubierto = false;
+  /**
+   * Todos los lotes vendibles del producto, sin el filtro del buscador ni la página visible.
+   *
+   * La tabla muestra de a poco y filtra contra el backend, así que por sí sola no sabe si queda
+   * algún lote sin marcar. Sin ese dato no se puede distinguir "todavía hay de dónde sacarlo" de
+   * "el stock por lote no alcanza", que es lo único que decide si la venta puede salir sin cubrir.
+   */
+  private universo: { loteId: number; disponible: number }[] = [];
+  /** Sin universo no se bloquea nada: una consulta caída no puede trabar el mostrador. */
+  private universoCargado = false;
+  /** Queda al menos un lote vendible sin marcar, en cualquier página. */
+  hayLotesSinMarcar = false;
+  /** Por qué está bloqueado el confirmar. Vacío cuando se puede confirmar. */
+  motivoBloqueo = '';
   puedeConfirmar = true;
   mensajeSinLotes = '';
 
@@ -189,7 +226,47 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
         this.cargarLotes();
       });
 
+    this.cargarUniverso();
     this.cargarLotes();
+  }
+
+  /**
+   * El universo se pide una sola vez y sin filtro: es la foto de todo lo que se puede elegir.
+   *
+   * Va aparte de la consulta de la tabla porque esa se rearma en cada tecla y en cada página, y lo
+   * que se necesita acá es justo lo contrario: algo estable contra lo que comparar lo marcado.
+   *
+   * Si falla, el diálogo sigue andando sin bloquear nada. Es la misma decisión que el resto de la
+   * pantalla: ante datos de lote incompletos, la venta sale igual.
+   */
+  private cargarUniverso(): void {
+    this.loteService
+      .onGetStockPorLoteEnPresentacion(
+        this.data.productoId,
+        this.data.sucursalId,
+        this.data.presentacionId,
+        null,
+        0,
+        TAMANIO_UNIVERSO,
+        false,
+        true
+      )
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (res: PageInfo<StockLotePresentacion>) => {
+          this.universo = (res?.getContent || []).map((lote) => ({
+            loteId: lote.loteId,
+            disponible: lote.cantidadDisponible || 0
+          }));
+          this.universoCargado = true;
+          this.recalcular();
+        },
+        error: () => {
+          this.universo = [];
+          this.universoCargado = false;
+          this.recalcular();
+        }
+      });
   }
 
   /**
@@ -308,6 +385,8 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
       cantidad: elegido ? elegido.cantidad : 0,
       cantidadLabel: elegido ? `${elegido.cantidad}` : '—',
       seleccionado: elegido != null,
+      // La resuelve recalcular(), que corre siempre después de mapear la página.
+      deshabilitado: false,
       clase: this.claseSegunFecha(lote)
     };
   }
@@ -338,10 +417,14 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
     if (fila.seleccionado) {
       this.desmarcar(fila);
     } else {
-      const pendiente = this.cantidadRequerida - this.totalSeleccionado;
-      const asignada = Math.max(0, Math.min(fila.disponible, pendiente));
-      // Con lo pedido ya cubierto no queda nada para este lote: marcarlo no diría nada.
+      // `pendiente` lo mantiene al día recalcular(), que corre al final de cada cambio.
+      const asignada = Math.max(0, Math.min(fila.disponible, this.pendiente));
+      // Con lo pedido ya cubierto no queda nada para este lote: marcarlo no diría nada. Con la
+      // fila deshabilitada esto casi no llega, pero si llega hay que repintar: el checkbox ya se
+      // tildó solo al hacer click y `seleccionado` no cambió de valor, así que el binding no lo
+      // vuelve atrás y el tilde queda mintiendo sobre de dónde sale el stock.
       if (asignada <= EPSILON) {
+        this.repintarFila(fila);
         return;
       }
       fila.seleccionado = true;
@@ -375,6 +458,36 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
       numeroLote: fila.numeroLote,
       cantidad: fila.cantidad,
       cantidadLabel: `${fila.cantidad}`
+    });
+  }
+
+  /**
+   * Fuerza a Angular a redibujar una fila reemplazando su objeto: con OnPush y `[checked]`, un
+   * valor que no cambió no repinta el checkbox, y el estado interno del mat-checkbox se queda con
+   * lo que pintó el click.
+   */
+  private repintarFila(fila: LoteRow): void {
+    const indice = this.filas.indexOf(fila);
+    if (indice < 0) {
+      return;
+    }
+    const copia = this.filas.slice();
+    copia[indice] = { ...fila };
+    this.filas = copia;
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * Un lote se puede marcar solo si le queda algo para llevar. Sin unidades pendientes —o sin
+   * saldo— marcarlo no asignaría nada, y un tilde sin cantidad hace creer que la venta salió de
+   * dos lotes cuando salió de uno: es justo lo que después no coincide con el ticket.
+   *
+   * Lo ya marcado nunca se deshabilita: destildarlo es la forma de cambiar de dónde sale.
+   */
+  private actualizarHabilitacion(): void {
+    this.filas.forEach((fila) => {
+      fila.deshabilitado = !fila.seleccionado
+        && (this.todoCubierto || fila.disponible <= EPSILON);
     });
   }
 
@@ -437,15 +550,47 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
     );
     this.totalSeleccionadoLabel = `${this.totalSeleccionado}`;
 
-    const faltante = this.cantidadRequerida - this.totalSeleccionado;
-    this.hayFaltante = faltante > EPSILON;
-    this.faltanteLabel = this.hayFaltante
-      ? `Faltan ${faltante} — el resto lo completa FEFO automáticamente.`
-      : '';
-    // Siempre se puede confirmar: sin nada marcado sale todo por FEFO, y lo que falte de lo
-    // marcado también. Bloquear acá dejaría al cajero sin salida.
-    this.puedeConfirmar = true;
+    this.pendiente = Math.max(0, this.cantidadRequerida - this.totalSeleccionado);
+    this.hayFaltante = this.pendiente > EPSILON;
+    this.todoCubierto = !this.hayFaltante;
+    this.mostrarCubierto = this.todoCubierto && this.hayLotesElegidos;
+    // Bloquear exige las dos cosas: saber que queda un lote sin marcar Y que la tabla esté en
+    // condiciones de marcarlo. Con la lista caída o vacía, pedirle al cajero que elija otro lote
+    // sería trabarlo sin salida.
+    const sePuedeElegir = !this.cargandoInicial && !this.sinLotes && !this.mensajeError;
+    this.hayLotesSinMarcar = this.universoCargado && sePuedeElegir
+      && this.universo.some((lote) => !this.seleccion.has(lote.loteId));
+    this.actualizarFaltante();
+    this.actualizarHabilitacion();
     this.cdr.markForCheck();
+  }
+
+  /**
+   * Mientras quede un lote sin marcar, el faltante es una decisión pendiente y no un dato: hay de
+   * dónde sacarlo y el cajero es el único que sabe de qué lote está agarrando la mercadería. Por
+   * eso el confirmar espera.
+   *
+   * Cuando ya no queda ninguno, el faltante pasa a ser un hecho del stock: se avisa que esas
+   * unidades salen sin trazabilidad y la venta se completa igual, que es la regla de toda la
+   * pantalla.
+   */
+  private actualizarFaltante(): void {
+    if (!this.hayFaltante) {
+      this.faltanteLabel = '';
+      this.motivoBloqueo = '';
+      this.puedeConfirmar = true;
+      return;
+    }
+    if (this.hayLotesSinMarcar) {
+      this.faltanteLabel = `Faltan ${this.pendiente} unid. — elegí otro lote para cubrirlas.`;
+      this.motivoBloqueo = `Elegí de qué lote salen las ${this.pendiente} unid. que faltan.`;
+      this.puedeConfirmar = false;
+      return;
+    }
+    this.faltanteLabel = `Faltan ${this.pendiente} unid. y no hay más stock por lote: `
+      + 'esas unidades salen sin trazabilidad.';
+    this.motivoBloqueo = '';
+    this.puedeConfirmar = true;
   }
 
   confirmar(): void {

--- a/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/seleccionar-lote-venta-dialog/seleccionar-lote-venta-dialog.component.ts
@@ -83,9 +83,9 @@ interface LoteRow {
 /**
  * Selector de lote para la venta.
  *
- * Abre con FEFO preseleccionado: confirmar sin tocar nada es la venta normal y no cambia el ritmo
- * del POS. Elegir lotes a mano es la excepción deliberada, y aun así el backend recorta cada
- * elección al saldo real y completa el faltante por FEFO.
+ * Abre directo en la lista de lotes, con el buscador enfocado. Confirmar sin marcar nada sigue
+ * siendo la venta normal: no se manda ningún lote y el backend descuenta por FEFO. Lo que se marca
+ * es una preferencia, que el backend recorta al saldo real y completa por FEFO si no alcanza.
  *
  * La lista se busca y se pagina contra el backend, porque con el tiempo un producto acumula
  * muchos lotes y filtrar solo la página visible dejaría lotes invisibles sin que el cajero se
@@ -123,9 +123,6 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
   /** La misma selección como lista, para que el template la recorra sin pipes ni conversiones. */
   lotesElegidos: LoteElegido[] = [];
   hayLotesElegidos = false;
-
-  /** Modo activo. Arranca en FEFO: es el camino de casi todas las ventas. */
-  modoFefo = true;
 
   /**
    * Solo la primera carga. Buscar y paginar recargan la lista, pero no deben esconder el buscador:
@@ -218,6 +215,7 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe({
         next: (res: PageInfo<StockLotePresentacion>) => {
+          const primeraCarga = this.cargandoInicial;
           const contenido = res?.getContent || [];
           this.totalElementos = res?.getTotalElements || 0;
           this.filas = contenido.map((lote) => this.mapearFila(lote));
@@ -226,6 +224,12 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
           this.cargandoInicial = false;
           this.recalcular();
           this.resolverEnterPendiente();
+          // El buscador recién existe cuando Angular pinta la lista, así que el foco va acá y no
+          // en ngOnInit: es lo primero que el cajero necesita para tipear el lote que tiene en la
+          // mano.
+          if (primeraCarga && !this.sinLotes) {
+            this.enfocarBusqueda();
+          }
         },
         error: () => {
           this.manejarErrorDeCarga();
@@ -322,20 +326,6 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
     return '';
   }
 
-  /** Vuelve a FEFO: se descarta lo elegido a mano. El filtro se conserva por si se vuelve atrás. */
-  activarFefo(): void {
-    this.modoFefo = true;
-    this.seleccion.clear();
-    this.filas.forEach((fila) => this.desmarcar(fila));
-    this.recalcular();
-  }
-
-  activarManual(): void {
-    this.modoFefo = false;
-    this.recalcular();
-    this.enfocarBusqueda();
-  }
-
   /**
    * Marcar un lote le asigna lo que falta cubrir, acotado a su saldo. La cantidad no se tipea: el
    * cajero elige DE QUÉ lote sale, y el reparto lo resuelve el sistema.
@@ -404,9 +394,6 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
    * pareciera no responder justo cuando el cajero va rápido.
    */
   onEnterBusqueda(): void {
-    if (this.modoFefo) {
-      return;
-    }
     if (this.hayUnSoloResultado()) {
       this.elegirUnicoResultado();
       return;
@@ -432,7 +419,7 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
   }
 
   private enfocarBusqueda(): void {
-    // El input recién existe después de que Angular pinta el modo manual.
+    // El input recién existe después de que Angular pinta la lista.
     setTimeout(() => this.inputBusqueda?.nativeElement?.focus());
   }
 
@@ -451,21 +438,17 @@ export class SeleccionarLoteVentaDialogComponent implements OnInit {
     this.totalSeleccionadoLabel = `${this.totalSeleccionado}`;
 
     const faltante = this.cantidadRequerida - this.totalSeleccionado;
-    this.hayFaltante = !this.modoFefo && faltante > EPSILON;
+    this.hayFaltante = faltante > EPSILON;
     this.faltanteLabel = this.hayFaltante
       ? `Faltan ${faltante} — el resto lo completa FEFO automáticamente.`
       : '';
-    // Siempre se puede confirmar: en FEFO no hay nada que elegir, y en manual lo que falte lo
-    // resuelve el backend. Bloquear acá dejaría al cajero sin salida.
+    // Siempre se puede confirmar: sin nada marcado sale todo por FEFO, y lo que falte de lo
+    // marcado también. Bloquear acá dejaría al cajero sin salida.
     this.puedeConfirmar = true;
     this.cdr.markForCheck();
   }
 
   confirmar(): void {
-    if (this.modoFefo) {
-      this.dialogRef.close({ lotes: [] } as SeleccionarLoteVentaDialogResult);
-      return;
-    }
     const lotes: VentaItemLoteInput[] = this.lotesElegidos
       .filter((elegido) => elegido.cantidad > EPSILON)
       .map((elegido) => ({ loteId: elegido.loteId, cantidad: elegido.cantidad }));


### PR DESCRIPTION
## Qué cambia

El selector de lote de la venta (`venta-touch`) deja de ser "FEFO por defecto, elegir a mano si querés" y pasa a ser "elegí de dónde sale; FEFO solo cuando no queda de dónde".

**1. Se va el toggle `FEFO automático` / `Elegir lote`.** El diálogo abre directo en la lista, con el buscador enfocado.

**2. El checkbox ya no miente.** Con la cantidad cubierta, tildar otro lote hacía `return` sin tocar `seleccionado`: el `mat-checkbox` se pintaba solo al hacer click y, como el binding no cambiaba de valor, Angular no lo volvía atrás. Quedaba un tilde sin unidades y el cajero creía haber vendido de dos lotes cuando la venta salía de uno. Ahora un lote sin nada que llevar no se puede marcar, y si igual llega un click se repinta la fila.

**3. El faltante es una decisión, no un dato.** Mientras quede un lote sin marcar, `Confirmar` espera con `Faltan N unid. — elegí otro lote para cubrirlas.`. Cuando ya no queda ninguno, avisa que esas unidades salen sin trazabilidad y deja confirmar.

Para saber si queda algún lote sin marcar se pide una vez el universo completo sin filtro: la tabla se pagina y se filtra contra el backend, así que por sí sola no ve más allá de la página visible. El backend ya arma esa lista entera en memoria antes de paginar, así que no cuesta más que pedir una página.

**4. Stock por lotes** ya no se precarga con el rango de vencimiento de hoy a +7 días, y "Limpiar Filtro" lo vacía.

## Cómo probarlo

- Producto con lote, cantidad **1**: marcás un lote y el resto queda gris. Confirmar habilitado recién con el primer tilde.
- Cantidad **6** con un lote de saldo 1: lo marcás (queda "Faltan 5"), marcás otro y se lleva los 5. El ticket sale con dos líneas: ` Lote: 8978 x1` y ` Lote: 54345435 x5`.
- Cantidad mayor al stock por lote total: marcás todos, el cartel avisa que el resto sale sin trazabilidad y deja confirmar.
- Producto con control de lote pero sin stock por lote: avisa y deja vender, como antes.

## Riesgo

**Medio.** Toca el camino del cobro. Todos los caminos de error son fail-open: si el universo no carga, si la tabla falla, si no hay lotes o mientras carga, no se bloquea nada.

**Cambio de ritmo a tener en cuenta:** con nada premarcado y el confirmar bloqueado, toda venta de un producto con lote exige al menos un tilde. Ya no existe el abrir-y-confirmar.

Sin impacto en auto-update. Sin cambios de schema GraphQL — usa `stockPorLoteEnPresentacion`, que ya existe.

## Verificación

`npm run check` (AOT) pasa. Karma no compila en este repo (devkit v16 vs Angular 15.1.5), así que no hay unit tests nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)