### PR TITLE
fix(rrhh): legajo — ingreso/sucursal desaparecen al cambiar salario, y Guardar pisa el sueldo

### DIFF
--- a/src/app/modules/rrhh/legajo/cambio-salario-dialog/cambio-salario-dialog.component.scss
+++ b/src/app/modules/rrhh/legajo/cambio-salario-dialog/cambio-salario-dialog.component.scss
@@ -16,10 +16,12 @@
 
   mat-form-field { width: 100%; }
 
-  // el botón va pegado debajo del salario, sin comerse el hint del mínimo
+  // el botón va debajo del salario, separado del hint del mínimo.
+  // El !important es necesario: fxLayoutGap del contenedor inyecta margin-bottom
+  // como estilo inline en cada hijo, y sin él una regla de hoja de estilos no lo pisa.
   .accion-minimo {
-    margin-top: -6px;
-    margin-bottom: 2px;
+    margin-top: 12px;
+    margin-bottom: 0 !important;
   }
 
   [mat-dialog-actions] {

--- a/src/app/modules/rrhh/legajo/graphql/graphql-query.ts
+++ b/src/app/modules/rrhh/legajo/graphql/graphql-query.ts
@@ -4,7 +4,10 @@ const FUNC = `funcionario { id persona { id nombre } }`;
 const CARGO_HIST = `id ${FUNC} cargo { id nombre } fechaDesde fechaHasta motivo autorizadoPor { id } creadoEn`;
 const SALARIO_HIST = `id ${FUNC} salarioAnterior salarioNuevo moneda { id denominacion } fechaVigencia motivo autorizadoPor { id } creadoEn`;
 const DOC = `id ${FUNC} tipo nombreArchivo rutaRelativa mimeType tamanoBytes fechaSubida vencimiento observacion anulado creadoEn`;
-const FUNC_FULL = `id activo sueldo credito fechaEgreso motivoEgreso cargo { id nombre } persona { id nombre } moneda { id denominacion }`;
+// Tiene que traer TODOS los campos que la cabecera del legajo pinta: el componente
+// reemplaza `funcionario` con lo que devuelven estas mutations, asi que un campo que
+// falte acá se ve como si el dato se hubiera borrado hasta recargar la pestaña.
+const FUNC_FULL = `id activo sueldo credito fechaIngreso fechaEgreso motivoEgreso diarista cargo { id nombre } persona { id nombre } sucursal { id nombre } moneda { id denominacion }`;
 
 export const cargoHistoricosQuery = gql`
   query ($funcionarioId: ID!) { data: funcionarioCargoHistoricos(funcionarioId: $funcionarioId) { ${CARGO_HIST} } }

--- a/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.ts
+++ b/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.ts
@@ -95,7 +95,6 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
   // Estado interno de guardado
   private personaActual: Persona = null;
   private personaId: number = null;
-  private funcionarioActual: Funcionario = null;
 
   constructor(
     private personaService: PersonaService,
@@ -169,7 +168,6 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
   }
 
   private precargar(f: Funcionario): void {
-    this.funcionarioActual = f;
     this.personaActual = f.persona;
     this.personaId = f.persona?.id;
 
@@ -204,7 +202,6 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
   }
 
   private limpiarFormulario(): void {
-    this.funcionarioActual = null;
     this.personaActual = null;
     this.personaId = null;
 
@@ -384,14 +381,13 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
       input.contactoEmergenciaTelefono = this.contactoEmergenciaTelefonoControl.value;
 
       // Este formulario no gestiona cargo/sueldo/credito/horario (tienen sus propias tabs en
-      // el legajo, vía CambioCargoDialogComponent/CambioSalarioDialogComponent). Si ya existe un
-      // funcionario cargado, preservamos esos valores para no pisarlos al guardar desde acá.
-      if (this.funcionarioActual != null) {
-        input.cargoId = this.funcionarioActual.cargo?.id;
-        input.credito = this.funcionarioActual.credito;
-        input.sueldo = this.funcionarioActual.sueldo;
-        input.horarioId = this.funcionarioActual.horario?.id;
-      }
+      // el legajo, vía CambioCargoDialogComponent/CambioSalarioDialogComponent), así que NO
+      // los manda: el backend preserva el valor guardado cuando el input viene sin ellos.
+      //
+      // Antes se reenviaban desde `funcionarioActual`, que es una foto tomada al abrir el
+      // legajo y no se refresca. Si en el medio se cambiaba el salario por su diálogo,
+      // guardar acá lo pisaba con el sueldo viejo — el síntoma era que el salario "volvía"
+      // solo al mínimo legal, que suele ser el valor anterior.
 
       this.funcionarioService.onSaveFuncionario(input).pipe(untilDestroyed(this)).subscribe((funcionarioGuardado: Funcionario) => {
         if (funcionarioGuardado == null) { return; }

--- a/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.ts
+++ b/src/app/modules/rrhh/legajo/legajo-funcionario/legajo-funcionario.component.ts
@@ -101,10 +101,7 @@ export class LegajoFuncionarioComponent implements OnInit {
   onSeleccionar() {
     if (this.funcionarioControl.value == null) { return; }
     this.funcionarioService.onGetFuncionarioById(this.funcionarioControl.value)
-      .pipe(untilDestroyed(this)).subscribe((f: Funcionario) => {
-        this.funcionario = f;
-        this.antiguedadTexto = this.calcularAntiguedad(f?.fechaIngreso);
-      });
+      .pipe(untilDestroyed(this)).subscribe((f: Funcionario) => this.setFuncionario(f));
     this.penalizacionService.onContarAdvertencias(this.funcionarioControl.value)
       .pipe(untilDestroyed(this)).subscribe(n => { this.advertencias = n ?? 0; });
     this.recargar();
@@ -119,6 +116,16 @@ export class LegajoFuncionarioComponent implements OnInit {
     if (funcionarioId == null) { return; }
     this.funcionarioControl.setValue(funcionarioId);
     this.onSeleccionar();
+  }
+
+  /**
+   * Único punto donde se reemplaza el funcionario de la cabecera. Los diálogos del
+   * legajo devuelven el funcionario ya actualizado y todos tienen que recalcular la
+   * antigüedad: hacerlo acá evita que uno se olvide y deje el dato viejo en pantalla.
+   */
+  private setFuncionario(f: Funcionario) {
+    this.funcionario = f;
+    this.antiguedadTexto = this.calcularAntiguedad(f?.fechaIngreso);
   }
 
   private calcularAntiguedad(fechaIngreso: any): string {
@@ -174,7 +181,7 @@ export class LegajoFuncionarioComponent implements OnInit {
         cargoActualNombre: this.funcionario.cargo?.nombre,
         salarioActual: this.funcionario.sueldo
       }, width: '460px', disableClose: true
-    }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => { if (res != null) { this.funcionario = res; this.antiguedadTexto = this.calcularAntiguedad(res?.fechaIngreso); this.recargar(); } });
+    }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => { if (res != null) { this.setFuncionario(res); this.recargar(); } });
   }
 
   onCambiarSalario() {
@@ -184,7 +191,7 @@ export class LegajoFuncionarioComponent implements OnInit {
         salarioActual: this.funcionario.sueldo,
         cargoActual: this.funcionario.cargo?.nombre
       }, width: '520px', disableClose: true
-    }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => { if (res != null) { this.funcionario = res; this.recargar(); } });
+    }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => { if (res != null) { this.setFuncionario(res); this.recargar(); } });
   }
 
   onEgresar() {
@@ -192,7 +199,7 @@ export class LegajoFuncionarioComponent implements OnInit {
       data: { funcionarioId: this.funcionario.id, nombre: this.funcionario.persona?.nombre }, width: '440px', disableClose: true
     }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => {
       if (res != null) {
-        this.funcionario = res;
+        this.setFuncionario(res);
         this.notificacion.notification$.next({ texto: 'Funcionario egresado', color: NotificacionColor.success, duracion: 3 });
       }
     });
@@ -221,7 +228,7 @@ export class LegajoFuncionarioComponent implements OnInit {
       }, width: '480px', disableClose: true
     }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => {
       if (res != null) {
-        this.funcionario = res;
+        this.setFuncionario(res);
         this.notificacion.notification$.next({
           texto: 'Egreso revertido: el funcionario, su usuario y su cliente vuelven a estar activos',
           color: NotificacionColor.success, duracion: 4


### PR DESCRIPTION
Cierra el lado desktop de GabFrank/frc-sistemas-integrados-angular#250.

## Qué resuelve

**1. Ingreso, sucursal y antigüedad desaparecían de la cabecera del legajo.** El fragmento `FUNC_FULL` que devuelven las mutations del legajo no pedía `fechaIngreso`, `sucursal` ni `diarista`, y el componente reemplaza el funcionario de la cabecera con esa respuesta parcial. No era persistente — reaparecían al recargar la pestaña. Afectaba a las cuatro mutations que comparten el fragmento (cambiar salario, cambiar cargo, egresar, revertir egreso), y en cambio de cargo dejaba además la *Antigüedad* en `—`.

**2. El sueldo volvía al valor anterior, típicamente el mínimo legal.** No es el diálogo de salario, que guarda bien: es el botón **Guardar** de "Información general" — el que se usaba como workaround del defecto 1. Reenviaba `sueldo`, `credito`, `cargoId` y `horarioId` desde `funcionarioActual`, una foto cargada al abrir el legajo que nunca se refresca (el fetch es `no-cache`), y pisaba el salario nuevo con el viejo.

**3.** Ajuste pedido aparte: el botón "Poner mínimo" quedaba pegado al hint del mínimo legal.

## Cambios

- `legajo/graphql/graphql-query.ts` — `FUNC_FULL` suma `fechaIngreso`, `sucursal { id nombre }` y `diarista`, con un comentario que explica por qué el fragmento tiene que cubrir todos los campos de la cabecera.
- `legajo-funcionario.component.ts` — `setFuncionario()` como único punto que reemplaza el funcionario y recalcula la antigüedad; lo usan los cuatro diálogos.
- `informacion-general.component.ts` — deja de reenviar `sueldo`/`credito`/`cargoId`/`horarioId`; se elimina el campo `funcionarioActual`, que queda sin uso.
- `cambio-salario-dialog.component.scss` — `margin-top: 12px` y se anula el `margin-bottom` que `fxLayoutGap` inyecta inline (requiere `!important`).

## Depende de

**GabFrank/franco-system-backend-servidor** rama `fix/rrhh-cambio-salario` — sin ese cambio, dejar de mandar `sueldo`/`credito`/`horarioId` los borraría en vez de preservarlos. **Los dos PRs tienen que desplegarse juntos.**

## Cómo probarlo

1. RRHH → Funcionarios → legajo de un funcionario con sueldo, fecha de ingreso y sucursal cargados.
2. Cambiar salario a un valor distinto → Guardar. La cabecera conserva Ingreso, Sucursal y Antigüedad, y muestra el salario nuevo.
3. "Información general" → Guardar. El salario se mantiene.
4. Repetir con un valor menor al mínimo legal: sale el confirm y guarda el valor ingresado, no el mínimo.
5. Cambiar cargo: la Antigüedad ya no queda en `—`.

Probado en local contra central 8081 + filial 8082 sobre datos reales, y verificado por el usuario.

## Riesgo

**Bajo.** Sin migraciones. `npm run check` (AOT) en verde.

Un cambio de comportamiento a tener presente, del lado del central: ahora que preserva `credito` ante un input que no lo trae, vaciar el campo crédito en "Adicionar funcionario" ya no lo borra (poner `0` sigue funcionando).

## Impacto en auto-update

Ninguno. No toca `installer.nsh`, `electron-builder.json` ni los manifests.
