### PR TITLE
fix(rrhh): gatear por rol las acciones de la lista de vales

### DIFF
--- a/src/app/modules/rrhh/vale/confirmar-vale-dialog/confirmar-vale-dialog.component.html
+++ b/src/app/modules/rrhh/vale/confirmar-vale-dialog/confirmar-vale-dialog.component.html
@@ -15,8 +15,13 @@
     <mat-error *ngIf="cajaControl.hasError('required')">Seleccione la caja</mat-error>
   </mat-form-field>
 
+  <div class="sin-cajas" *ngIf="!cargandoCajas && cajas.length === 0">
+    No hay cajas mayores activas. Configure una caja mayor antes de confirmar el vale.
+  </div>
+
   <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end center" fxLayoutGap="10px">
     <button mat-stroked-button (click)="onCancelar()">Cancelar</button>
-    <button mat-raised-button color="primary" *ngIf="puedeAprobar" [disabled]="cajaControl.invalid" (click)="onConfirmar()">Confirmar</button>
+    <button mat-raised-button color="primary" *ngIf="puedeAprobar"
+      [disabled]="cajaControl.invalid || cajas.length === 0" (click)="onConfirmar()">Confirmar</button>
   </div>
 </div>

--- a/src/app/modules/rrhh/vale/confirmar-vale-dialog/confirmar-vale-dialog.component.scss
+++ b/src/app/modules/rrhh/vale/confirmar-vale-dialog/confirmar-vale-dialog.component.scss
@@ -7,4 +7,9 @@
     font-size: 12px;
     opacity: 0.75;
   }
+
+  .sin-cajas {
+    font-size: 12px;
+    color: #ffb74d;
+  }
 }

--- a/src/app/modules/rrhh/vale/confirmar-vale-dialog/confirmar-vale-dialog.component.spec.ts
+++ b/src/app/modules/rrhh/vale/confirmar-vale-dialog/confirmar-vale-dialog.component.spec.ts
@@ -1,0 +1,90 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Subject, of } from 'rxjs';
+
+import { MainService } from '../../../../main.service';
+import { CajaVirtual } from '../../caja-virtual/caja-virtual.model';
+import { CajaVirtualService } from '../../caja-virtual/caja-virtual.service';
+import { Vale } from '../vale.model';
+import { ValeService } from '../vale.service';
+import { ConfirmarValeDialogComponent } from './confirmar-vale-dialog.component';
+
+function caja(id: number, nombre: string, tipo: string): CajaVirtual {
+  const c = new CajaVirtual();
+  c.id = id;
+  c.nombre = nombre;
+  (c as any).tipo = tipo;
+  return c;
+}
+
+describe('ConfirmarValeDialogComponent', () => {
+
+  let fixture: ComponentFixture<ConfirmarValeDialogComponent>;
+  let component: ConfirmarValeDialogComponent;
+
+  function montar(activas$, puedeAprobar = true) {
+    TestBed.configureTestingModule({
+      declarations: [ConfirmarValeDialogComponent],
+      imports: [ReactiveFormsModule, NoopAnimationsModule, MatFormFieldModule, MatSelectModule],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: { vale: new Vale() } },
+        { provide: MatDialogRef, useValue: { close: () => { } } },
+        { provide: ValeService, useValue: { onConfirmar: () => of(null) } },
+        { provide: CajaVirtualService, useValue: { onGetActivas: () => activas$ } },
+        { provide: MainService, useValue: { tieneAlgunRol: () => puedeAprobar, usuarioActual: { id: 1 } } }
+      ]
+    });
+    fixture = TestBed.createComponent(ConfirmarValeDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  const texto = () => fixture.nativeElement.querySelector('.sin-cajas')?.textContent?.trim();
+  const botonConfirmar = () =>
+    Array.from(fixture.nativeElement.querySelectorAll('button'))
+      .find((b: any) => b.textContent.includes('Confirmar')) as HTMLButtonElement | undefined;
+
+  it('no muestra el cartel mientras la consulta de cajas no responde', () => {
+    montar(new Subject<CajaVirtual[]>()); // nunca emite
+    expect(component.cargandoCajas).toBeTrue();
+    expect(texto()).toBeUndefined();
+  });
+
+  it('avisa cuando no hay cajas mayores activas y bloquea el boton', () => {
+    montar(of([caja(1, 'CAJA CHICA', 'CAJA_CHICA')])); // ninguna CAJA_MAYOR
+    fixture.detectChanges();
+    expect(component.cargandoCajas).toBeFalse();
+    expect(component.cajas.length).toBe(0);
+    expect(texto()).toContain('No hay cajas mayores activas');
+    expect(botonConfirmar()?.disabled).toBeTrue();
+  });
+
+  it('avisa tambien cuando la consulta falla y devuelve null', () => {
+    montar(of(null));
+    fixture.detectChanges();
+    expect(component.cargandoCajas).toBeFalse();
+    expect(texto()).toContain('No hay cajas mayores activas');
+  });
+
+  it('con cajas mayores activas no muestra el cartel', () => {
+    montar(of([caja(1, 'CAJA MAYOR HQ', 'CAJA_MAYOR'), caja(2, 'CAJA CHICA', 'CAJA_CHICA')]));
+    fixture.detectChanges();
+    expect(component.cajas.length).toBe(1);
+    expect(texto()).toBeUndefined();
+  });
+
+  it('oculta el boton Confirmar si el usuario no tiene RRHH APROBAR', () => {
+    montar(of([caja(1, 'CAJA MAYOR HQ', 'CAJA_MAYOR')]), false);
+    fixture.detectChanges();
+    expect(component.puedeAprobar).toBeFalse();
+    expect(botonConfirmar()).toBeUndefined();
+  });
+});

