### PR TITLE
fix(movimiento-stock): mostrar el desglose por sucursal segun el filtro aplicado

### DIFF
--- a/src/app/modules/operaciones/movimiento-stock/list-movimiento-stock/list-movimiento-stock.component.html
+++ b/src/app/modules/operaciones/movimiento-stock/list-movimiento-stock/list-movimiento-stock.component.html
@@ -156,16 +156,16 @@
       </div>
 
       <mat-accordion multi="true" class="resumen-accordion">
-        <mat-expansion-panel [disabled]="!stockActualDesglose || stockActualDesglose.length <= 1"
-                             [hideToggle]="!stockActualDesglose || stockActualDesglose.length <= 1"
+        <mat-expansion-panel [disabled]="!desgloseHabilitado"
+                             [hideToggle]="!desgloseHabilitado"
                              style="background-color: transparent; box-shadow: none !important;">
           
           <mat-expansion-panel-header 
-              [class.sin-desplegable]="!stockActualDesglose || stockActualDesglose.length <= 1"
+              [class.sin-desplegable]="!desgloseHabilitado"
               style="padding: 0 5px; height: auto; min-height: 30px;">
             
             <div class="separator-horizontal-bottom" 
-                 [style.padding-right]="(!stockActualDesglose || stockActualDesglose.length <= 1) ? '0px' : ''"
+                 [style.padding-right]="!desgloseHabilitado ? '0px' : ''"
                  fxLayout="row" fxLayoutAlign="space-between center"
                  style="border-bottom: 1px solid; width: 100%; color: white;">
               <div>
@@ -193,14 +193,14 @@
       </div>
       <mat-accordion multi="true" class="resumen-accordion">
         <mat-expansion-panel *ngFor="let item of stockPorTipoMovimiento" 
-                             [disabled]="!item.expanded || item.expanded.length <= 1"
-                             [hideToggle]="!item.expanded || item.expanded.length <= 1"
+                             [disabled]="!desgloseHabilitado"
+                             [hideToggle]="!desgloseHabilitado"
                              style="background-color: transparent; box-shadow: none !important;">
           
-          <mat-expansion-panel-header [class.sin-desplegable]="!item.expanded || item.expanded.length <= 1"
+          <mat-expansion-panel-header [class.sin-desplegable]="!desgloseHabilitado"
           style="padding: 0 5px; height: auto; min-height: 30px;">
           <div class="separator-horizontal-bottom" 
-            [style.padding-right]="(!item.expanded || item.expanded.length <= 1) ? '0px' : ''"
+            [style.padding-right]="!desgloseHabilitado ? '0px' : ''"
             fxLayout="row" fxLayoutAlign="space-between center"
             style="border-bottom: 1px solid; width: 100%; color: white;">
               <div>

--- a/src/app/modules/operaciones/movimiento-stock/list-movimiento-stock/list-movimiento-stock.component.ts
+++ b/src/app/modules/operaciones/movimiento-stock/list-movimiento-stock/list-movimiento-stock.component.ts
@@ -122,6 +122,10 @@ export class ListMovimientoStockComponent implements OnInit {
   selectedPageInfo: PageInfo<MovimientoStock>;
   
   stockActualDesglose: { sucursal: string; stock: number }[] = [];
+  // Habilita el desglose por sucursal en el resumen. Depende de cuántas sucursales
+  // se filtraron, no de cuántas devolvieron datos: un tipo de movimiento que solo
+  // existe en una sucursal igual tiene que mostrar de cuál se trata.
+  desgloseHabilitado = false;
   stockTotal = 0;
   stockPorRangoFecha = 0;
   stockPorTipoMovimiento: StockResumenView[];
@@ -223,6 +227,7 @@ export class ListMovimientoStockComponent implements OnInit {
       this.stockPorRangoFecha = 0;
       this.stockPorTipoMovimiento = [];
       this.stockActualDesglose = [];
+      this.desgloseHabilitado = sucursalIdList.length > 1;
 
       if (this.selectedProducto?.id) {
         


### PR DESCRIPTION
## Problema

En el Resumen lateral de list-movimiento-stock, con varias sucursales filtradas, algunos items (por ejemplo AJUSTE o COMPRA) mostraban un total sin desplegable, asi que no habia forma de saber a que sucursal correspondia ese numero.

## Causa

Los acordeones se habilitaban con `item.expanded.length <= 1`, es decir segun cuantas sucursales **devolvieron datos para ese tipo de movimiento**, no segun cuantas se filtraron. Un AJUSTE que solo existe en una sucursal quedaba con `expanded.length === 1` y por lo tanto `[disabled]` y sin toggle.

## Cambio

- Campo `desgloseHabilitado` en el componente, seteado en `onGetResumen` como `sucursalIdList.length > 1`. Es un campo plano y no un getter, para no llamar funciones desde el HTML (regla de performance del repo).
- Los dos acordeones del resumen ("Stock actual" y "Total por tipo de movimiento") usan ese unico campo en sus cuatro bindings (`disabled`, `hideToggle`, `sin-desplegable`, `padding-right`).

Con mas de una sucursal seleccionada todos los items son expandibles, aunque el detalle muestre una sola linea. Con una sola sucursal se mantiene el comportamiento actual sin desplegable.

## Verificacion

- `npm run check` (build AOT de produccion): 0 errores, solo los warnings conocidos de CommonJS.
- Probado por el usuario en la UI: el desglose ya muestra la sucursal.

PR relacionado: mismo nombre de rama en `franco-system-backend-servidor` (#250), que arregla el error de serializacion Int/Double del mismo modulo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeVu8bzARUfXiyC9U7f8k1
