### PR TITLE
fix(solicitud-pago): que el botón de quitar nota funcione y refresque la tabla

### DIFF
--- a/src/app/modules/operaciones/solicitud-pago/create-edit-solicitud-pago-dialog/create-edit-solicitud-pago-dialog.component.html
+++ b/src/app/modules/operaciones/solicitud-pago/create-edit-solicitud-pago-dialog/create-edit-solicitud-pago-dialog.component.html
@@ -63,7 +63,7 @@
           </div>
 
           <div class="tabla-scroll" *ngIf="notasAgregadas?.length > 0; else sinNotas">
-            <table mat-table [dataSource]="notasAgregadas" class="table-center" multiTemplateDataRows style="width: 100%;">
+            <table mat-table [dataSource]="notasTableDataSource" class="table-center" multiTemplateDataRows style="width: 100%;">
               <ng-container matColumnDef="numero">
                 <th mat-header-cell *matHeaderCellDef>Número</th>
                 <td mat-cell *matCellDef="let nota">{{ nota.numero }}</td>
@@ -94,7 +94,7 @@
               </ng-container>
               <ng-container matColumnDef="quitar">
                 <th mat-header-cell *matHeaderCellDef></th>
-                <td mat-cell *matCellDef="let nota; let i = index">
+                <td mat-cell *matCellDef="let nota; let i = dataIndex">
                   <button *ngIf="isEditable" mat-icon-button (click)="onQuitarNota(i); $event.stopPropagation()" type="button">
                     <mat-icon color="warn">delete</mat-icon>
                   </button>

--- a/src/app/modules/operaciones/solicitud-pago/create-edit-solicitud-pago-dialog/create-edit-solicitud-pago-dialog.component.ts
+++ b/src/app/modules/operaciones/solicitud-pago/create-edit-solicitud-pago-dialog/create-edit-solicitud-pago-dialog.component.ts
@@ -59,6 +59,13 @@ export class CreateEditSolicitudPagoDialogComponent implements OnInit, AfterView
   formaPagoList: FormaPago[] = [];
   /** Notas con display de proveedor y datos de pedido para la tabla (sin usar funciones en template). */
   notasAgregadas: NotaRecepcionConDisplay[] = [];
+  /**
+   * DataSource de la tabla de notas. Es obligatorio: un array pelado como [dataSource]
+   * se renderiza una sola vez y el CDK no ve los push/splice sobre la misma referencia,
+   * así que al quitar o agregar una nota la tabla quedaba desactualizada.
+   */
+  notasTableDataSource = new MatTableDataSource<NotaRecepcionConDisplay>([]);
+
   /** Detalles (formas de pago) con display para la tabla. */
   detallesAgregados: (SolicitudPagoDetalleInput & { monedaDenominacion?: string; formaPagoDescripcion?: string })[] = [];
   /** DataSource de la tabla de formas de pago para que mat-table detecte cambios al agregar/editar. */
@@ -331,6 +338,7 @@ export class CreateEditSolicitudPagoDialogComponent implements OnInit, AfterView
           this.solicitudPagoService.onRemoverNotaDeSolicitudPago(this.solicitudPagoId, nota.id).subscribe({
             next: () => {
               this.notasAgregadas.splice(index, 1);
+              this.refrescarTablaNotas();
               this.updateMontoTotal();
               this.updatePuedeEditarProveedor();
               this.saving = false;
@@ -342,6 +350,7 @@ export class CreateEditSolicitudPagoDialogComponent implements OnInit, AfterView
           });
         } else {
           this.notasAgregadas.splice(index, 1);
+          this.refrescarTablaNotas();
           this.updateMontoTotal();
           this.updatePuedeEditarProveedor();
         }
@@ -613,6 +622,11 @@ export class CreateEditSolicitudPagoDialogComponent implements OnInit, AfterView
     this.totalFormasPagoComputed = this.detallesAgregados.reduce((sum, d) => sum + (d.valor ?? 0), 0);
   }
 
