### PR TITLE
fix(pdv): no perder la venta ni re-emitir la factura cuando el servidor falla

### DIFF
--- a/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
+++ b/src/app/modules/financiero/factura-legal/add-factura-legal-dialog/add-factura-legal-dialog.component.ts
@@ -938,8 +938,15 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
     if (this.isServidor) {
       this.onSaveFacturaToFilial(facturaInput, facturaItemInputList, deseaImprimir);
     } else {
-      // Modo normal (desde venta)
-      // Intento principal: servidor central. Si falla, fallback al servidor local
+      // Modo normal (desde venta).
+      //
+      // No se reintenta ante un fallo. El "fallback al servidor local" que había acá
+      // mandaba servidor=false, igual que este intento, así que no caía a otro servidor:
+      // volvía a llamar al mismo. Y como el backend puede fallar DESPUÉS de haber
+      // guardado la factura, ese reintento emitía una segunda con otro número de
+      // timbrado. Emitir es irreversible, así que ante la duda se avisa al cajero en
+      // vez de re-emitir: la factura pudo haberse guardado y hay que mirar la lista
+      // antes de volver a intentar.
       this.facturaService
         .onSaveFactura(facturaInput, facturaItemInputList, false)
         .pipe(untilDestroyed(this))
@@ -948,11 +955,12 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
             if (res != null) {
               this.handleFacturaSuccess(res);
             } else {
-              this.trySaveFacturaLocal(facturaInput, facturaItemInputList);
+              this.onFacturaNoConfirmada();
             }
           },
-          error: () => {
-            this.trySaveFacturaLocal(facturaInput, facturaItemInputList);
+          error: (err) => {
+            console.error("Error al guardar la factura legal:", err);
+            this.onFacturaNoConfirmada();
           },
         });
     }
@@ -1038,26 +1046,17 @@ export class AddFacturaLegalDialogComponent implements OnInit, AfterViewInit {
     }, 1000);
   }
 
