### PR TITLE
fix(caja): evitar que transferir caja se superponga con las acciones del conteo

### DIFF
--- a/src/app/modules/financiero/conteo/adicionar-conteo-dialog/adicionar-conteo-dialog.component.html
+++ b/src/app/modules/financiero/conteo/adicionar-conteo-dialog/adicionar-conteo-dialog.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="column" fxLayoutGap="10px" style="width: 100%; height: 100%">
+<div fxLayout="column" fxLayoutGap="6px" style="width: 100%; height: 100%">
   <div
     fxFlex="80"
     fxLayout="row"
@@ -10,10 +10,10 @@
       <form [formGroup]="gsFormGroup">
         <mat-card
           fxLayout="column"
-          fxLayoutGap="5px"
+          fxLayoutGap="2px"
           style="
             background-color: rgb(32, 32, 32);
-            padding: 10px;
+            padding: 6px;
             border-color: balck;
           "
         >
@@ -157,8 +157,8 @@
       <form [formGroup]="rsFormGroup">
         <mat-card
           fxLayout="column"
-          fxLayoutGap="5px"
-          style="background-color: rgb(32, 32, 32); padding: 10px"
+          fxLayoutGap="2px"
+          style="background-color: rgb(32, 32, 32); padding: 6px"
         >
           <mat-form-field
             style="height: 30px !important"
@@ -372,8 +372,8 @@
       <form [formGroup]="dsFormGroup">
         <mat-card
           fxLayout="column"
-          fxLayoutGap="5px"
-          style="background-color: rgb(32, 32, 32); padding: 10px"
+          fxLayoutGap="2px"
+          style="background-color: rgb(32, 32, 32); padding: 6px"
         >
           <mat-form-field
             style="height: 30px !important"
@@ -480,7 +480,6 @@
       </form>
     </div>
   </div>
-  <br />
   <div fxFlex>
     <button
       *ngIf="selectedConteo == null"

--- a/src/app/modules/financiero/conteo/adicionar-conteo-dialog/adicionar-conteo-dialog.component.scss
+++ b/src/app/modules/financiero/conteo/adicionar-conteo-dialog/adicionar-conteo-dialog.component.scss
@@ -92,3 +92,9 @@
     vertical-align: middle;
   }
 }
+
+// Los titulos de moneda no necesitan el margen por defecto de h3: ese aire es justo
+// lo que empujaba las acciones del conteo fuera del alto del dialogo.
+:host h3 {
+  margin: 0 0 6px;
+}

--- a/src/app/modules/financiero/pdv/caja/adicionar-caja-dialog/adicionar-caja-dialog.component.html
+++ b/src/app/modules/financiero/pdv/caja/adicionar-caja-dialog/adicionar-caja-dialog.component.html
@@ -1,9 +1,9 @@
-<div fxLayout="column" fxLayoutAlign="start" style="height: 90%; padding: 20px;">
+<div class="caja-dialog__contenido" fxLayout="column" fxLayoutAlign="start" style="padding: 20px;">
   <div fxFlex="5" style="width: 100%; text-align: center; font-size: large;">
     <h3 *ngIf="selectedCaja?.id != null">Editar Caja</h3>
     <h3 *ngIf="selectedCaja?.id == null">Nueva Caja</h3>
   </div>
-  <div fxFlex="95" fxLayout="row" style="width: 100%; height: 100%">
+  <div class="caja-dialog__cuerpo" fxFlex="95" fxLayout="row" style="width: 100%; height: 100%">
     <mat-card
       appearance="outlined"
       fxFlex="30%"
@@ -189,7 +189,7 @@
         </div>
       </div> -->
     </mat-card>
-    <div fxFlex="70%" fxLayout="column">
+    <div class="caja-dialog__stepper" fxFlex="70%" fxLayout="column">
       <div fxFlex="100">
         <mat-stepper linear #stepper>
           <!-- <mat-step>

--- a/src/app/modules/financiero/pdv/caja/adicionar-caja-dialog/adicionar-caja-dialog.component.scss
+++ b/src/app/modules/financiero/pdv/caja/adicionar-caja-dialog/adicionar-caja-dialog.component.scss
@@ -6,6 +6,21 @@ input {
   pointer-events: none !important;
 }
 