+  /** Vuelca notasAgregadas en la tabla. Llamar tras cada alta o baja de notas. */
+  private refrescarTablaNotas(): void {
+    this.notasTableDataSource.data = this.notasAgregadas;
+  }
+
   /** Marca la nota con el nombre del proveedor que muestra la tabla. El resto de los display los completa updateNotasDisplay(). */
   private withProveedorDisplay(nota: NotaRecepcion): NotaRecepcionConDisplay {
     const notaConDisplay = nota as NotaRecepcionConDisplay;
@@ -717,6 +731,7 @@ export class CreateEditSolicitudPagoDialogComponent implements OnInit, AfterView
       map[nota.id] = !!(n.pedidoObservacionDisplay && n.pedidoObservacionDisplay.length > 0);
     });
     this.notaTieneObservacionMap = map;
+    this.refrescarTablaNotas();
   }
 
   onNotaRowClick(nota: NotaRecepcion): void {


### PR DESCRIPTION
## Qué resuelve

El ícono de eliminar de la tabla de notas en "Editar solicitud de pago" no hacía nada. Con esto se puede sacar notas de una solicitud y dejar solo las que se van a pagar.

Eran **dos problemas encadenados**:

**1. El índice llegaba `undefined`.** El template leía `let i = index`, pero esa tabla usa `multiTemplateDataRows` (por la fila expandible con la observación de forma de pago). En ese modo el CDK solo asigna `dataIndex` y `renderIndex`, **nunca** `index` (`@angular/cdk/.../table.mjs:1885-1890`). Así que `onQuitarNota` resolvía `notasAgregadas[undefined]`, caía en el guard `if (!nota) return` y salía en silencio, en todas las filas.

**2. La tabla no se re-renderizaba.** Estaba bindeada al array pelado `notasAgregadas`. Para un array el CDK hace `of(dataSource)` (`table.mjs:1760`): emite una sola vez y solo vuelve a renderizar si cambia la referencia, con lo cual los `splice`/`push` sobre la misma referencia no se ven. Con el índice ya arreglado, la nota se desvinculaba en el backend pero la fila quedaba en pantalla. Lo mismo le pasaba a "Adicionar nota": una nota agregada sobre una solicitud ya abierta no aparecía hasta reabrir el diálogo.

Se pasa esa tabla a `MatTableDataSource` —el mismo patrón que ya usa la tabla de formas de pago en este archivo— y se sincroniza tras cada alta y baja.

## Backend

**Sin cambios.** `SolicitudPagoNotaRecepcionService.removerNotaDeSolicitud` ya borra la relación y llama a `recalcularMontoTotalSolicitud`, así que el monto de la solicitud se recalcula solo. Verificado leyendo el flujo completo.

## Cómo probarlo

1. Abrir una solicitud en estado PENDIENTE con varias notas → borrar una: la fila desaparece y A PAGAR / DIFERENCIA se recalculan.
2. Cerrar y reabrir la solicitud: la nota sigue borrada y el monto es el correcto.
3. "Adicionar nota" sobre esa misma solicitud abierta: la nota nueva aparece en la tabla sin reabrir el diálogo.
4. Solicitud en estado no editable (SOLICITADO / CONCLUIDO): el botón no debe aparecer.

## Impacto

- **DB:** ninguno, sin migraciones.
- **Rollback:** sin riesgo, solo frontend.
- **API GraphQL:** sin cambios; usa `removerNotaDeSolicitudPago`, que ya existía.
- **Riesgo:** bajo. `npm run check` en verde.

## Nota

Si se borran **todas** las notas, la solicitud queda persistida con 0 notas y monto 0 (comportamiento que ya tenía el backend). Guardar exige al menos una nota, pero la solicitud vacía queda hasta que se le agregue otra o se cancele. No se toca acá; se puede bloquear el borrado de la última nota si se prefiere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVK9y6YH8f4K4A4RUPAGcC