### PR TITLE
fix(marcacion): habilitar el ajuste a 8 horas en jornadas cerradas mal

### DIFF
--- a/src/app/modules/administrativo/marcacion/pages/list-marcacion/list-marcacion.component.html
+++ b/src/app/modules/administrativo/marcacion/pages/list-marcacion/list-marcacion.component.html
@@ -160,7 +160,7 @@
                         <mat-icon>more_vert</mat-icon>
                     </button>
                     <mat-menu #menu="matMenu">
-                        <button mat-menu-item (click)="onAjustar8Horas(marcacion)" [disabled]="marcacion.estado !== estadoJornada.INCOMPLETO">
+                        <button mat-menu-item (click)="onAjustar8Horas(marcacion)" [disabled]="!puedeAjustarA8Horas(marcacion)">
                             <mat-icon>timer</mat-icon>
                             <span>Ajustar 8 Horas</span>
                         </button>

--- a/src/app/modules/administrativo/marcacion/pages/list-marcacion/list-marcacion.component.ts
+++ b/src/app/modules/administrativo/marcacion/pages/list-marcacion/list-marcacion.component.ts
@@ -425,6 +425,18 @@ export class ListMarcacionComponent implements OnInit {
     this.marcacionService.onImprimirReporteMarcaciones(usuarioId, fechaInicio, fechaFin);
   }
 
+  /**
+   * Se puede ajustar a 8 horas una jornada que quedó incompleta, y también una que cerró
+   * mal: cuando alguien olvida marcar la salida, la entrada del día siguiente le cierra la
+   * jornada y le deja horas extras que no hizo. Esa queda en NORMAL, así que antes el ajuste
+   * aparecía deshabilitado justo en el caso donde hace falta.
+   */
+  puedeAjustarA8Horas(jornada: any): boolean {
+    if (!jornada) return false;
+    if (jornada.estado === this.estadoJornada.INCOMPLETO) return true;
+    return (jornada.minutosExtras || 0) > 0;
+  }
+
   onAjustar8Horas(marcacion: any): void {
     this.matDialog.open(ObservacionJornadaDialogComponent, {
       data: {


### PR DESCRIPTION
## Qué resuelve

"Ajustar 8 Horas" solo se habilitaba con la jornada en `INCOMPLETO`.

Cuando alguien olvida marcar la salida, la entrada del día siguiente le cierra la jornada: queda en `NORMAL` y con horas extras que no hizo (se vieron casos de 16 h de "extra" en un día). Justo en ese caso la acción aparecía deshabilitada, así que no había forma de corregirla desde la pantalla.

Ahora se habilita también cuando la jornada tiene minutos extras acumulados. Sigue deshabilitada en jornadas normales sin nada que corregir, para no pisar datos buenos por accidente.

## Cómo probarlo

```bash
npm run check
```

Build de producción sin errores (los warnings de CommonJS son preexistentes y ajenos a este cambio).

En la pantalla de Marcaciones, sobre una jornada en `NORMAL` con horas extras cargadas, el menú de tres puntos ahora ofrece "Ajustar 8 Horas" habilitado. Abre el diálogo de observación de siempre y deja la jornada en 08:00 trabajadas / 00:00 extras.

> Este repo no corre unit tests: el devkit v16 no compila contra Angular 15.1.5.

## Impacto en DB

Ninguno. El backend tampoco cambia: `ajustarA8Horas` ya aceptaba cualquier jornada y guarda la observación del diálogo. La restricción era puramente visual.

## Impacto en rollback

Limpio. Son 13 líneas en 2 archivos; revertir el commit devuelve el botón a su condición anterior sin efectos residuales.

## Riesgo

**Bajo.** Habilita una acción manual que ya existía, ya pasa por un diálogo de confirmación y ya deja observación registrada en la jornada.

## Nota de despliegue

Acompaña al PR `GabFrank/franco-system-backend-servidor#254`, que corrige el cálculo de horas extras. Conviene **desplegar el backend primero**: si va este solo, el botón se habilita pero el cálculo sigue viejo. No rompe nada, solo queda a medio camino.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hnd9a7crAZxYKz6mbD1yS
