### PR TITLE
fix(compras): navegacion con enter en el buscador de productos y el dialogo de item

### DIFF
--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/add-edit-item-dialog/add-edit-item-dialog.component.ts
@@ -1996,11 +1996,29 @@ export class AddEditItemDialogComponent implements OnInit {
           }
         }, 0);
       } else {
-        // Si es el último, ir al botón guardar
-        if (this.canSaveComputed) {
-          this.guardarBtn?.focus();
-        }
+        // Si es el último, seguir con vencimiento y luego guardar
+        this.enfocarTrasCantidad();
       }
+    }
+  }
+
+  /**
+   * Destino del foco una vez cargada la cantidad: primero el vencimiento (si el
+   * producto lo maneja, el campo solo existe en ese caso) y recién después el
+   * botón de guardar.
+   */
+  private enfocarTrasCantidad(): void {
+    const vencimiento = this.vencimientoInput?.nativeElement;
+    if (vencimiento) {
+      setTimeout(() => {
+        vencimiento.focus();
+        vencimiento.select?.();
+      }, 0);
+      return;
+    }
+
+    if (this.canSaveComputed) {
+      this.guardarBtn?.focus();
     }
   }
 
@@ -2055,9 +2073,7 @@ export class AddEditItemDialogComponent implements OnInit {
       if (event.key === "Enter") {
         event.preventDefault();
       }
-      if (this.canSaveComputed) {
-        this.guardarBtn?.focus();
-      }
+      this.enfocarTrasCantidad();
     }
   }
 

--- a/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/dialogs/compras-search-producto-dialog/compras-search-producto-dialog.component.ts
@@ -196,7 +196,12 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
     } as ComprasSearchProductoResponse);
   }
 
