### PR TITLE
feat(rrhh): abm de conceptos de liquidacion con es_remunerativo explicito

### DIFF
--- a/src/app/modules/rrhh/liquidacion-concepto/edit-liquidacion-concepto-dialog/edit-liquidacion-concepto-dialog.component.html
+++ b/src/app/modules/rrhh/liquidacion-concepto/edit-liquidacion-concepto-dialog/edit-liquidacion-concepto-dialog.component.html
@@ -1,0 +1,60 @@
+<div class="concepto">
+  <div class="concepto__banda">
+    <mat-icon>playlist_add_check</mat-icon>
+    <div class="concepto__titulo">
+      <h3>{{ selectedConcepto.id ? 'Editar concepto' : 'Nuevo concepto' }}</h3>
+      <span>{{ selectedConcepto.id ? selectedConcepto.codigo : 'Catálogo de liquidación' }}</span>
+    </div>
+  </div>
+
+  <form class="concepto__cuerpo" [formGroup]="formGroup">
+    <mat-form-field class="concepto__campo">
+      <mat-label>Código</mat-label>
+      <input matInput [formControl]="codigoControl" required />
+      <mat-error *ngIf="codigoControl.hasError('required')">Ingresá el código</mat-error>
+    </mat-form-field>
+
+    <mat-form-field class="concepto__campo">
+      <mat-label>Descripción</mat-label>
+      <input matInput [formControl]="descripcionControl" required />
+      <mat-error *ngIf="descripcionControl.hasError('required')">Ingresá la descripción</mat-error>
+    </mat-form-field>
+
+    <mat-form-field class="concepto__campo">
+      <mat-label>Tipo</mat-label>
+      <mat-select [formControl]="esHaberControl" required>
+        <mat-option [value]="true">Haber (suma)</mat-option>
+        <mat-option [value]="false">Descuento (resta)</mat-option>
+      </mat-select>
+      <mat-error *ngIf="esHaberControl.hasError('required')">Elegí si suma o resta</mat-error>
+    </mat-form-field>
+
+    <mat-form-field class="concepto__campo">
+      <mat-label>¿Es remunerativo?</mat-label>
+      <mat-select [formControl]="esRemunerativoControl" required>
+        <mat-option [value]="true">Sí</mat-option>
+        <mat-option [value]="false">No</mat-option>
+      </mat-select>
+      <mat-error *ngIf="esRemunerativoControl.hasError('required')">Elegí una opción</mat-error>
+    </mat-form-field>
+
+    <p class="concepto__nota">Entra a la base del aguinaldo, del IPS del finiquito y de la indemnización.</p>
+
+    <div class="concepto__checks">
+      <mat-checkbox [formControl]="esCalculadoAutoControl">Lo calcula el sistema</mat-checkbox>
+      <mat-checkbox [formControl]="activoControl">Activo</mat-checkbox>
+    </div>
+  </form>
+
+  <div class="concepto__pie">
+    <div class="concepto__estado" *ngIf="!isEditting">
+      <mat-icon>lock</mat-icon>
+      <span>Solo lectura</span>
+    </div>
+    <div class="concepto__acciones">
+      <button mat-stroked-button (click)="onCancelar()">Cancelar</button>
+      <button *ngIf="!isEditting" mat-raised-button color="accent" (click)="onHabilitarEdicion()">Editar</button>
+      <button *ngIf="isEditting" mat-raised-button color="accent" [disabled]="formGroup.invalid" (click)="onGuardar()">Guardar</button>
+    </div>
+  </div>
+</div>

