### PR TITLE
feat(usuarios): seleccionar y agregar varios roles a la vez [FRC]

### DIFF
--- a/src/app/modules/configuracion/roles/graphql/graphql-query.ts
+++ b/src/app/modules/configuracion/roles/graphql/graphql-query.ts
@@ -102,6 +102,24 @@ export const saveUsuarioRole = gql`
   }
 `;
 
+export const saveUsuarioRoleList = gql`
+  mutation saveUsuarioRoleList($entity: [UsuarioRoleInput!]!) {
+    data: saveUsuarioRoleList(usuarioRoleList: $entity) {
+      id
+      role {
+        id
+        nombre
+      }
+      creadoEn
+      usuario {
+        persona {
+          nombre
+        }
+      }
+    }
+  }
+`;
+
 export const deleteUsuarioRoleQuery = gql`
   mutation deleteUsuarioRole($id: ID!) {
     deleteUsuarioRole(id: $id)

--- a/src/app/modules/configuracion/roles/graphql/saveUsuarioRoleList.ts
+++ b/src/app/modules/configuracion/roles/graphql/saveUsuarioRoleList.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { UsuarioRole } from '../role.model';
+import { saveUsuarioRoleList } from './graphql-query';
+
+export interface Response {
+  data: UsuarioRole[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SaveUsuarioRoleListGQL extends Mutation<Response> {
+  document = saveUsuarioRoleList;
+}

--- a/src/app/modules/configuracion/roles/role.service.ts
+++ b/src/app/modules/configuracion/roles/role.service.ts
@@ -7,6 +7,7 @@ import { RoleByIdGQL } from './graphql/roleById';
 import { RolesGQL } from './graphql/rolesQuery';
 import { SaveRoleGQL } from './graphql/saveRole';
 import { SaveUsuarioRoleGQL } from './graphql/saveUsuarioRole';
+import { SaveUsuarioRoleListGQL } from './graphql/saveUsuarioRoleList';
 import { UsuarioRolePorUsuarioIdGQL } from './graphql/usuarioRolePorUsuarioId';
 import { Role, UsuarioRole } from './role.model';
 
@@ -24,6 +25,7 @@ export class RoleService {
     private deleteRole: DeleteRoleGQL,
     private getUsuarioRolePorUsuarioId: UsuarioRolePorUsuarioIdGQL,
     private saveUsuarioRole: SaveUsuarioRoleGQL,
+    private saveUsuarioRoleList: SaveUsuarioRoleListGQL,
     private deleteUsuarioRole: DeleteUsuarioRoleGQL,
     private injector: Injector
   ) {
@@ -52,6 +54,10 @@ export class RoleService {
 
   onSaveUsuarioRole(input): Observable<UsuarioRole> {
     return this.genericCrud.onSave(this.saveUsuarioRole, input)
+  }
+
+  onSaveUsuarioRoleList(inputList): Observable<UsuarioRole[]> {
+    return this.genericCrud.onSave(this.saveUsuarioRoleList, inputList)
   }
 
   onDeleteUsuarioRole(id): Observable<boolean> {

--- a/src/app/modules/personas/usuarios/adicionar-usuario-dialog/adicionar-usuario-dialog.component.ts
+++ b/src/app/modules/personas/usuarios/adicionar-usuario-dialog/adicionar-usuario-dialog.component.ts
@@ -117,13 +117,17 @@ export class AdicionarUsuarioDialogComponent implements OnInit {
   onAddUsuarioRole() {
     const openSearch = () => {
       this.onSearchRole().pipe(untilDestroyed(this)).subscribe((res) => {
-        if (res != null) {
-          const selectedRole: Role = res;
-          const input = new UsuarioRoleInput;
-          input.roleId = selectedRole.id;
-          input.userId = this.selectedUsuario.id;
-          this.roleService.onSaveUsuarioRole(input).pipe(untilDestroyed(this)).subscribe(saveRes => {
-            this.usuarioRoleList.data = updateDataSource(this.usuarioRoleList.data, saveRes)
+        if (res != null && res.length > 0) {
+          const inputList = res.map(role => {
+            const input = new UsuarioRoleInput;
+            input.roleId = role.id;
+            input.userId = this.selectedUsuario.id;
+            return input;
+          });
+          this.roleService.onSaveUsuarioRoleList(inputList).pipe(untilDestroyed(this)).subscribe(saveRes => {
+            if (saveRes != null) {
+              this.usuarioRoleList.data = [...saveRes, ...this.usuarioRoleList.data]
+            }
           })
         }
       })
@@ -139,9 +143,11 @@ export class AdicionarUsuarioDialogComponent implements OnInit {
     }
   }
 
-  onSearchRole(): Observable<Role> {
+  onSearchRole(): Observable<Role[]> {
     const data: SearchListtDialogData = {
-      titulo: "Seleccionar rol",
+      titulo: "Seleccionar roles",
+      multiple: true,
+      labelAceptar: "Agregar",
       query: null,
       tableData: [
         { id: "id", nombre: "Id", width: "20%" },

--- a/src/app/shared/components/search-list-dialog/search-list-dialog.component.html
+++ b/src/app/shared/components/search-list-dialog/search-list-dialog.component.html
@@ -114,7 +114,7 @@
         [disabled]="cantidadSeleccionados() === 0"
         class="apply-btn">
         <mat-icon>check</mat-icon>
-        Aplicar filtro ({{ cantidadSeleccionados() }})
+        {{ data?.labelAceptar || 'Aplicar filtro' }} ({{ cantidadSeleccionados() }})
       </button>
 
       <button *ngIf="!data?.multiple" mat-raised-button color="primary" (click)="onAceptar()" [disabled]="selectedItem == null">

--- a/src/app/shared/components/search-list-dialog/search-list-dialog.component.ts
+++ b/src/app/shared/components/search-list-dialog/search-list-dialog.component.ts
@@ -49,6 +49,8 @@ export class SearchListtDialogData {
   searchFieldName?: string;
   textHint?: string;
   fallbackToLocal?: boolean = false;
+  /** Texto del boton de confirmacion en modo multiple. Default: 'Aplicar filtro' */
+  labelAceptar?: string;
 }
 
 @UntilDestroy({ checkProperties: true })


### PR DESCRIPTION
## Qué resuelve

Para asignar roles a un usuario había que abrir el diálogo "Seleccionar rol", elegir uno, guardar, y repetir por cada rol. Ahora el diálogo se abre en modo múltiple con checkboxes y se agregan todos de una.

## Qué cambia

- `adicionar-usuario-dialog.component.ts` — abre `SearchListDialogComponent` con `multiple: true`; `onSearchRole()` pasa a devolver `Role[]` y `onAddUsuarioRole()` manda todos los seleccionados en una sola llamada.
- `role.service.ts` + `graphql/saveUsuarioRoleList.ts` (nuevo) + `graphql-query.ts` — cliente de la nueva mutation `saveUsuarioRoleList`.
- `search-list-dialog.component` — nuevo `labelAceptar?: string` opcional en `SearchListtDialogData`, default `'Aplicar filtro'`. Sin este parámetro el componente se comporta exactamente igual que antes.

El modo múltiple (checkboxes, `seleccionadosMap`, botón con contador) ya existía en el diálogo compartido; este PR solo lo usa desde roles. Los roles que el usuario ya tiene se siguen filtrando de la lista.

## Dependencia

Necesita el PR del backend que agrega `saveUsuarioRoleList` (`franco-system-backend-servidor`). Es un cambio de API **aditivo**: `saveUsuarioRole` queda intacto, así que nada existente se rompe, pero el botón "Agregar" de este PR no funciona hasta que el central esté desplegado.

## Cómo probarlo

1. Usuarios → editar un usuario → botón de agregar rol.
2. El diálogo dice "Seleccionar roles" y cada fila tiene checkbox.
3. Marcar varios, "Agregar (N)" → los N aparecen en la tabla de roles del usuario.
4. Reabrir el diálogo: los recién agregados ya no aparecen en la lista.
5. Regresión: gráficos → venta por funcionario, y reportes → lucro por funcionario. Ambos usan `multiple: true` y deben seguir mostrando "Aplicar filtro (N)".

## Impacto

- **DB:** ninguno, sin migraciones.
- **Rollback:** limpio, solo se revierte el front.
- **Riesgo:** bajo. El único archivo compartido es `search-list-dialog`, y el cambio ahí es un parámetro opcional con default igual al comportamiento actual.

## Verificación

`npm run check` (build de producción AOT) en verde. Karma sigue sin compilar en este repo (devkit v16 vs Angular 15.1.5), así que no hay unit tests nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyppKiNNxzE37GnTtrZEW6