-  ejecutarBusqueda(texto: string, page: number, append: boolean): void {
+  ejecutarBusqueda(
+    texto: string,
+    page: number,
+    append: boolean,
+    alObtenerResultados?: () => void
+  ): void {
     const termino = (texto ?? '').trim();
     this.terminoBusqueda = termino;
 
@@ -232,6 +237,7 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
           } else {
             this.dataSource.data = productos;
             this.intentarSeleccionPorCoincidenciaExacta(productos);
+            alObtenerResultados?.();
           }
 
           this.cdr.markForCheck();
@@ -357,18 +363,24 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
         this.resaltarFila(index - 1);
         this.expandedProducto = null;
         break;
-      case 'Enter':
-        if (!this.isProductoExpandido(this.dataSource.data[index])) {
-          this.expandirProducto(index);
+      case 'Enter': {
+        const producto = this.dataSource.data[index];
+        if (!producto) {
+          break;
+        }
+
+        // Si la fila ya está expandida y hay una presentación resaltada, se
+        // respeta esa elección. Si no, Enter lleva el producto directo: no
+        // tiene sentido que expanda y obligue a un segundo Enter.
+        const presentacion =
+          producto.presentaciones?.[this.selectedPresentacionRowIndex];
+        if (this.isProductoExpandido(producto) && presentacion) {
+          this.onPresentacionClick(presentacion, producto);
         } else {
-          const producto = this.dataSource.data[index];
-          const presentacion =
-            producto?.presentaciones?.[this.selectedPresentacionRowIndex];
-          if (presentacion) {
-            this.onPresentacionClick(presentacion, producto);
-          }
+          this.seleccionarProducto(producto);
         }
         break;
+      }
       case 'ArrowRight':
         if (this.selectedPresentacionRowIndex === -1) {
           this.resaltarPresentacion(0);
@@ -398,9 +410,56 @@ export class ComprasSearchProductoDialogComponent implements OnInit, AfterViewIn
         this.enfocarTabla();
       }
     } else if (tecla === 'Enter') {
-      const texto = this.formGroup.get('buscarControl')?.value;
-      this.ejecutarBusqueda(texto, 0, false);
+      this.onEnterEnBuscador();
     }
+  }
+
+  /**
+   * Enter en el campo de texto: resuelve la selección en lugar de limitarse a
+   * repetir la búsqueda. Con un único resultado lo devuelve directamente; con
+   * varios baja el foco a la tabla para que el usuario elija con las flechas.
+   */
+  private onEnterEnBuscador(): void {
+    const texto = (this.formGroup.get('buscarControl')?.value ?? '').trim();
+    if (!texto) {
+      return;
+    }
+
+    const resultadosVigentes =
+      !this.busquedaEnCurso &&
+      this.terminoBusqueda === texto &&
+      this.dataSource.data.length > 0;
+
+    if (resultadosVigentes) {
+      this.resolverSeleccionDesdeInput();
+      return;
+    }
+
+    this.ejecutarBusqueda(texto, 0, false, () => this.resolverSeleccionDesdeInput());
+  }
+
+  private resolverSeleccionDesdeInput(): void {
+    const filas = this.dataSource.data;
+    if (filas.length === 0) {
+      return;
+    }
+
+    // Enter siempre lleva un producto: el resaltado si el usuario ya navegó con
+    // las flechas, el primero de la lista si no.
+    const index =
+      this.selectedRowIndex >= 0 && this.selectedRowIndex < filas.length
+        ? this.selectedRowIndex
+        : 0;
+
+    this.seleccionarProducto(filas[index]);
+  }
+
+  /** Cierra devolviendo el producto sin presentación: la elige el diálogo del ítem. */
+  private seleccionarProducto(producto: Producto): void {
+    this.dialogRef.close({
+      producto,
+      searchText: this.formGroup.get('buscarControl')?.value ?? '',
+    } as ComprasSearchProductoResponse);
   }
 
   enfocarTabla(): void {

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.html
@@ -566,6 +566,7 @@
                       type="text"
                       [formControl]="codigoControl"
                       [disabled]="itemsTabState !== 'editable'"
+                      (keydown)="onCodigoKeydown($event)"
                       (keyup.enter)="onSearchPorCodigo()"
                       (keyup.tab)="onSearchPorCodigo()"
                       (focusin)="onCodigoFocus()"

--- a/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
+++ b/src/app/modules/operaciones/compra/gestion-compras/gestion-compras.component.ts
@@ -284,6 +284,8 @@ export class GestionComprasComponent
   // Último texto de búsqueda en el diálogo Añadir Item (persiste dentro de la misma sesión de gestión)
   private lastItemSearchText = '';
   codigoControl = new FormControl<string | null>(null, Validators.required);
+  /** true solo si el keydown de Enter/Tab se produjo sobre el buscador por código. */
+  private codigoKeydownPropio = false;
 
   // Pedido resumen from backend (for edit mode)
   pedidoResumen: PedidoResumen | null = null;
@@ -2342,9 +2344,35 @@ export class GestionComprasComponent
   }
 
   private focusAddItemInput(): void {
+    // Si hay un diálogo abierto encima, el foco le pertenece a él.
+    if (this.hayDialogoAbierto()) {
+      return;
+    }
     if (this.addItemInput?.nativeElement) {
       this.addItemInput.nativeElement.focus();
     }
+  }
+
+  /**
+   * Indica si hay algún diálogo modal abierto por encima de este componente.
+   * Mientras lo haya, el componente de fondo no debe robar el foco ni procesar
+   * atajos globales de teclado: el Enter pertenece al diálogo activo.
+   */
+  private hayDialogoAbierto(): boolean {
+    return this.dialog.openDialogs.length > 0;
+  }
+
+  /**
+   * Devuelve el foco al buscador por código, salvo que para cuando venza el
+   * timer ya se haya abierto un diálogo (p. ej. el de añadir ítem).
+   */
+  private seleccionarCodigoInputDiferido(): void {
+    setTimeout(() => {
+      if (this.hayDialogoAbierto()) {
+        return;
+      }
+      this.addItemInput?.nativeElement?.select();
+    }, 100);
   }
 
   /**
@@ -2424,7 +2452,32 @@ export class GestionComprasComponent
     this.tabService.addTab(new Tab(ProductoComponent, "Nuevo Producto", null, null));
   }
 
+  /**
+   * Registra que el Enter/Tab empezó en este input. El keyup que dispara la
+   * búsqueda solo es válido si su keydown ocurrió aquí.
+   */
+  onCodigoKeydown(event: KeyboardEvent): void {
+    if (event.key === "Enter" || event.key === "Tab") {
+      this.codigoKeydownPropio = true;
+    }
+  }
+
   onSearchPorCodigo(): void {
+    // Keyup huérfano: el keydown ocurrió en otro lado, típicamente el Enter que
+    // seleccionó un producto dentro del diálogo de búsqueda. Al cerrarse el
+    // diálogo MatDialog devuelve el foco a este input y el keyup cae acá,
+    // reabriendo el buscador. Ese Enter no es nuestro.
+    const keydownPropio = this.codigoKeydownPropio;
+    this.codigoKeydownPropio = false;
+    if (!keydownPropio) {
+      return;
+    }
+
+    // Con un diálogo abierto encima, este buscador tampoco debe actuar.
+    if (this.hayDialogoAbierto()) {
+      return;
+    }
+
     if (this.itemsTabState !== "editable") {
       return;
     }
@@ -2458,7 +2511,7 @@ export class GestionComprasComponent
       this.lastItemSearchText = "";
       this.openAddEditItemDialog(producto, undefined, undefined, true);
       this.codigoControl.setValue(null);
-      setTimeout(() => this.addItemInput?.nativeElement?.select(), 100);
+      this.seleccionarCodigoInputDiferido();
     };
 
     const procesarResultados = (productos: Producto[]) => {
@@ -2522,7 +2575,7 @@ export class GestionComprasComponent
       }
 
       this.codigoControl.setValue(null);
-      setTimeout(() => this.addItemInput?.nativeElement?.select(), 100);
+      this.seleccionarCodigoInputDiferido();
     });
   }
 
@@ -2673,7 +2726,7 @@ export class GestionComprasComponent
         }
       }
 
-      setTimeout(() => this.addItemInput?.nativeElement?.select(), 100);
+      this.seleccionarCodigoInputDiferido();
     });
   }
 
@@ -4722,6 +4775,13 @@ export class GestionComprasComponent
       return;
     }
 
+    // Con un diálogo modal abierto, las teclas son del diálogo, no de esta lista.
+    // No alcanza con mirar el target: el foco puede haber quedado en una fila de
+    // fondo (focusProductoProveedorRow) mientras el diálogo sigue visible.
+    if (this.hayDialogoAbierto()) {
+      return;
+    }
+
     // Solo procesar Arrow Up/Down/Enter si no estamos en un input o textarea
     const target = event.target as HTMLElement;
     if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
@@ -4883,6 +4943,12 @@ export class GestionComprasComponent
    * no retenga el foco y el Enter abra directamente el siguiente producto.
    */
   private focusProductoProveedorRow(index: number): void {
+    // Con un diálogo abierto el foco debe quedarse dentro de él; si lo traemos
+    // a la fila de fondo, el Enter del usuario termina abriendo ese producto.
+    if (this.hayDialogoAbierto()) {
+      return;
+    }
+
     const tableContainer = document.querySelector('.productos-proveedor-section .table-content-wrapper');
 
     if (!tableContainer) {


### PR DESCRIPTION
## Qué resuelve

En el tab de **Ítems del Pedido** de Gestión de Compras, el `Enter` no servía para elegir un producto en el diálogo **Buscar Producto**: lo capturaba el componente de fondo y terminaba abriendo el producto ya asociado al proveedor con el cartel *"ya se encuentra en la lista de items, ¿desea modificarlo?"*.

Al destapar eso aparecieron tres problemas encadenados más. Los cinco fixes:

| # | Síntoma | Causa raíz |
|---|---|---|
| 1 | Enter abría el producto del proveedor en vez de seleccionar en el buscador | El listener global de `keydown` sobre `document` (`onProductosProveedorKeydown`) y los `setTimeout` que mueven el foco (`focusProductoProveedorRow`, `focusAddItemInput`, los `select()` diferidos) no miraban si había un modal abierto. El foco terminaba en un `<tr>` de fondo y las guardas por `event.target` no alcanzaban. |
| 2 | Al seleccionar un producto, el buscador se reabría solo | `keyup` huérfano: el `keydown` del Enter lo consumía el diálogo (`stopPropagation` + `preventDefault`), y al cerrarse MatDialog devolvía el foco al input "Código de barra", donde caía el `keyup` y disparaba `(keyup.enter)="onSearchPorCodigo()"` de nuevo. |
| 3 | Enter en el campo de texto del buscador no cargaba nada | `keydownEvent()` con Enter solo repetía la misma búsqueda; nunca seleccionaba. |
| 4 | Enter sobre una fila expandía en vez de llevar el producto | Flujo de dos pasos: primer Enter expandía presentaciones, segundo elegía. |
| 5 | Enter en la cantidad se salteaba el vencimiento | Los dos handlers de cantidad saltaban directo a `guardarBtn`. |

## Cómo se resolvió

- **Invariante nueva:** el componente de fondo no reacciona al teclado ni roba el foco mientras hay un modal arriba. Helper `hayDialogoAbierto()` (`this.dialog.openDialogs.length > 0`) aplicado en el listener global y en cada punto que mueve el foco por `setTimeout`.
- **Flag `codigoKeydownPropio`:** el `keyup` del input de código solo dispara la búsqueda si su `keydown` empezó en ese mismo input.
- **`Enter` uniforme en el buscador:** siempre lleva un producto al diálogo de ítem — la fila resaltada si navegaste con las flechas, la primera si no. Si la fila ya está expandida y hay una presentación resaltada, se respeta esa elección. La presentación se elige en el diálogo del ítem, que abre el select automáticamente cuando llega un producto sin presentación.
- **Recorrido con Enter en el diálogo de ítem:** precio unitario → cantidad a pedir → siguientes filas de distribución → **vencimiento esperado** → guardar. El vencimiento se saltea solo cuando el producto no lo maneja (el campo está bajo `*ngIf`).

## Cómo probarlo

Pedido en estado **EN PLANIFICACIÓN**, tab "2. Ítems del Pedido":

1. Escribir un texto en "Código de barra" y `Enter` → abre el buscador. Escribir y dar `Enter` → el producto se carga en "Añadir Nuevo Ítem" y el foco queda en el select de Presentación, desplegado.
2. Repetir bajando con `↓` a la lista y dando `Enter` sobre una fila → mismo resultado.
3. Verificar que el buscador **no** se reabre solo después de seleccionar.
4. Con un producto seleccionado en "Productos del proveedor" y el buscador abierto, dar `Enter` → debe actuar el buscador, **no** aparecer el cartel "¿desea modificarlo?".
5. Cargar la cantidad y dar `Enter` → el foco debe ir a "Vencimiento Esperado" (o directo a Guardar si el producto no maneja vencimiento) y recién de ahí al botón.

## Riesgo

**Bajo.** Cambios acotados a `gestion-compras` y sus diálogos de compras; no se toca modelo de datos, GraphQL ni schema. El único cambio de comportamiento deliberado fuera del bug reportado es que `Enter` sobre una fila del buscador ya no expande presentaciones: ahora lleva el producto directo (se pidió explícitamente). La elección de presentación por mouse y el flujo expandido siguen funcionando.

## Impacto en auto-update

Ninguno. No se tocan `installer.nsh`, `electron-builder.json`, manifests YAML ni nombres de artefactos.

## Verificación

`npm run check` (build AOT de producción) en verde después de cada cambio.
No se corrieron unit tests: en este repo Karma no compila (devkit v16 vs Angular 15.1.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnCTjC94GbUMFmF3ETbsJD
