### PR TITLE
fix(pdv): arreglar el layout del dialogo de reimpresion de tickets y centrar utilitarios

### DIFF
--- a/src/app/modules/operaciones/venta/ultimas-ventas-dialog/ultimas-ventas-dialog.component.html
+++ b/src/app/modules/operaciones/venta/ultimas-ventas-dialog/ultimas-ventas-dialog.component.html
@@ -1,11 +1,11 @@
-<div class="container-fluid" style="padding: 16px;" fxLayout="column" style="height: 100%; width: 100%;">
-    <div class="row" fxFlex="10">
+<div class="container-fluid ultimas-ventas" fxLayout="column">
+    <div class="row ultimas-ventas__fija">
         <div class="col-12 mb-3">
             <h2 class="titulo-center">{{titulo}}</h2>
         </div>
     </div>
 
-    <div class="row mb-3" fxFlex="10" style="height: 100%; width: 100%;">
+    <div class="row mb-3 ultimas-ventas__fija">
         <div class="col-md-8 offset-md-2">
             <mat-card>
                 <mat-card-content>
@@ -28,14 +28,15 @@
         </div>
     </div>
 
-    <div class="row" fxFlex="70" style="height: 100%; width: 100%;">
+    <div class="row ultimas-ventas__tabla">
         <div class="col-12">
             <div *ngIf="isLoading" class="text-center p-3">
                 <mat-spinner diameter="40" class="mx-auto"></mat-spinner>
                 <p class="mt-2">Cargando datos...</p>
             </div>
 
-            <div class="mat-elevation-z2" *ngIf="!isLoading">
+            <div class="mat-elevation-z2 ultimas-ventas__grilla" *ngIf="!isLoading">
+                <div class="ultimas-ventas__scroll">
                 <table mat-table [dataSource]="dataSource" matSort class="w-100">
                     <!-- ID Column -->
                     <ng-container matColumnDef="id">
@@ -77,13 +78,7 @@
                     <ng-container matColumnDef="estado">
                         <th mat-header-cell *matHeaderCellDef mat-sort-header> Estado </th>
                         <td mat-cell *matCellDef="let venta">
-                            <span [ngClass]="{
-                                        'badge bg-success': venta.estado === 'CONCLUIDA',
-                                        'badge bg-danger': venta.estado === 'CANCELADA',
-                                        'badge bg-warning': venta.estado !== 'CONCLUIDA' && venta.estado !== 'CANCELADA'
-                                    }">
-                                {{venta.estado}}
-                            </span>
+                            <span class="estado-chip" [ngClass]="'estado-' + venta.estado">{{venta.estado}}</span>
                         </td>
                     </ng-container>
 
@@ -97,15 +92,17 @@
                     <!-- Acciones Column -->
                     <ng-container matColumnDef="acciones">
                         <th mat-header-cell *matHeaderCellDef> Acciones </th>
-                        <td mat-cell *matCellDef="let venta; let i = index" class="action-buttons">
-                            <button *ngIf="data?.cancelacion == true && venta?.estado == 'CONCLUIDA'" mat-mini-fab
-                                color="warn" matTooltip="Cancelar venta" (click)="cancelarVenta(venta, i)">
-                                <mat-icon>cancel</mat-icon>
-                            </button>
-                            <button *ngIf="data?.reimpresion == true" mat-mini-fab color="primary"
-                                matTooltip="Reimprimir venta" (click)="reimpresionVenta(venta.id)">
-                                <mat-icon>print</mat-icon>
-                            </button>
+                        <td mat-cell *matCellDef="let venta; let i = index">
+                            <div class="action-buttons">
+                                <button *ngIf="data?.cancelacion == true && venta?.estado == 'CONCLUIDA'" mat-mini-fab
+                                    color="warn" matTooltip="Cancelar venta" (click)="cancelarVenta(venta, i)">
+                                    <mat-icon>cancel</mat-icon>
+                                </button>
+                                <button *ngIf="data?.reimpresion == true" mat-mini-fab color="primary"
+                                    matTooltip="Reimprimir venta" (click)="reimpresionVenta(venta.id)">
+                                    <mat-icon>print</mat-icon>
+                                </button>
+                            </div>
                         </td>
                     </ng-container>
 
@@ -119,6 +116,7 @@
                         </td>
                     </tr>
                 </table>
+                </div>
 
                 <mat-paginator #paginator itemsPerPageLabel="Itens por página" [pageSizeOptions]="pageSizeOptions"
                     [pageSize]="pageSize" [length]="selectedPageInfo?.getTotalElements" (page)="handlePageEvent($event)"
@@ -129,7 +127,7 @@
     </div>
 
     <!-- add here a salir button on the right side of the page -->
-    <div class="row" fxFlex="10">
+    <div class="row ultimas-ventas__acciones">
         <div style="text-align: right; width: 100%; padding-right: 50px;">
             <button mat-raised-button color="primary" style="width: 120px;" (click)="salir()">Salir</button>
         </div>

--- a/src/app/modules/operaciones/venta/ultimas-ventas-dialog/ultimas-ventas-dialog.component.scss
+++ b/src/app/modules/operaciones/venta/ultimas-ventas-dialog/ultimas-ventas-dialog.component.scss
@@ -1,13 +1,34 @@
-th, td {
-    text-align: center;
+th,
+td {
+    // !important: el tema MDC alinea a la izquierda por defecto y le gana a la clase del componente.
+    text-align: center !important;
+    vertical-align: middle;
+}
+
+// Los encabezados ordenables envuelven el texto en un flex, asi que el text-align de
+// arriba no los mueve: quedaban a la izquierda mientras las celdas iban centradas.
+// La flecha de orden ademas reserva su ancho en el flujo y corria el titulo 9px, por eso
+// va fuera del flujo, apoyada al borde de la celda.
+:host ::ng-deep .mat-sort-header-container {
+    justify-content: center;
+    position: relative;
+}
+
+:host ::ng-deep .mat-sort-header-arrow {
+    position: absolute;
+    right: 0;
 }
 
 .mat-column-acciones {
     width: 120px;
 }
 
+// Va en un div dentro de la celda, no en el propio td: un display: flex sobre el td lo
+// saca del layout de tabla, deja de tomar el alto de la fila y los iconos quedan unos
+// pixeles mas arriba que el resto de los datos.
 .action-buttons {
     display: flex;
+    align-items: center;
     justify-content: center;
     gap: 8px;
 }
@@ -26,12 +47,22 @@ table {
     margin-bottom: 16px;
 }
 
-.badge {
-    padding: 6px 12px;
-    border-radius: 16px;
-    color: white;
+// Mismo chip de estado que usa list-solicitud-pago, para que se lean igual en todo el sistema.
+.estado-chip {
+    display: inline-block;
+    padding: 3px 12px;
+    border-radius: 12px;
+    color: #fff;
     font-size: 12px;
     font-weight: 500;
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+    background-color: #607d8b;
+
+    &.estado-CONCLUIDA { background-color: #43a047; }
+    &.estado-CANCELADA { background-color: #e53935; }
+    &.estado-ABIERTA { background-color: #1e88e5; }
+    &.estado-EN_VERIFICACION { background-color: #fb8c00; }
 }
 
 // Dialog dimensions
@@ -68,5 +99,63 @@ table {
 @media (max-width: 768px) {
     ::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
         min-width: 100%;
+    }
+}
+
+// El dialogo es una columna: titulo, buscador y el boton salir no se encogen, y lo
+// unico que scrollea es la tabla. Antes cada fila llevaba un height: 100% inline con
+// fxFlex, asi que la tabla desbordaba y el boton salir quedaba flotando encima de ella.
+:host {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.ultimas-ventas {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    padding: 16px;
+    box-sizing: border-box;
+
+    &__fija {
+        flex: 0 0 auto;
+    }
+
+    &__tabla {
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow: hidden;
+
+        > .col-12 {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+            min-height: 0;
+        }
+    }
+
+    // Scrollea solo el cuerpo de la tabla: el paginador queda visible sin bajar la lista.
+    &__grilla {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        overflow: hidden;
+    }
+
+    &__scroll {
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow: auto;
+    }
+
+    &__acciones {
+        flex: 0 0 auto;
+        padding-top: 12px;
     }
 }

--- a/src/app/modules/operaciones/venta/ultimas-ventas-dialog/ultimas-ventas-dialog.component.ts
+++ b/src/app/modules/operaciones/venta/ultimas-ventas-dialog/ultimas-ventas-dialog.component.ts
@@ -122,7 +122,7 @@ export class UltimasVentasDialogComponent implements OnInit {
       .confirm(
         "ATENCIÓN!!",
         "Realmente desea cancelar la venta " + venta.id + "?",
-        "Al cancelar una venta debe escribir el motivo de canceación en el ticket y enviar una foto de la nota"
+        "Al cancelar una venta debe escribir el motivo de cancelación en el ticket y enviar una foto de la nota"
       ).pipe(untilDestroyed(this))
       .subscribe((res) => {
         if (res) {

--- a/src/app/modules/pdv/comercial/venta-touch/utilitarios-dialog/utilitarios-dialog.component.html
+++ b/src/app/modules/pdv/comercial/venta-touch/utilitarios-dialog/utilitarios-dialog.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="row wrap" style="width: 100%; padding: 20px !important;" fxLayoutGap="20px">
+<div class="utilitarios" fxLayout="row wrap" fxLayoutAlign="center center" style="width: 100%; padding: 20px !important;" fxLayoutGap="20px">
   <mat-card
     appearance="outlined"
     fxFlex="15"

--- a/src/app/modules/pdv/comercial/venta-touch/utilitarios-dialog/utilitarios-dialog.component.scss
+++ b/src/app/modules/pdv/comercial/venta-touch/utilitarios-dialog/utilitarios-dialog.component.scss
@@ -1,6 +1,12 @@
+// El margin-bottom que traian las tarjetas dejaba 30px de aire abajo contra 20px arriba.
+// La separacion entre filas ahora la da el row-gap del contenedor, que no desbalancea.
 :host::ng-deep mat-card {
-    margin-bottom: 10px;
+    margin-bottom: 0;
   }
+
+.utilitarios {
+  row-gap: 20px;
+}
 
   p {
     font-size: medium;


### PR DESCRIPTION
## Qué resuelve

Varios ajustes de UI en el PDV, todos verificados en la app corriendo.

### 1. El botón Salir flotaba sobre la lista de tickets

Cada fila del diálogo llevaba `fxFlex` **más** un `height: 100%` inline, así que todas pedían el alto completo del contenedor: la tabla desbordaba y `Salir` quedaba pintado encima de la lista. Ahora el diálogo es una columna flex — título, buscador y `Salir` no se encogen y lo único que scrollea es la tabla.

De paso, el paginador estaba dentro de esa zona desbordada (había que scrollear a ciegas para cambiar de página): ahora scrollea solo el cuerpo de la tabla y el paginador queda fijo y visible.

También el div raíz tenía **dos atributos `style`** y el segundo pisaba al primero, así que su `padding: 16px` no se aplicaba nunca.

### 2. Ajustes de la tabla

- **`th` y `td` centrados de verdad.** El `text-align: center` ya estaba pero lo pisaba el tema MDC. Además los encabezados **ordenables** envuelven el texto en un flex que no se mueve con `text-align`: estaban entre 33 y 177 px corridos a la izquierda mientras los datos iban centrados. La flecha de orden reservaba su ancho en el flujo y corría el título otros 9 px, así que va fuera del flujo.
- **Columna Acciones desnivelada.** La causa era `display: flex` sobre el propio `<td>`, que lo saca del layout de tabla: dejaba de tomar el alto de la fila (48 px contra 52) y los iconos quedaban 2,6 px arriba. El flex pasó a un `div` dentro de la celda. Desfase final: 0,27 px.
- **Estado en pill.** Reemplaza las clases de Bootstrap (`badge bg-success`/`bg-danger`/`bg-warning`) por el `estado-chip` que ya usa `list-solicitud-pago`, cubriendo los cuatro valores de `VentaEstado`.

### 3. Diálogo de utilitarios descentrado

Los botones quedaban pegados a la izquierda con un hueco a la derecha (`row wrap` sin `fxLayoutAlign`, o sea `flex-start`). De alto tampoco estaba parejo: 20 px arriba contra 30 abajo, por el `margin-bottom` de las `mat-card`. Ahora **53,3 px a cada lado y 20 px arriba y abajo**.

### 4. Typo

"el motivo de ~~canceación~~ **cancelación**" en el aviso al cancelar una venta. Era la única ocurrencia en el proyecto.

## Cómo probarlo

1. *PDV → Utilitarios (F1)*: los botones tienen que quedar centrados, con el mismo aire arriba y abajo.
2. *Reimpresión de ticket*: `Salir` abajo a la derecha sin tocar la lista, paginador visible sin scrollear, encabezados centrados sobre sus columnas y los iconos de impresora a la misma altura que los datos de la fila.
3. Probar el ordenamiento haciendo clic en un encabezado: la flecha aparece sin descentrar el título.
4. *Cancelación de venta* (mismo componente, otro modo): tocar el botón rojo de una fila muestra el aviso con el texto corregido — se puede cerrar con "No" sin cancelar nada.

## Riesgo

**Bajo.** Solo CSS, marcado de layout y un string. Sin cambios de lógica, datos ni GraphQL. `npm run check` (AOT de producción) pasa con 0 errores.

Nota: los estados CANCELADA, ABIERTA y EN_VERIFICACION se validaron por CSS, no en pantalla — en la caja de prueba solo había ventas CONCLUIDAS.

## Impacto en auto-update

Ninguno: no se tocan `installer.nsh`, `electron-builder.json` ni los manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oCMTiJd1oLtc9uaMbyVV8