+// Scopeado con :host: un ::ng-deep suelto se emite sin el atributo del componente
+// y le pisaria el stepper a toda la app.
+:host ::ng-deep {
+  // El header es solo indicador de paso (no se clickea): no necesita los 72px por defecto.
+  .mat-horizontal-stepper-header {
+    height: 48px !important;
+    padding: 0 16px !important;
+  }
+
+  // El contenedor reserva 24px abajo que aca solo empujan las acciones del conteo.
+  .mat-horizontal-content-container {
+    padding-bottom: 8px !important;
+  }
+}
+
 .verificarMaletin:hover {
   color: #43a047;
 }
@@ -20,10 +35,43 @@ mat-step {
   height: 100%;
 }
 
+// El dialogo es una columna: el contenido scrollea y la barra de transferir queda
+// siempre anclada abajo. Antes el contenido tenia height: 90% fijo y desbordaba,
+// tapando el boton de transferir con las acciones del conteo (editar montos / ver historial).
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.caja-dialog__contenido {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+// El cuerpo no crece: si el conteo es mas alto que el dialogo, scrollea la columna
+// del stepper y el menu lateral queda siempre visible.
+.caja-dialog__cuerpo {
+  min-height: 0;
+}
+
+.caja-dialog__stepper {
+  min-height: 0;
+  overflow: auto;
+}
+
 .botonTransferir {
+  flex: 0 0 auto;
   justify-content: end;
   align-items: center;
   display: flex;
   gap: 10px;
-  padding-right: 20px
+  padding: 8px 20px 12px;
+  box-sizing: border-box;
 }

--- a/src/app/modules/financiero/pdv/caja/list-caja/list-caja.component.ts
+++ b/src/app/modules/financiero/pdv/caja/list-caja/list-caja.component.ts
@@ -163,7 +163,8 @@ export class ListCajaComponent implements OnInit {
         caja,
       },
       width: "90%",
-      height: "80%",
+      // 90%: el conteo + las acciones + la barra de transferir entran sin scroll.
+      height: "90%",
       disableClose: true,
       autoFocus: true,
       restoreFocus: true,


### PR DESCRIPTION
## Qué resuelve

El botón **Transferir caja** del diálogo de caja se superponía con **Editar montos** (y con **Ver historial** cuando está visible).

El contenedor del contenido tenía `height: 90%` fijo, así que la fila de acciones del conteo desbordaba ese alto y quedaba pintada encima de `.botonTransferir`, que va después en el flujo normal.

## Qué cambia

- **`adicionar-caja-dialog.component.html` / `.scss`** — el diálogo pasa a ser una columna flex: el cuerpo ocupa el alto disponible y la barra de transferir es una fila propia anclada abajo (`flex: 0 0 auto`), en vez de flotar después del contenido. Lo que scrollea (si hiciera falta) es solo la columna del stepper, así que el menú lateral queda siempre visible.
- **`adicionar-conteo-dialog.component.html` / `.scss`** — se recupera espacio muerto para que además entre todo sin scroll: un `<br />` huérfano, los márgenes por defecto de los `h3` de moneda y la separación entre los campos de billetes (5 → 2 px, padding de tarjetas 10 → 6 px).
- **`list-caja.component.ts`** — el diálogo se abre al 90% de alto en vez del 80% (el otro punto de entrada, venta touch, ya usaba 95%).

Las reglas nuevas de stepper van scopeadas con `:host ::ng-deep`: un `::ng-deep` suelto se emite sin el atributo del componente y le cambiaría el stepper a toda la app.

Resultado: el contenido mínimo bajó de 755 a 626 px y el diálogo ofrece 764 px, así que no aparece scroll. El orden de los botones no cambia.

## Cómo probarlo

1. *Lista de cajas* → una caja abierta → menú de la fila → **Ir a Caja**.
2. Paso **Conteo Apertura**: la fila `Editar montos` / `Ver historial` tiene que quedar completa y bien separada de `Transferir caja`, sin scroll.
3. Repetir en **Maletín** y **Conteo Cierre**.

Verificado en los tres pasos, incluyendo el caso de `Editar montos` y `Ver historial` visibles a la vez (140 px de separación con la barra de transferir).

## Riesgo

**Bajo.** Solo CSS y marcado de layout, sin cambios de lógica, datos ni GraphQL. `npm run check` (AOT de producción) pasa sin errores.

## Impacto en auto-update

Ninguno: no se tocan `installer.nsh`, `electron-builder.json` ni los manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oCMTiJd1oLtc9uaMbyVV8