--- a/src/app/modules/rrhh/liquidacion-concepto/edit-liquidacion-concepto-dialog/edit-liquidacion-concepto-dialog.component.scss
+++ b/src/app/modules/rrhh/liquidacion-concepto/edit-liquidacion-concepto-dialog/edit-liquidacion-concepto-dialog.component.scss
@@ -1,0 +1,103 @@
+// Cabecera con el degradado del dialogo de montos corregidos de un conteo
+// (historial-conteo-dialog). El cuerpo va sin paneles: hereda el fondo del dialogo.
+.concepto {
+  width: 100%;
+  box-sizing: border-box;
+
+  &__banda {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 20px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #ffffff;
+
+    mat-icon {
+      font-size: 32px;
+      width: 32px;
+      height: 32px;
+    }
+
+    h3 {
+      margin: 0;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    }
+
+    span {
+      font-size: 0.8em;
+      opacity: 0.85;
+    }
+  }
+
+  &__titulo {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__cuerpo {
+    display: flex;
+    flex-direction: column;
+    padding: 18px 20px 4px;
+  }
+
+  &__campo {
+    width: 100%;
+  }
+
+  &__nota {
+    margin: -2px 0 14px;
+    font-size: 0.78em;
+    line-height: 1.35;
+    opacity: 0.6;
+  }
+
+  &__checks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    padding-bottom: 6px;
+  }
+
+  &__pie {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 20px 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  &__acciones {
+    display: flex;
+    gap: 10px;
+    margin-left: auto;
+  }
+
+  &__estado {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 0.78em;
+
+    mat-icon {
+      font-size: 15px;
+      width: 15px;
+      height: 15px;
+    }
+  }
+}
+
+// styles.scss:276 le pone `height: 0px !important` al subscript de TODOS los form-field,
+// asi que un mat-error se dibuja fuera de su caja y se monta sobre el campo siguiente.
+// Aca se le devuelve el alto para que el error empuje en vez de superponerse.
+:host ::ng-deep .concepto .mat-mdc-form-field-subscript-wrapper {
+  height: auto !important;
+  min-height: 18px;
+}

--- a/src/app/modules/rrhh/liquidacion-concepto/edit-liquidacion-concepto-dialog/edit-liquidacion-concepto-dialog.component.ts
+++ b/src/app/modules/rrhh/liquidacion-concepto/edit-liquidacion-concepto-dialog/edit-liquidacion-concepto-dialog.component.ts
@@ -1,0 +1,95 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { MainService } from '../../../../main.service';
+import { LiquidacionConcepto } from '../liquidacion-concepto.model';
+import { LiquidacionConceptoService } from '../liquidacion-concepto.service';
+
+export interface LiquidacionConceptoDialogData {
+  concepto: LiquidacionConcepto;
+}
+
+@UntilDestroy()
+@Component({
+  selector: 'app-edit-liquidacion-concepto-dialog',
+  templateUrl: './edit-liquidacion-concepto-dialog.component.html',
+  styleUrls: ['./edit-liquidacion-concepto-dialog.component.scss']
+})
+export class EditLiquidacionConceptoDialogComponent implements OnInit {
+
+  selectedConcepto: LiquidacionConcepto;
+  formGroup: FormGroup;
+  isEditting = false;
+
+  codigoControl = new FormControl(null, [Validators.required]);
+  descripcionControl = new FormControl(null, [Validators.required]);
+  esHaberControl = new FormControl(null, [Validators.required]);
+  /**
+   * Arranca en null a proposito, incluso en el alta: la columna tiene DEFAULT TRUE, asi
+   * que un concepto que se guarde sin elegir entra a la base del aguinaldo y del IPS sin
+   * que nadie lo haya decidido. El required obliga a que la decision sea explicita.
+   */
+  esRemunerativoControl = new FormControl(null, [Validators.required]);
+  esCalculadoAutoControl = new FormControl(false);
+  activoControl = new FormControl(true);
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) private data: LiquidacionConceptoDialogData,
+    private dialogRef: MatDialogRef<EditLiquidacionConceptoDialogComponent>,
+    private liquidacionConceptoService: LiquidacionConceptoService,
+    private mainService: MainService
+  ) {
+    this.selectedConcepto = data?.concepto != null ? data.concepto : new LiquidacionConcepto();
+  }
+
+  ngOnInit(): void {
+    this.formGroup = new FormGroup({
+      codigo: this.codigoControl,
+      descripcion: this.descripcionControl,
+      esHaber: this.esHaberControl,
+      esRemunerativo: this.esRemunerativoControl,
+      esCalculadoAuto: this.esCalculadoAutoControl,
+      activo: this.activoControl
+    });
+
+    if (this.selectedConcepto.id) {
+      this.codigoControl.setValue(this.selectedConcepto.codigo);
+      this.descripcionControl.setValue(this.selectedConcepto.descripcion);
+      this.esHaberControl.setValue(this.selectedConcepto.esHaber);
+      this.esRemunerativoControl.setValue(this.selectedConcepto.esRemunerativo);
+      this.esCalculadoAutoControl.setValue(this.selectedConcepto.esCalculadoAuto === true);
+      this.activoControl.setValue(this.selectedConcepto.activo !== false);
+      this.formGroup.disable();
+    } else {
+      this.isEditting = true;
+    }
+  }
+
+  onHabilitarEdicion() {
+    this.isEditting = true;
+    this.formGroup.enable();
+  }
+
+  onCancelar() {
+    this.dialogRef.close(null);
+  }
+
+  onGuardar() {
+    if (this.formGroup.invalid) { return; }
+    // Apollo congela los resultados: se clona antes de mutar.
+    const aux = new LiquidacionConcepto();
+    Object.assign(aux, this.selectedConcepto);
+    aux.codigo = this.codigoControl.value?.trim().toUpperCase();
+    aux.descripcion = this.descripcionControl.value ? this.descripcionControl.value.toUpperCase() : null;
+    aux.esHaber = this.esHaberControl.value;
+    aux.esRemunerativo = this.esRemunerativoControl.value;
+    aux.esCalculadoAuto = this.esCalculadoAutoControl.value === true;
+    aux.activo = this.activoControl.value === true;
+    aux.usuario = this.mainService.usuarioActual;
+
+    this.liquidacionConceptoService.onSave(aux.toInput())
+      .pipe(untilDestroyed(this))
+      .subscribe(res => { if (res != null) this.dialogRef.close(res); });
+  }
+}