-  private trySaveFacturaLocal(facturaInput: any, facturaItemInputList: FacturaLegalItemInput[]) {
-    this.notificacionService.openWarn(
-      "Servidor central no disponible. Se imprimirá desde el servidor local.",
+  /**
+   * El servidor no confirmó la factura. No se puede saber si llegó a guardarse: el
+   * backend consume el número de timbrado y recién después hace tareas que pueden
+   * fallar. Por eso no se reintenta solo — se libera el botón y se le pide al cajero
+   * que verifique en la lista de facturas antes de volver a emitir.
+   */
+  private onFacturaNoConfirmada() {
+    this.guardando = false;
+    this.notificacionService.openAlgoSalioMal(
+      "No se pudo confirmar la factura. Verifique en la lista de facturas si se emitió antes de volver a intentar."
     );
-    this.facturaService
-      .onSaveFactura(facturaInput, facturaItemInputList, false)
-      .pipe(untilDestroyed(this))
-      .subscribe({
-        next: (resLocal: TimbradoDetalle) => {
-          if (resLocal != null) {
-            this.handleFacturaSuccess(resLocal);
-          } else {
-            this.guardando = false;
-          }
-        },
-        error: () => {
-          this.guardando = false;
-          this.notificacionService.openAlgoSalioMal("Error al guardar la factura en el servidor local");
-        },
-      });
   }
 
   private handleFacturaSuccess(res: TimbradoDetalle) {

--- a/src/app/modules/pdv/comercial/venta-touch/venta-touch.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/venta-touch.component.ts
@@ -1302,115 +1302,132 @@ export class VentaTouchComponent implements OnInit, OnDestroy, AfterViewInit {
           false
         )
         .pipe(untilDestroyed(this))
-        .subscribe((res) => {
-          if (res.id != null) {
-            this.notificacionSnackbar.notification$.next({
-              color: NotificacionColor.success,
-              texto: "Venta guardada con éxito",
-              duracion: 2,
-            });
-            if (facturaLegalId != null) {
-              // La factura se generó manualmente antes de que la venta existiera
-              // (flujo "Finalizar con Factura"): se vincula ahora que ya tenemos el id.
-              this.facturaLegalService
-                .onVincularFacturaAVenta(facturaLegalId, res.id, false)
-                .pipe(untilDestroyed(this))
-                .subscribe({
-                  error: (err) =>
-                    console.error("Error al vincular factura a la venta:", err),
-                });
-            }
-            if (ventaCreditoInput != null && ventaCreditoInput.clienteId != null) {
-              const sucursalId = ventaCreditoInput.sucursalId || this.mainService.sucursalActual?.id;
-              const personaId = venta.cliente?.persona?.id;
-
-              if (personaId && sucursalId) {
-                this.notificationHttpService.sendCompraCreditoNotification(
-                  res.id,
-                  sucursalId,
-                  personaId,
-                  ventaCreditoInput.valorTotal,
-                  this.mainService.sucursalActual?.nombre
-                ).subscribe({
-                  next: () => console.log('Notificación de compra a crédito enviada exitosamente'),
-                  error: (err) => console.error('Error al enviar notificación de compra a crédito:', err)
-                });
+        .subscribe({
+          next: (res) => {
+            if (res?.id != null) {
+              this.notificacionSnackbar.notification$.next({
+                color: NotificacionColor.success,
+                texto: "Venta guardada con éxito",
+                duracion: 2,
+              });
+              if (facturaLegalId != null) {
+                // La factura se generó manualmente antes de que la venta existiera
+                // (flujo "Finalizar con Factura"): se vincula ahora que ya tenemos el id.
+                this.facturaLegalService
+                  .onVincularFacturaAVenta(facturaLegalId, res.id, false)
+                  .pipe(untilDestroyed(this))
+                  .subscribe({
+                    error: (err) =>
+                      console.error("Error al vincular factura a la venta:", err),
+                  });
               }
-            }
-            if (cobro?.cobroDetalleList?.length > 0) {
-              const pagoTransferencia = cobro.cobroDetalleList.find(
-                (cd) => cd.formaPago?.descripcion === 'TRANSFERENCIA'
-              );
-
-              if (pagoTransferencia) {
-                const sucursalId = this.cajaService.selectedCaja?.sucursalId || this.mainService.sucursalActual?.id;
-
-                const totalTransferencia = cobro.cobroDetalleList
-                  .filter(cd => cd.formaPago?.descripcion === 'TRANSFERENCIA')
-                  .reduce((acc, curr) => acc + curr.valor, 0);
-
-                if (sucursalId && totalTransferencia > 0) {
-                  this.notificationHttpService.sendVentaTransferenciaNotification(
+              if (ventaCreditoInput != null && ventaCreditoInput.clienteId != null) {
+                const sucursalId = ventaCreditoInput.sucursalId || this.mainService.sucursalActual?.id;
+                const personaId = venta.cliente?.persona?.id;
+  
+                if (personaId && sucursalId) {
+                  this.notificationHttpService.sendCompraCreditoNotification(
                     res.id,
                     sucursalId,
-                    totalTransferencia,
-                    this.mainService.usuarioActual?.persona?.nombre,
+                    personaId,
+                    ventaCreditoInput.valorTotal,
                     this.mainService.sucursalActual?.nombre
                   ).subscribe({
-                    next: () => console.log('Notificación de Transferencia enviada exitosamente'),
-                    error: (err) => console.error('Error al enviar notificación de transferencia:', err)
+                    next: () => console.log('Notificación de compra a crédito enviada exitosamente'),
+                    error: (err) => console.error('Error al enviar notificación de compra a crédito:', err)
                   });
                 }
               }
-            }
-
-            const sucursalId =
-              this.cajaService.selectedCaja?.sucursalId ||
-              this.mainService.sucursalActual?.id;
-            if (res.id && sucursalId) {
-              this.getStockCriticoItems$(sucursalId)
-                .pipe(untilDestroyed(this))
-                .subscribe((stockCriticoItems) => {
-                  if (stockCriticoItems.length === 0) {
-                    return;
-                  }
-                  this.notificationHttpService
-                    .sendVentaStockCriticoNotification({
-                      ventaId: res.id,
+              if (cobro?.cobroDetalleList?.length > 0) {
+                const pagoTransferencia = cobro.cobroDetalleList.find(
+                  (cd) => cd.formaPago?.descripcion === 'TRANSFERENCIA'
+                );
+  
+                if (pagoTransferencia) {
+                  const sucursalId = this.cajaService.selectedCaja?.sucursalId || this.mainService.sucursalActual?.id;
+  
+                  const totalTransferencia = cobro.cobroDetalleList
+                    .filter(cd => cd.formaPago?.descripcion === 'TRANSFERENCIA')
+                    .reduce((acc, curr) => acc + curr.valor, 0);
+  
+                  if (sucursalId && totalTransferencia > 0) {
+                    this.notificationHttpService.sendVentaTransferenciaNotification(
+                      res.id,
                       sucursalId,
-                      usuarioNombre:
-                        this.mainService.usuarioActual?.persona?.nombre,
-                      sucursalNombre: this.mainService.sucursalActual?.nombre,
-                      items: stockCriticoItems,
-                    })
-                    .subscribe({
-                      next: () =>
-                        console.log(
-                          "Notificación de stock crítico enviada exitosamente"
-                        ),
-                      error: (err) =>
-                        console.error(
-                          "Error al enviar notificación de stock crítico:",
-                          err
-                        ),
+                      totalTransferencia,
+                      this.mainService.usuarioActual?.persona?.nombre,
+                      this.mainService.sucursalActual?.nombre
+                    ).subscribe({
+                      next: () => console.log('Notificación de Transferencia enviada exitosamente'),
+                      error: (err) => console.error('Error al enviar notificación de transferencia:', err)
                     });
-                });
+                  }
+                }
+              }
+  
+              const sucursalId =
+                this.cajaService.selectedCaja?.sucursalId ||
+                this.mainService.sucursalActual?.id;
+              if (res.id && sucursalId) {
+                this.getStockCriticoItems$(sucursalId)
+                  .pipe(untilDestroyed(this))
+                  .subscribe((stockCriticoItems) => {
+                    if (stockCriticoItems.length === 0) {
+                      return;
+                    }
+                    this.notificationHttpService
+                      .sendVentaStockCriticoNotification({
+                        ventaId: res.id,
+                        sucursalId,
+                        usuarioNombre:
+                          this.mainService.usuarioActual?.persona?.nombre,
+                        sucursalNombre: this.mainService.sucursalActual?.nombre,
+                        items: stockCriticoItems,
+                      })
+                      .subscribe({
+                        next: () =>
+                          console.log(
+                            "Notificación de stock crítico enviada exitosamente"
+                          ),
+                        error: (err) =>
+                          console.error(
+                            "Error al enviar notificación de stock crítico:",
+                            err
+                          ),
+                      });
+                  });
+              }
+  
+              const tarjetaPagos = this._pendingTarjetaPagos;
+              this._pendingTarjetaPagos = [];
+              this.registrarPagosConTarjeta(tarjetaPagos, res.id);
+  
+              this.resetForm();
+              obs.next(res);
+            } else {
+              this.notificacionSnackbar.notification$.next({
+                color: NotificacionColor.danger,
+                texto: "Ups! Ocurrió un problema al guardar",
+                duracion: 3,
+              });
+              obs.next(null);
             }
-
-            const tarjetaPagos = this._pendingTarjetaPagos;
-            this._pendingTarjetaPagos = [];
-            this.registrarPagosConTarjeta(tarjetaPagos, res.id);
-
-            this.resetForm();
-            obs.next(res);
-          } else {
+          },
+          // Sin este handler el error quedaba sin manejar: la venta no se
+          // guardaba y el cajero no se enteraba. Cuando ya se emitió la
+          // factura eso deja una factura legal sin venta asociada, con el
+          // número de timbrado ya consumido y el stock sin descontar.
+          error: (err) => {
+            console.error("Error al guardar la venta:", err);
             this.notificacionSnackbar.notification$.next({
               color: NotificacionColor.danger,
-              texto: "Ups! Ocurrió un problema al guardar",
-              duracion: 3,
+              texto: facturaLegalId != null
+                ? "No se pudo guardar la venta y la factura ya fue emitida. Avise al encargado antes de continuar."
+                : "No se pudo guardar la venta. Verifique antes de continuar.",
+              duracion: 10,
             });
             obs.next(null);
-          }
+          },
         });
     });
   }


### PR DESCRIPTION
## Qué resuelve

Dos defectos del POS que dejan **facturas legales emitidas y numeradas sin venta asociada** — sin stock descontado y sin entrar al arqueo de caja.

Va junto con [franco-system-backend-filial#118](https://github.com/GabFrank/franco-system-backend-filial/pull/118), que ataca la causa del lado del filial.

### 1. `venta-touch.component.ts` — subscribe sin manejo de error

`onSaveVenta` tenía un solo callback, sin `error:`. Si la mutación fallaba, el error quedaba sin manejar: la venta no se guardaba y **el cajero no se enteraba**. Con la factura ya emitida, eso deja el comprobante sin respaldo.

Se pasa a `{ next, error }` con handler que loguea y avisa, con mensaje distinto según haya factura emitida. Además `res.id` → `res?.id`: un `res` nulo tiraba un TypeError dentro del callback y producía el mismo silencio.

> El cuerpo del callback queda reindentado por el nivel de anidamiento nuevo. **Revisar con `git diff -w`** — el cambio real son ~20 líneas.

### 2. `add-factura-legal-dialog.component.ts` — reintento que re-emite

El "fallback al servidor local" mandaba `servidor=false`, **igual que el intento principal**, así que no caía a otro servidor: volvía a llamar al mismo filial. Y como el backend puede fallar después de haber guardado la factura, ese reintento emitía una segunda con otro número de timbrado.

Emitir es irreversible, así que ante una respuesta que no confirma ya no se reintenta solo: se libera el botón y se le pide al cajero que verifique en la lista antes de volver a intentar.

## Verificación

Ambos fixes probados en la app corriendo, no solo por lectura de código.

### Fix 1

POS → ítem → Pago → emitir factura → bajar el filial (8082) → Finalizar.

Resultado: snackbar *"No se pudo guardar la venta y la factura ya fue emitida. Avise al encargado antes de continuar."*, `console.error` con el `ApolloError` (`Http failure response for http://localhost:8082/graphql: 0 Unknown Error`), ninguna venta creada, y los ítems siguen en el carrito para reintentar.

### Fix 2

Para reproducir el fallo real en vez de simularlo, se corrió el **filial sin el fix de #118** (que todavía lanza la excepción después de haber guardado la factura) contra este frontend ya parcheado, con el central caído y una dirección cargada en el cliente.

Log del filial:

```
14:55:58.243 INFO   DE generado para factura ID: 33084 CDC=0180099482502100100143822...
14:55:58.312 ERROR  Error al guardar factura legal: Error la conectar con el servidor central:
                    I/O error on POST "http://localhost:8081/api/personas": Connection refused
14:55:58.316 WARN   graphql.GraphQLException: Error al guardar factura legal...
```

La factura se commiteó, `syncPersona` reventó, y la excepción salió como `GraphQLException` — el gatillo exacto del cluster de 8 huérfanas del 02/09 en producción.

Resultado en la base: **una sola factura** (`33084`). Con el código anterior, ahí `trySaveFacturaLocal` emitía la `33085` y quedaban las dos huérfanas. El diálogo quedó abierto con el botón habilitado de nuevo (`guardando = false`) y no hubo re-emisión.

## Alcance

**No afecta la emisión administrativa** del módulo financiero. Ese camino entra por la rama `isServidor` → `onSaveFacturaToFilial`, que queda intacta; el cambio está en el `else`. `trySaveFacturaLocal`, que se elimina, tenía sus dos únicos llamadores ahí dentro.

## Riesgo

**Medio.** El fix 1 solo agrega un handler que antes no existía. El fix 2 **quita** un reintento: si había casos en que ese reintento salvaba una emisión legítimamente fallida, ahora el cajero tiene que reintentar a mano. Es deliberado — re-emitir un documento fiscal automáticamente es peor que pedir verificación.

Sin impacto en auto-update: no toca `installer.nsh`, `electron-builder.json` ni manifests. Sin cambios de schema GraphQL. Rollback: revertir los dos commits.

`npm run check` (AOT) limpio sobre la punta de `develop`: 26 warnings, todos CommonJS preexistentes, cero errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNbduUkU1PrBwbnPwdEpJG