--- a/src/app/modules/rrhh/vale/confirmar-vale-dialog/confirmar-vale-dialog.component.ts
+++ b/src/app/modules/rrhh/vale/confirmar-vale-dialog/confirmar-vale-dialog.component.ts
@@ -24,6 +24,9 @@ export class ConfirmarValeDialogComponent implements OnInit {
   cajas: CajaVirtual[] = [];
   cajaControl = new FormControl(null, [Validators.required]);
   puedeAprobar = false;
+  // Mientras la query no responde no se muestra el cartel de "no hay cajas":
+  // el select vacio inicial no significa que no existan cajas mayores activas.
+  cargandoCajas = true;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) private data: ConfirmarValeDialogData,
@@ -41,6 +44,7 @@ export class ConfirmarValeDialogComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe((res: CajaVirtual[]) => {
         this.cajas = (res || []).filter(c => c.tipo === 'CAJA_MAYOR');
+        this.cargandoCajas = false;
       });
   }
 

--- a/src/app/modules/rrhh/vale/list-vale/list-vale.component.html
+++ b/src/app/modules/rrhh/vale/list-vale/list-vale.component.html
@@ -1,4 +1,4 @@
-<app-generic-list titulo="Vales" style="height: 100%" [isAdicionar]="true" (adicionar)="onNuevo()"
+<app-generic-list titulo="Vales" style="height: 100%" [isAdicionar]="puedeGestionar" (adicionar)="onNuevo()"
   (filtrar)="onFiltrar()" (resetFiltro)="onResetFiltro()">
 
   <div filtros fxLayout="row wrap" fxLayoutGap="10px" style="width: 100%">
@@ -71,10 +71,11 @@
             <mat-icon>more_vert</mat-icon>
           </button>
           <mat-menu #menu="matMenu">
-            <button mat-menu-item (click)="onConfirmar(row)" [disabled]="row.estado !== 'SOLICITADO'">
+            <button mat-menu-item *ngIf="puedeAprobar" (click)="onConfirmar(row)"
+              [disabled]="row.estado !== 'SOLICITADO'">
               <mat-icon>check_circle</mat-icon><span>Confirmar</span>
             </button>
-            <button mat-menu-item (click)="onAnular(row)"
+            <button mat-menu-item *ngIf="puedeGestionar" (click)="onAnular(row)"
               [disabled]="row.estado !== 'SOLICITADO' && row.estado !== 'CONFIRMADO'">
               <mat-icon>block</mat-icon><span>Anular</span>
             </button>

--- a/src/app/modules/rrhh/vale/list-vale/list-vale.component.spec.ts
+++ b/src/app/modules/rrhh/vale/list-vale/list-vale.component.spec.ts
@@ -1,0 +1,77 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+
+import { MainService } from '../../../../main.service';
+import { NotificacionSnackbarService } from '../../../../notificacion-snackbar.service';
+import { DialogosService } from '../../../../shared/components/dialogos/dialogos.service';
+import { ImpresionService } from '../../../../shared/components/imprimir/impresion.service';
+import { ReportesRrhhService } from '../../reportes/reportes-rrhh.service';
+import { ValeService } from '../vale.service';
+import { ListValeComponent } from './list-vale.component';
+
+/**
+ * El gating de acciones vive en flags calculados en ngOnInit (no se llaman
+ * funciones desde el HTML). Estos tests fijan los roles exactos que exige el
+ * backend: confirmarVale -> RRHH APROBAR, saveVale/anularVale -> RRHH GESTIONAR.
+ */
+describe('ListValeComponent (gating por rol)', () => {
+
+  let tieneAlgunRolSpy: jasmine.Spy;
+
+  function crear(rolesConcedidos: string[]) {
+    tieneAlgunRolSpy = jasmine.createSpy('tieneAlgunRol')
+      .and.callFake((roles: string[]) => (roles || []).some(r => rolesConcedidos.includes(r)));
+
+    TestBed.configureTestingModule({
+      declarations: [ListValeComponent],
+      providers: [
+        { provide: ValeService, useValue: { onGetPage: () => of(null), onAnular: () => of(null) } },
+        { provide: MainService, useValue: { tieneAlgunRol: tieneAlgunRolSpy } },
+        { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of(null) }) } },
+        { provide: DialogosService, useValue: { confirm: () => of(false) } },
+        { provide: NotificacionSnackbarService, useValue: {} },
+        { provide: ReportesRrhhService, useValue: {} },
+        { provide: ImpresionService, useValue: { imprimir: () => { } } }
+      ]
+    });
+    // Template vacio: estos tests cubren la logica de gating, no el render.
+    TestBed.overrideComponent(ListValeComponent, { set: { template: '' } });
+
+    const fixture = TestBed.createComponent(ListValeComponent);
+    fixture.detectChanges(); // dispara ngOnInit
+    return fixture.componentInstance;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('consulta exactamente los roles RRHH APROBAR y RRHH GESTIONAR', () => {
+    crear([]);
+    expect(tieneAlgunRolSpy).toHaveBeenCalledWith(['RRHH APROBAR']);
+    expect(tieneAlgunRolSpy).toHaveBeenCalledWith(['RRHH GESTIONAR']);
+  });
+
+  it('sin roles RRHH no habilita ni confirmar ni gestionar', () => {
+    const c = crear([]);
+    expect(c.puedeAprobar).toBeFalse();
+    expect(c.puedeGestionar).toBeFalse();
+  });
+
+  it('con solo RRHH VER no habilita confirmar (caso reportado en la issue #230)', () => {
+    const c = crear(['RRHH VER']);
+    expect(c.puedeAprobar).toBeFalse();
+    expect(c.puedeGestionar).toBeFalse();
+  });
+
+  it('con RRHH APROBAR habilita confirmar pero no crear/anular', () => {
+    const c = crear(['RRHH APROBAR']);
+    expect(c.puedeAprobar).toBeTrue();
+    expect(c.puedeGestionar).toBeFalse();
+  });
+
+  it('con RRHH GESTIONAR habilita crear/anular pero no confirmar', () => {
+    const c = crear(['RRHH GESTIONAR']);
+    expect(c.puedeAprobar).toBeFalse();
+    expect(c.puedeGestionar).toBeTrue();
+  });
+});

--- a/src/app/modules/rrhh/vale/list-vale/list-vale.component.ts
+++ b/src/app/modules/rrhh/vale/list-vale/list-vale.component.ts
@@ -41,6 +41,11 @@ export class ListValeComponent implements OnInit {
   pageSize = 25;
   selectedPageInfo: PageInfo<Vale>;
 
+  // Gating por rol: el backend exige RRHH APROBAR para confirmar y RRHH GESTIONAR
+  // para crear/anular. Se calculan una sola vez para no llamar funciones desde el HTML.
+  puedeAprobar = false;
+  puedeGestionar = false;
+
   constructor(
     private valeService: ValeService,
     public mainService: MainService,
@@ -57,6 +62,8 @@ export class ListValeComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.puedeAprobar = this.mainService.tieneAlgunRol(['RRHH APROBAR']);
+    this.puedeGestionar = this.mainService.tieneAlgunRol(['RRHH GESTIONAR']);
     this.onFiltrar();
   }
 


### PR DESCRIPTION
Closes #230

## Qué resuelve

En la lista de vales el menú de acciones no consultaba los roles del usuario. Cualquiera con acceso al módulo veía **Confirmar** habilitado (solo se deshabilitaba por `estado !== 'SOLICITADO'`) y recibía el error de autorización recién al confirmar, después de haber elegido una caja.

La asimetría de fondo: `cajaVirtualesActivas` (central) acepta **cualquier** rol de Tesorería o RRHH, mientras `confirmarVale` exige **`RRHH APROBAR`**. Un usuario con solo `RRHH VER` abría el diálogo, veía las cajas, y recién al final se llevaba el rechazo.

## Qué cambia

Solo frontend. Backend y schema GraphQL sin tocar.

- **`list-vale.component.ts`**: flags `puedeAprobar` (`RRHH APROBAR`) y `puedeGestionar` (`RRHH GESTIONAR`) calculados en `ngOnInit` — no se llaman funciones desde el HTML, según la regla de performance del repo. `tieneAlgunRol` ya devuelve `true` para ADMIN.
- **`list-vale.component.html`**: `*ngIf` en **Confirmar** (`puedeAprobar`) y en **Anular** (`puedeGestionar`), siguiendo el padrón de `list-aguinaldo.component.html:58`. Se conservan los `[disabled]` por estado.
- **Botón Adicionar**: `[isAdicionar]="puedeGestionar"`. No estaba en el issue, pero abre `EditValeDialog` → `saveVale`, que el backend también gatea con `GESTIONAR`; tenía el mismo defecto.
- **`confirmar-vale-dialog`**: cartel *"No hay cajas mayores activas…"* cuando la lista queda vacía, con flag `cargandoCajas` para no mostrarlo mientras la query no respondió, y el botón Confirmar bloqueado en ese caso.
- **Specs nuevos** para ambos componentes (no existían).

Nota sobre el punto 2 del issue: no hace falta distinguir "sin permiso" de "no hay cajas". Al gatear Confirmar por `RRHH APROBAR`, quien abre el diálogo siempre tiene permiso de lectura sobre las cajas (`cajaVirtualesActivas` acepta cualquier rol RRHH). El error de red/autorización ya lo notifica el snackbar global de `generic-crud.service.ts`.

El punto 3 mencionaba "editar" en el menú de vales: esa acción no existe, el menú tiene solo Confirmar / Anular / Imprimir recibo.

## Cómo probarlo

Central en 8081, filial en 8082, front en 4200. R.R.H.H. → Anticipos → Vales.

| Roles del usuario | Menú de acciones | Botón Adicionar |
|---|---|---|
| `RRHH APROBAR` + `RRHH GESTIONAR` | Confirmar + Anular + Imprimir | visible |
| sin `RRHH APROBAR` | Anular + Imprimir | visible |
| sin roles RRHH de escritura | solo Imprimir | oculto |

Verificado en Chrome sobre la app real con los tres estados. Los specs nuevos (10 casos) pasan en Chrome headless.

## Impacto en DB

Ninguno. Sin migraciones.

## Impacto en rollback

Ninguno. Cambio solo de presentación; volver a la versión anterior restaura el comportamiento previo sin efectos de datos.

## Riesgo

**Bajo.** Un usuario que hoy veía acciones que no podía ejecutar deja de verlas. No se habilita nada nuevo a nadie: el backend ya rechazaba esas operaciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJLG49Jj6fXTimoduUB4Dk