--- a/src/app/modules/rrhh/liquidacion-concepto/graphql/DeleteLiquidacionConcepto.ts
+++ b/src/app/modules/rrhh/liquidacion-concepto/graphql/DeleteLiquidacionConcepto.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { deleteLiquidacionConceptoQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class DeleteLiquidacionConceptoGQL extends Mutation<Response> { document = deleteLiquidacionConceptoQuery; }

--- a/src/app/modules/rrhh/liquidacion-concepto/graphql/LiquidacionConceptos.ts
+++ b/src/app/modules/rrhh/liquidacion-concepto/graphql/LiquidacionConceptos.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { LiquidacionConcepto } from '../liquidacion-concepto.model';
+import { liquidacionConceptosQuery } from './graphql-query';
+
+export interface Response {
+  data: LiquidacionConcepto[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class LiquidacionConceptosGQL extends Query<Response> {
+  document = liquidacionConceptosQuery;
+}

--- a/src/app/modules/rrhh/liquidacion-concepto/graphql/SaveLiquidacionConcepto.ts
+++ b/src/app/modules/rrhh/liquidacion-concepto/graphql/SaveLiquidacionConcepto.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { saveLiquidacionConceptoQuery } from './graphql-query';
+
+export interface Response { data: any; }
+
+@Injectable({ providedIn: 'root' })
+export class SaveLiquidacionConceptoGQL extends Mutation<Response> { document = saveLiquidacionConceptoQuery; }

--- a/src/app/modules/rrhh/liquidacion-concepto/graphql/graphql-query.ts
+++ b/src/app/modules/rrhh/liquidacion-concepto/graphql/graphql-query.ts
@@ -1,0 +1,29 @@
+import gql from "graphql-tag";
+
+const LIQUIDACION_CONCEPTO_FIELDS = `
+  id
+  codigo
+  descripcion
+  esHaber
+  esCalculadoAuto
+  esRemunerativo
+  activo
+`;
+
+export const liquidacionConceptosQuery = gql`
+  query liquidacionConceptos($page: Int, $size: Int) {
+    data: liquidacionConceptos(page: $page, size: $size) { ${LIQUIDACION_CONCEPTO_FIELDS} }
+  }
+`;
+
+export const saveLiquidacionConceptoQuery = gql`
+  mutation saveLiquidacionConcepto($entity: LiquidacionConceptoInput!) {
+    data: saveLiquidacionConcepto(liquidacionConcepto: $entity) { ${LIQUIDACION_CONCEPTO_FIELDS} }
+  }
+`;
+
+export const deleteLiquidacionConceptoQuery = gql`
+  mutation deleteLiquidacionConcepto($id: ID!) {
+    data: deleteLiquidacionConcepto(id: $id)
+  }
+`;

--- a/src/app/modules/rrhh/liquidacion-concepto/liquidacion-concepto.model.ts
+++ b/src/app/modules/rrhh/liquidacion-concepto/liquidacion-concepto.model.ts
@@ -1,0 +1,42 @@
+import { Usuario } from '../../personas/usuarios/usuario.model';
+
+/**
+ * Concepto del catalogo `rrhh.liquidacion_concepto`. Los items de liquidacion lo
+ * referencian por `codigo` (un String, no una FK), asi que el codigo es la llave real
+ * contra lo ya emitido.
+ */
+export class LiquidacionConcepto {
+  id: number;
+  codigo: string;
+  descripcion: string;
+  esHaber: boolean;
+  esCalculadoAuto: boolean;
+  esRemunerativo: boolean;
+  activo: boolean;
+  creadoEn: Date;
+  usuario: Usuario;
+
+  toInput(): LiquidacionConceptoInput {
+    return {
+      id: this.id,
+      codigo: this.codigo,
+      descripcion: this.descripcion,
+      esHaber: this.esHaber,
+      esCalculadoAuto: this.esCalculadoAuto,
+      esRemunerativo: this.esRemunerativo,
+      activo: this.activo,
+      usuarioId: this.usuario?.id
+    };
+  }
+}
+
+export interface LiquidacionConceptoInput {
+  id: number;
+  codigo: string;
+  descripcion: string;
+  esHaber: boolean;
+  esCalculadoAuto: boolean;
+  esRemunerativo: boolean;
+  activo: boolean;
+  usuarioId: number;
+}

--- a/src/app/modules/rrhh/liquidacion-concepto/liquidacion-concepto.service.ts
+++ b/src/app/modules/rrhh/liquidacion-concepto/liquidacion-concepto.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { GenericCrudService } from '../../../generics/generic-crud.service';
+import { LiquidacionConcepto } from './liquidacion-concepto.model';
+import { LiquidacionConceptosGQL } from './graphql/LiquidacionConceptos';
+import { SaveLiquidacionConceptoGQL } from './graphql/SaveLiquidacionConcepto';
+import { DeleteLiquidacionConceptoGQL } from './graphql/DeleteLiquidacionConcepto';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LiquidacionConceptoService {
+
+  constructor(
+    private genericService: GenericCrudService,
+    private liquidacionConceptosGQL: LiquidacionConceptosGQL,
+    private saveLiquidacionConceptoGQL: SaveLiquidacionConceptoGQL,
+    private deleteLiquidacionConceptoGQL: DeleteLiquidacionConceptoGQL
+  ) { }
+
+  /**
+   * El backend no expone busqueda por texto para este catalogo, solo paginado. Es un
+   * catalogo chico (los codigos que el motor de liquidacion sabe resolver), asi que se
+   * trae entero y la lista filtra en memoria.
+   */
+  onGetAll(page = 0, size = 200, servidor = true): Observable<any> {
+    return this.genericService.onGetAll(this.liquidacionConceptosGQL, page, size, servidor);
+  }
+
+  onSave(input: any, servidor = true): Observable<LiquidacionConcepto> {
+    return this.genericService.onSave<LiquidacionConcepto>(this.saveLiquidacionConceptoGQL, input, null, null, servidor);
+  }
+
+  /**
+   * El backend rechaza con GraphQLException si el concepto ya aparece en items emitidos
+   * (liquidacion_item.codigo es un String, no una FK) y ese mensaje llega al snackbar.
+   * Sin ese chequeo, CrudService.deleteById devolveria false en silencio y la UI diria
+   * "eliminado con exito". Mismo patron que CargoService.onDelete.
+   */
+  onDelete(id: number, servidor = true): Observable<any> {
+    return this.genericService.onDelete(this.deleteLiquidacionConceptoGQL, id, null, null, false, servidor);
+  }
+}

--- a/src/app/modules/rrhh/liquidacion-concepto/list-liquidacion-concepto/list-liquidacion-concepto.component.html
+++ b/src/app/modules/rrhh/liquidacion-concepto/list-liquidacion-concepto/list-liquidacion-concepto.component.html
@@ -1,0 +1,93 @@
+<app-generic-list titulo="Conceptos de liquidación" style="height: 100%" [isAdicionar]="true" (adicionar)="onNuevo()"
+  (filtrar)="onFiltrar()" (resetFiltro)="onResetFiltro()">
+
+  <div filtros fxLayout="row wrap" fxLayoutGap="10px" style="width: 100%">
+    <mat-form-field fxFlex="320px">
+      <mat-label>Código o descripción</mat-label>
+      <input matInput [formControl]="textoControl" (keyup.enter)="onFiltrar()" />
+    </mat-form-field>
+
+    <mat-form-field fxFlex="180px">
+      <mat-label>Estado</mat-label>
+      <mat-select [formControl]="activoControl" (selectionChange)="onFiltrar()">
+        <mat-option [value]="null">Todos</mat-option>
+        <mat-option [value]="true">Activos</mat-option>
+        <mat-option [value]="false">Inactivos</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <div table style="height: 100%" fxLayout="column" fxLayoutAlign="space-between start">
+    <table mat-table [dataSource]="dataSource" class="mat-elevation-z2" style="width: 100%">
+
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>Id</th>
+        <td mat-cell *matCellDef="let row" [ngClass]="row.activo ? '' : 'inactivo'">{{ row.id }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="codigo">
+        <th mat-header-cell *matHeaderCellDef>Código</th>
+        <td mat-cell *matCellDef="let row" [ngClass]="row.activo ? '' : 'inactivo'">{{ row.codigo }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="descripcion">
+        <th mat-header-cell *matHeaderCellDef>Descripción</th>
+        <td mat-cell *matCellDef="let row" [ngClass]="row.activo ? '' : 'inactivo'">
+          {{ row.descripcion }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="tipo">
+        <th mat-header-cell *matHeaderCellDef class="col-centro">Tipo</th>
+        <td mat-cell *matCellDef="let row" class="col-centro">{{ row.esHaber ? 'Haber' : 'Descuento' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="esRemunerativo">
+        <th mat-header-cell *matHeaderCellDef class="col-centro">Remunerativo</th>
+        <td mat-cell *matCellDef="let row" class="col-centro">
+          <mat-icon class="si" *ngIf="row.esRemunerativo">check_circle</mat-icon>
+          <span class="no" *ngIf="!row.esRemunerativo">-</span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="esCalculadoAuto">
+        <th mat-header-cell *matHeaderCellDef class="col-centro">Calculado por el sistema</th>
+        <td mat-cell *matCellDef="let row" class="col-centro">
+          <mat-icon class="si" *ngIf="row.esCalculadoAuto">check_circle</mat-icon>
+          <span class="no" *ngIf="!row.esCalculadoAuto">-</span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="activo">
+        <th mat-header-cell *matHeaderCellDef class="col-centro">Activo</th>
+        <td mat-cell *matCellDef="let row" class="col-centro">
+          <mat-icon [ngClass]="row.activo ? 'si' : 'no'">{{ row.activo ? 'check_circle' : 'cancel' }}</mat-icon>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef class="col-centro">Acciones</th>
+        <td mat-cell *matCellDef="let row" class="col-centro">
+          <button mat-icon-button [matMenuTriggerFor]="menu" (click)="$event.stopPropagation()">
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #menu="matMenu">
+            <button mat-menu-item (click)="onEditar(row)">
+              <mat-icon>edit</mat-icon><span>Editar</span>
+            </button>
+            <button mat-menu-item (click)="onCambiarEstado(row)">
+              <mat-icon>{{ row.activo ? 'toggle_off' : 'toggle_on' }}</mat-icon>
+              <span>{{ row.activo ? 'Desactivar' : 'Activar' }}</span>
+            </button>
+            <button mat-menu-item (click)="onEliminar(row)">
+              <mat-icon>delete</mat-icon><span>Eliminar</span>
+            </button>
+          </mat-menu>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </div>
+</app-generic-list>

--- a/src/app/modules/rrhh/liquidacion-concepto/list-liquidacion-concepto/list-liquidacion-concepto.component.scss
+++ b/src/app/modules/rrhh/liquidacion-concepto/list-liquidacion-concepto/list-liquidacion-concepto.component.scss
@@ -1,0 +1,21 @@
+// El componente se crea dentro de app-tab-content, que no define altura. Sin un host
+// con altura definida, el <div fxFlex> de app-generic-list (flex-basis: 0%) colapsa a
+// cero y la tabla queda invisible.
+:host {
+  display: block;
+  height: 100%;
+  overflow: hidden;
+}
+
+table { width: 100%; }
+
+// Las clases sin prefijo `mat-mdc-` son de la API vieja de Material y no matchean nada
+// en la 15: el padding hay que aplicarlo sobre las MDC.
+th.mat-mdc-header-cell, td.mat-mdc-cell { padding: 4px 8px; }
+
+// Columnas de dato corto o de iconos: centradas. Codigo y descripcion se leen mejor
+// alineadas a la izquierda, que es el default de la tabla.
+.col-centro { text-align: center; }
+.si { color: #66bb6a; }
+.no { opacity: 0.5; }
+.inactivo { opacity: 0.55; }

--- a/src/app/modules/rrhh/liquidacion-concepto/list-liquidacion-concepto/list-liquidacion-concepto.component.ts
+++ b/src/app/modules/rrhh/liquidacion-concepto/list-liquidacion-concepto/list-liquidacion-concepto.component.ts
@@ -1,0 +1,131 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { MatTableDataSource } from '@angular/material/table';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { MainService } from '../../../../main.service';
+import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
+import { LiquidacionConcepto } from '../liquidacion-concepto.model';
+import { LiquidacionConceptoService } from '../liquidacion-concepto.service';
+import { EditLiquidacionConceptoDialogComponent } from '../edit-liquidacion-concepto-dialog/edit-liquidacion-concepto-dialog.component';
+
+/**
+ * ABM del catalogo de conceptos de liquidacion. El backend existia entero desde V154.0;
+ * lo que faltaba era esta pantalla, asi que `es_remunerativo` -- que decide que entra a
+ * la base del aguinaldo, del IPS del finiquito y de la indemnizacion -- solo se editaba
+ * por SQL, y un concepto nuevo se llevaba el DEFAULT TRUE de la columna sin que nadie lo
+ * decidiera.
+ */
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'app-list-liquidacion-concepto',
+  templateUrl: './list-liquidacion-concepto.component.html',
+  styleUrls: ['./list-liquidacion-concepto.component.scss']
+})
+export class ListLiquidacionConceptoComponent implements OnInit {
+
+  displayedColumns = ['id', 'codigo', 'descripcion', 'tipo', 'esRemunerativo', 'esCalculadoAuto', 'activo', 'acciones'];
+  dataSource = new MatTableDataSource<LiquidacionConcepto>([]);
+
+  textoControl = new FormControl(null);
+  /** tri-state: null=Todos, true=Activos, false=Inactivos */
+  activoControl = new FormControl(null);
+
+  /** El catalogo completo tal cual vino del backend; los filtros trabajan sobre esto. */
+  private conceptos: LiquidacionConcepto[] = [];
+
+  constructor(
+    private liquidacionConceptoService: LiquidacionConceptoService,
+    public mainService: MainService,
+    private dialog: MatDialog,
+    private dialogosService: DialogosService
+  ) { }
+
+  ngOnInit(): void {
+    this.onCargar();
+  }
+
+  onCargar() {
+    this.liquidacionConceptoService.onGetAll().pipe(untilDestroyed(this)).subscribe(res => {
+      if (res != null) {
+        this.conceptos = res || [];
+        this.onFiltrar();
+      }
+    });
+  }
+
+  onFiltrar() {
+    const texto = this.textoControl.value ? this.textoControl.value.trim().toUpperCase() : null;
+    const activo = this.activoControl.value;
+    this.dataSource.data = this.conceptos.filter(c => {
+      if (activo != null && (c.activo === true) !== activo) { return false; }
+      if (texto == null) { return true; }
+      return (c.codigo || '').toUpperCase().includes(texto)
+        || (c.descripcion || '').toUpperCase().includes(texto);
+    });
+  }
+
+  onResetFiltro() {
+    this.textoControl.setValue(null);
+    this.activoControl.setValue(null);
+    this.onCargar();
+  }
+
+  onNuevo() {
+    this.abrir(null);
+  }
+
+  onEditar(concepto: LiquidacionConcepto) {
+    this.abrir(concepto);
+  }
+
+  private abrir(concepto: LiquidacionConcepto) {
+    this.dialog.open(EditLiquidacionConceptoDialogComponent, {
+      data: { concepto },
+      width: '560px',
+      maxWidth: '95vw',
+      panelClass: 'liquidacion-concepto-panel',
+      autoFocus: false,
+      disableClose: true
+    }).afterClosed().pipe(untilDestroyed(this)).subscribe(res => { if (res != null) this.onCargar(); });
+  }
+
+  /**
+   * Alternativa al borrado para un concepto ya usado: lo saca del select de item manual
+   * sin tocar los recibos que lo referencian por codigo.
+   */
+  onCambiarEstado(concepto: LiquidacionConcepto) {
+    const activar = !concepto.activo;
+    this.dialogosService.confirm(
+      activar ? 'Activar concepto' : 'Desactivar concepto',
+      (activar ? '¿Desea activar el concepto ' : '¿Desea desactivar el concepto ') + concepto.codigo + '?',
+      activar
+        ? 'Vuelve a estar disponible para cargar ítems manuales.'
+        : 'Deja de ofrecerse al cargar ítems manuales. Las liquidaciones ya emitidas no cambian.',
+      null, true, 'Sí', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(res => {
+      if (res === true) {
+        // Apollo congela los resultados: se clona antes de mutar.
+        const aux = new LiquidacionConcepto();
+        Object.assign(aux, concepto);
+        aux.activo = activar;
+        aux.usuario = this.mainService.usuarioActual;
+        this.liquidacionConceptoService.onSave(aux.toInput())
+          .pipe(untilDestroyed(this)).subscribe(guardado => { if (guardado != null) this.onCargar(); });
+      }
+    });
+  }
+
+  onEliminar(concepto: LiquidacionConcepto) {
+    this.dialogosService.confirm(
+      'Eliminar concepto', '¿Desea eliminar el concepto ' + concepto.codigo + '?',
+      'Si ya aparece en ítems de liquidaciones emitidas, el backend lo rechaza: en ese caso desactivalo.',
+      null, true, 'Sí', 'No'
+    ).pipe(untilDestroyed(this)).subscribe(res => {
+      if (res === true) {
+        this.liquidacionConceptoService.onDelete(concepto.id)
+          .pipe(untilDestroyed(this)).subscribe(ok => { if (ok) this.onCargar(); });
+      }
+    });
+  }
+}

--- a/src/app/modules/rrhh/rrhh.module.ts
+++ b/src/app/modules/rrhh/rrhh.module.ts
@@ -34,6 +34,8 @@ import { PagarAguinaldoDialogComponent } from './aguinaldo/pagar-aguinaldo-dialo
 import { ListBonoComponent } from './bono/list-bono/list-bono.component';
 import { EditBonoDialogComponent } from './bono/edit-bono-dialog/edit-bono-dialog.component';
 import { ListLiquidacionComponent } from './liquidacion/list-liquidacion/list-liquidacion.component';
+import { ListLiquidacionConceptoComponent } from './liquidacion-concepto/list-liquidacion-concepto/list-liquidacion-concepto.component';
+import { EditLiquidacionConceptoDialogComponent } from './liquidacion-concepto/edit-liquidacion-concepto-dialog/edit-liquidacion-concepto-dialog.component';
 import { GenerarLiquidacionDialogComponent } from './liquidacion/generar-liquidacion-dialog/generar-liquidacion-dialog.component';
 import { LiquidacionDetalleDialogComponent } from './liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component';
 import { LegajoFuncionarioComponent } from './legajo/legajo-funcionario/legajo-funcionario.component';
@@ -84,6 +86,8 @@ import { ManualRrhhComponent } from './manual/manual-rrhh.component';
     ListBonoComponent,
     EditBonoDialogComponent,
     ListLiquidacionComponent,
+    ListLiquidacionConceptoComponent,
+    EditLiquidacionConceptoDialogComponent,
     GenerarLiquidacionDialogComponent,
     LiquidacionDetalleDialogComponent,
     LegajoFuncionarioComponent,

--- a/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
+++ b/src/app/shared/components/side-mini-variant/side-mini-variant.component.ts
@@ -64,6 +64,7 @@ import { ListJustificativoComponent } from '../../../modules/rrhh/justificativo/
 import { ListTipoJustificativoComponent } from '../../../modules/rrhh/tipo-justificativo/list-tipo-justificativo/list-tipo-justificativo.component';
 import { ListMotivoValeComponent } from '../../../modules/rrhh/motivo-vale/list-motivo-vale/list-motivo-vale.component';
 import { ListCargoComponent } from '../../../modules/empresarial/cargo/list-cargo/list-cargo.component';
+import { ListLiquidacionConceptoComponent } from '../../../modules/rrhh/liquidacion-concepto/list-liquidacion-concepto/list-liquidacion-concepto.component';
 import { ListValeComponent } from '../../../modules/rrhh/vale/list-vale/list-vale.component';
 import { ListPrestamoComponent } from '../../../modules/rrhh/prestamo/list-prestamo/list-prestamo.component';
 import { ListVacacionComponent } from '../../../modules/rrhh/vacacion/list-vacacion/list-vacacion.component';
@@ -333,6 +334,12 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
               name: 'Cargos',
               icon: 'work',
               action: 'list-cargo',
+              visibilityRoles: [ROLES.RRHH_GESTIONAR, ROLES.RRHH_CONFIG, ROLES.ADMIN]
+            },
+            {
+              name: 'Conceptos de liquidación',
+              icon: 'playlist_add_check',
+              action: 'list-liquidacion-concepto',
               visibilityRoles: [ROLES.RRHH_GESTIONAR, ROLES.RRHH_CONFIG, ROLES.ADMIN]
             },
             {
@@ -1073,6 +1080,16 @@ export class SideMiniVariantComponent implements OnInit, OnDestroy {
         break;
       case "list-cargo":
         this.openTabIfAuthorized(ROLES.RRHH_GESTIONAR, ListCargoComponent, "Cargos");
+        break;
+      case "list-liquidacion-concepto":
+        // El backend acepta RRHH CONFIG o RRHH GESTIONAR (LiquidacionConceptoGraphQL), y
+        // openTabIfAuthorized solo compara contra un rol: si abriera solo por CONFIG, el
+        // item quedaria visible para GESTIONAR y le negaria la pantalla al abrirla.
+        if (this.hasAnyRole([ROLES.RRHH_CONFIG, ROLES.RRHH_GESTIONAR])) {
+          this.tabService.addTab(new Tab(ListLiquidacionConceptoComponent, "Conceptos de liquidación", null, null));
+        } else {
+          this.notificacionService.openWarn('No tenés acceso a esta opción.');
+        }
         break;
       case "list-prestamo":
         this.openTabIfAuthorized(ROLES.RRHH_VER, ListPrestamoComponent, "Préstamos");

--- a/src/app/shared/widgets/search-bar-dialog/search-bar.service.ts
+++ b/src/app/shared/widgets/search-bar-dialog/search-bar.service.ts
@@ -17,6 +17,7 @@ import { ListActualizacionComponent } from '../../../modules/configuracion/actua
 import { ListCajaComponent } from '../../../modules/financiero/pdv/caja/list-caja/list-caja.component';
 import { ListSectorComponent } from '../../../modules/empresarial/sector/list-sector/list-sector.component';
 import { ListCargoComponent } from '../../../modules/empresarial/cargo/list-cargo/list-cargo.component';
+import { ListLiquidacionConceptoComponent } from '../../../modules/rrhh/liquidacion-concepto/list-liquidacion-concepto/list-liquidacion-concepto.component';
 import { SolicitarRecursosDialogComponent } from '../../../modules/configuracion/solicitar-recursos-dialog/solicitar-recursos-dialog.component';
 import { ROLES } from '../../../modules/personas/roles/roles.enum';
 import { PrecioDeliveryComponent } from '../../../modules/operaciones/delivery/precio-delivery/precio-delivery.component';
@@ -57,6 +58,7 @@ export const componenteList: SearchData[] =
     { title: 'Lista de cajas', component: ListCajaComponent, visibilityRoles: [ROLES.ANALISIS_DE_CAJA] },
     { title: 'Lista de sectores', component: ListSectorComponent, visibilityRoles: [ROLES.ADMIN] },
     { title: 'Lista de cargos', component: ListCargoComponent, visibilityRoles: [ROLES.ADMIN] },
+    { title: 'Conceptos de liquidación', component: ListLiquidacionConceptoComponent, visibilityRoles: [ROLES.RRHH_CONFIG, ROLES.RRHH_GESTIONAR, ROLES.ADMIN] },
     { title: 'Solicitar Recursos', component: SolicitarRecursosDialogComponent, visibilityRoles: [ROLES.SOPORTE] },
     { title: 'Precio del Delivery', component: PrecioDeliveryComponent, visibilityRoles: [ROLES.ADMIN] },
     { title: 'Lista de clientes', component: ListClientesComponent, visibilityRoles: [ROLES.VER_PERSONAS] },

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -496,9 +496,10 @@ input {
   }
 }
 
-// Historial de edicion de un conteo: sin padding, para que la banda de color
-// llegue hasta los bordes del dialogo.
-.historial-conteo-panel {
+// Dialogos con banda de color a sangre (historial de edicion de un conteo, ABM de
+// conceptos de liquidacion): sin padding, para que la banda llegue hasta los bordes.
+.historial-conteo-panel,
+.liquidacion-concepto-panel {
   .mat-mdc-dialog-container {
     padding: 0;
     overflow: hidden;


### PR DESCRIPTION
Closes #246

## Qué resuelve

El catálogo `rrhh.liquidacion_concepto` solo se editaba por SQL: el backend estaba entero desde `V154.0` y del lado del cliente había únicamente una query de lectura para el select del ítem manual.

El problema no era la falta de pantalla sino el default de `es_remunerativo`. La columna se creó con `DEFAULT TRUE` para que la migración sola no cambiara ningún comportamiento, así que un concepto nuevo entraba a la base del aguinaldo, del IPS del finiquito y de la indemnización sin que nadie lo decidiera.

- **`es_remunerativo` obligatorio en el alta**: el select arranca vacío y sin elegirlo el botón Guardar queda deshabilitado. No hay forma de heredar el default en silencio.
- **La lista muestra `esHaber` y `esCalculadoAuto`**, que ya existían y no se veían, más `activo` e `id`.
- **Desactivar como alternativa a borrar**: saca el concepto del select de ítem manual sin tocar lo ya emitido.
- Filtros por código/descripción y por estado, resueltos en memoria (el catálogo son ~20 filas y el backend no expone búsqueda por texto).
- Entrada de menú en RRHH → Configuración y en el buscador global, abierta por `RRHH CONFIG` o `RRHH GESTIONAR`, los mismos roles que exige el resolver.

Moldeado sobre el ABM de Cargos. El diálogo toma la estética del de «Montos corregidos» de un conteo (`historial-conteo-dialog`): banda con degradado, cuerpo sin paneles, pie con las acciones.

**Requiere el PR del central**: GabFrank/franco-system-backend-servidor#266, que impide borrar un concepto ya usado y valida el código. Sin él, la acción Eliminar de esta pantalla puede reportar éxito sin haber borrado nada.

## Cómo probarlo

Con central en 8081 y el desktop apuntando ahí, en RRHH → Configuración → Conceptos de liquidación:

1. Editar `VIATICO` y ponerlo en «No» remunerativo → persiste.
2. Adicionar sin elegir «¿Es remunerativo?» → Guardar deshabilitado.
3. Adicionar con un código que ya existe → rechazado por el backend.
4. Eliminar `SALARIO_BASE` (482 ítems) → rechazado, con el conteo; eliminar uno recién creado sin ítems → se borra.
5. Desactivar y reactivar un concepto → persiste sin pisar `esHaber` ni `esRemunerativo`; el filtro Estado los separa.

Todo lo anterior fue probado en la app contra el central de desarrollo, contrastando la base después de cada paso.

## Riesgo

Bajo. Pantalla nueva; lo único compartido que toca es una regla de `styles.scss`, donde el selector sin padding de `historial-conteo-panel` ahora incluye también `liquidacion-concepto-panel`. No cambia comportamiento existente.

## Impacto en auto-update

Ninguno: no toca `installer.nsh`, `electron-builder.json` ni los manifests YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCvkRsbeRLuPFX36aGTjQn