### PR TITLE
fix(factura-legal): duplicado contra el backend correcto y fila fantasma en la lista

### DIFF
--- a/src/app/generics/generic-crud.service.ts
+++ b/src/app/generics/generic-crud.service.ts
@@ -160,6 +160,11 @@ export class GenericCrudService {
                 color: NotificacionColor.danger,
                 duracion: 3,
               });
+              // Cerrar el observable igual: si no, el que llamo queda esperando para
+              // siempre una respuesta que ya no va a llegar. Con errorPolicy 'all' puede
+              // venir data parcial, asi que se emite lo que haya en vez de descartarla.
+              obs.next(res.data?.["data"] ?? null);
+              obs.complete();
             }
           },
           error: (error) => {

--- a/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
+++ b/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
@@ -722,7 +722,11 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
         this.mainService?.usuarioActual?.id,
         this.selectedCliente?.id,
         totalFinal,
-        items
+        items,
+        // En modo servidor la factura va a la sucursal elegida a mano, y es contra esa
+        // sucursal que hay que buscar el duplicado; el central no la puede deducir solo.
+        this.isServidor ? this.selectedSucursal?.id : null,
+        this.isServidor
       )
       .pipe(
         switchMap((facturaSimilar) => {

--- a/src/app/modules/financiero/factura-legal/factura-legal.service.ts
+++ b/src/app/modules/financiero/factura-legal/factura-legal.service.ts
@@ -86,6 +86,7 @@ export class FacturaLegalService {
     clienteId: number,
     totalFinal: number,
     items: FacturaLegalItemInput[],
+    sucursalId: number = null,
     servidor: boolean = false
   ): Observable<FacturaSimilar> {
     if (
@@ -102,7 +103,7 @@ export class FacturaLegalService {
     return this.genericService
       .onCustomQuery(
         this.facturaSimilarRecienteGQL,
-        { usuarioId, clienteId, totalFinal, items },
+        { usuarioId, clienteId, totalFinal, items, sucursalId },
         servidor,
         null,
         true

--- a/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/factura-legal/graphql/graphql-query.ts
@@ -267,12 +267,14 @@ export const facturaSimilarRecienteQuery = gql`
     $clienteId: ID
     $totalFinal: Float!
     $items: [FacturaLegalItemInput]
+    $sucursalId: ID
   ) {
     data: facturaSimilarReciente(
       usuarioId: $usuarioId
       clienteId: $clienteId
       totalFinal: $totalFinal
       items: $items
+      sucursalId: $sucursalId
     ) {
       facturaLegalId
       numeroFactura

--- a/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
+++ b/src/app/modules/financiero/factura-legal/list-factura-legal/list-factura-legal.component.ts
@@ -8,7 +8,6 @@ import {
 import { FormControl, FormGroup, Validators } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import { updateDataSource } from "../../../../commons/core/utils/numbersUtils";
 import { CargandoDialogService } from "../../../../shared/components/cargando-dialog/cargando-dialog.service";
 import { ConfirmDialogComponent } from "../../../../shared/components/confirm-dialog/confirm-dialog.component";
 import { NotificacionSnackbarService } from "../../../../notificacion-snackbar.service";
@@ -342,8 +341,13 @@ export class ListFacturaLegalComponent implements OnInit {
       })
       .afterClosed()
       .subscribe((res) => {
-        if (res != null) {
-          this.dataSource.data = updateDataSource(this.dataSource.data, res);
+        // El dialogo no devuelve la factura creada sino un acuse
+        // ({facturado, cliente, facturaLegalId}), asi que no se puede insertar en la
+        // tabla como si fuera una FacturaLegal: entraba una fila con todas las columnas
+        // vacias y sin id, y al expandirla la consulta de items fallaba por id null.
+        // Se recarga la busqueda, que es de donde salen las filas bien formadas.
+        if (res?.facturado === true) {
+          this.onGetFacturas();
         }
       });
   }
@@ -396,6 +400,16 @@ export class ListFacturaLegalComponent implements OnInit {
   onToggleExpand(factura: FacturaLegal) {
     if (this.expandedElement === factura) {
       this.expandedElement = null;
+      return;
+    }
+
+    // Sin id no hay a quien pedirle los items: la consulta declara id como ID! y
+    // rechazaria la variable en null con un error que no le dice nada al cajero.
+    if (factura?.id == null) {
+      this.expandedElement = factura;
+      this.cargandoItems = false;
+      this.totalItemsFactura = 0;
+      this.facturaItemDataSource.data = [];
       return;
     }
 


### PR DESCRIPTION
Tres arreglos del módulo de factura legal, en **commits separados** para que se puedan revisar y revertir por separado.

## 1. `abc8f44a` — el duplicado se consultaba mal

En modo servidor el diálogo no pasaba el flag `servidor` a `onVerificarFacturaSimilar`, así que la consulta salía por el cliente por defecto, y tampoco mandaba la sucursal elegida a mano. Se agrega `sucursalId` a la query y el diálogo manda ambos datos.

Fuera de modo servidor no cambia nada: `sucursalId` va en null y el filial sigue usando la suya.

> Requiere los PRs de backend: GabFrank/franco-system-backend-servidor#251 y GabFrank/franco-system-backend-filial#111.

## 2. `e56d9ec1` — la fila vacía de la lista

Al emitir, el diálogo cierra con un acuse (`{facturado, cliente, facturaLegalId}`), no con la `FacturaLegal` creada — los 5 `close()` exitosos lo hacen así. `onAdd` lo insertaba igual en la tabla, así que aparecía una fila con todas las columnas vacías y con los chips PAPEL e INACTIVA, porque `isElectronico` y `activo` venían `undefined`. Al desplegarla se consultaban los items con `id` null:

```
Variable 'id' has coerced Null value for NonNull type 'ID!'
```

Ahora se recarga la búsqueda, que es de donde salen las filas bien formadas, y `onToggleExpand` no consulta items si la factura no tiene id.

Dos consecuencias visibles: si el filtro actual no coincide con la sucursal o fecha de la factura recién emitida, no va a aparecer en la lista (antes aparecía la fila rota), y se dispara un request de búsqueda extra por emisión.

## 3. `5925394c` — `onCustomQuery` dejaba el observable colgado

Cuando la respuesta traía `errors` se mostraba el snackbar y **no** se llamaba a `obs.next`, `complete` ni `error`: el que llamó quedaba esperando para siempre. En la verificación de duplicado el `timeout` de 5 s lo tapaba —de ahí la espera antes de poder emitir—, pero cualquier llamada sin timeout propio se cuelga.

⚠️ **Este commit es el de mayor radio de impacto del PR** y conviene decidirlo aparte. `onCustomQuery` tiene **376 llamadas en 106 archivos**. El cambio afecta **solo el camino de error**: antes colgaba, ahora emite lo que haya en `data` (con `errorPolicy: 'all'` puede venir parcial) y completa. Lo atenúa que los consumidores ya reciben null de forma rutinaria en el camino feliz —`facturaLegalByCdc` devuelve null cuando no encuentra—, pero un consumidor que asigne el resultado a una lista podría vaciarla ante un error transitorio, donde antes conservaba el valor viejo.

**No es necesario para el fix**: una vez que la query existe en el central, esa rama deja de dispararse en este flujo. Si se prefiere un hotfix de riesgo mínimo, se puede dropear este commit y dejarlo para un release normal con prueba de regresión. El mismo branch muerto existe en otras tres funciones del archivo (~103, ~280, ~857) y **no** se tocaron.

## Impacto en la facturación

La emisión —papel y electrónica— va toda por `onCustomMutation`, que **no se toca**: el diff de `generic-crud.service.ts` son 5 líneas, todas dentro de `onCustomQuery`.

## Verificación

- `npm run check` (build de producción AOT) ✅ exit 0, sin errores TS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNH1tFMSRTe8cowpR3mxoP