### PR TITLE
feat(venta-tarjeta): acceso desde el PDV, confirmacion de diferencias y fixes de escaneo

### DIFF
--- a/src/app/modules/financiero/financiero.module.ts
+++ b/src/app/modules/financiero/financiero.module.ts
@@ -55,6 +55,7 @@ import { PrintTerminalPosDialogComponent } from "./terminal-pos/print-terminal-p
 import { ScanTerminalPosDialogComponent } from "./terminal-pos/scan-terminal-pos-dialog/scan-terminal-pos-dialog.component";
 import { TerminalPosDashboard } from "./terminal-pos/terminal-pos-dashboard/terminal-pos-dashboard.component";
 import { ListVentaTarjetaComponent } from "./venta-tarjeta/list-venta-tarjeta/list-venta-tarjeta.component";
+import { VentasTarjetaCajaDialogComponent } from "./venta-tarjeta/ventas-tarjeta-caja-dialog/ventas-tarjeta-caja-dialog.component";
 import { RegistrarVentaTarjetaDialogComponent } from "./venta-tarjeta/qr-pos/registrar-venta-tarjeta-dialog/registrar-venta-tarjeta-dialog.component";
 import { FormatoQrPosComponent } from "./venta-tarjeta/qr-pos/formato-qr-pos/formato-qr-pos.component";
 import { EditFormatoQrPosComponent } from "./venta-tarjeta/qr-pos/formato-qr-pos/edit-formato-qr-pos/edit-formato-qr-pos.component";
@@ -144,6 +145,7 @@ import { AddCuentaBancariaDialogComponent } from './cuenta-bancaria/add-cuenta-b
     ScanTerminalPosDialogComponent,
     TerminalPosDashboard,
     ListVentaTarjetaComponent,
+    VentasTarjetaCajaDialogComponent,
     RegistrarVentaTarjetaDialogComponent,
     FormatoQrPosComponent,
     EditFormatoQrPosComponent,

--- a/src/app/modules/financiero/venta-tarjeta/graphql/filtrarVentasTarjetaPorCaja.ts
+++ b/src/app/modules/financiero/venta-tarjeta/graphql/filtrarVentasTarjetaPorCaja.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { filtrarVentasTarjetaPorCajaQuery } from './graphql-query';
+
+@Injectable({ providedIn: 'root' })
+export class FiltrarVentasTarjetaPorCajaGQL extends Query<any> {
+  document = filtrarVentasTarjetaPorCajaQuery;
+}

--- a/src/app/modules/financiero/venta-tarjeta/graphql/graphql-query.ts
+++ b/src/app/modules/financiero/venta-tarjeta/graphql/graphql-query.ts
@@ -154,3 +154,56 @@ export const cobrosTarjetaDeVentaQuery = gql`
     }
   }
 `;
+
+
+/**
+ * Pre-chequeo de cupon ya usado, contra el FILIAL. Devuelve el motivo o null.
+ *
+ * La validacion de verdad corre igual al guardar; esto solo la adelanta. Detectarlo recien en el
+ * saveVenta dejaba al cajero enterandose cuando la venta ya estaba registrada y el dato escaneado
+ * ya se habia descartado.
+ */
+export const motivoCuponNoUsableQuery = gql`
+  query motivoCuponNoUsable($qrCrudo: String, $identificadorTransaccion: String, $sucId: ID!) {
+    data: motivoCuponNoUsable(
+      qrCrudo: $qrCrudo
+      identificadorTransaccion: $identificadorTransaccion
+      sucId: $sucId
+    )
+  }
+`;
+
+/**
+ * Ventas con tarjeta de UNA caja, paginadas y filtradas, contra el FILIAL.
+ *
+ * `cajaId` y `sucId` acotan el universo del lado del servidor, asi que la pantalla no puede ver
+ * otra caja ni otra sucursal aunque alguien manipule los filtros.
+ */
+export const filtrarVentasTarjetaPorCajaQuery = gql`
+  query filtrarVentasTarjetaPorCaja(
+    $cajaId: ID!, $sucId: ID!, $estado: String, $terminalPosId: ID, $monedaId: ID,
+    $montoDesde: Float, $montoHasta: Float, $page: Int, $size: Int
+  ) {
+    data: filtrarVentasTarjetaPorCaja(
+      cajaId: $cajaId, sucId: $sucId, estado: $estado, terminalPosId: $terminalPosId,
+      monedaId: $monedaId, montoDesde: $montoDesde, montoHasta: $montoHasta,
+      page: $page, size: $size
+    ) {
+      getContent {
+        id
+        sucursalId
+        ventaId
+        cajaId
+        terminalPos { id codigo descripcion proveedorServicio { id } moneda { id simbolo decimales } }
+        moneda { id simbolo decimales }
+        codigoAutorizacion
+        numeroBoleta
+        monto
+        montoEscaneado
+        estado
+        creadoEn
+      }
+      getTotalElements
+    }
+  }
+`;

--- a/src/app/modules/financiero/venta-tarjeta/graphql/motivoCuponNoUsable.ts
+++ b/src/app/modules/financiero/venta-tarjeta/graphql/motivoCuponNoUsable.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { motivoCuponNoUsableQuery } from './graphql-query';
+
+export interface MotivoCuponNoUsableResponse {
+  data: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MotivoCuponNoUsableGQL extends Query<MotivoCuponNoUsableResponse> {
+  document = motivoCuponNoUsableQuery;
+}

--- a/src/app/modules/financiero/venta-tarjeta/qr-pos/escanear-cupon-dialog/escanear-cupon-dialog.component.html
+++ b/src/app/modules/financiero/venta-tarjeta/qr-pos/escanear-cupon-dialog/escanear-cupon-dialog.component.html
@@ -7,7 +7,7 @@
 
   <div class="monto-caja">
     <span class="monto-label">A cobrar</span>
-    <span class="monto">{{ data.monto | number: '1.0-2' }} {{ data.monedaSimbolo || 'Gs.' }}</span>
+    <span class="monto">{{ data.monto | number: digitosMonto }} {{ data.monedaSimbolo || 'Gs.' }}</span>
     <!-- Dato útil ANTES de escanear: si la terminal está en otra moneda, el cupón va a venir en
          esa y no va a servir para este cobro. -->
     <span class="aviso-moneda" *ngIf="avisoMonedaTerminal">{{ avisoMonedaTerminal }}</span>

--- a/src/app/modules/financiero/venta-tarjeta/qr-pos/escanear-cupon-dialog/escanear-cupon-dialog.component.ts
+++ b/src/app/modules/financiero/venta-tarjeta/qr-pos/escanear-cupon-dialog/escanear-cupon-dialog.component.ts
@@ -4,6 +4,7 @@ import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dial
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { debounceTime, filter, map } from 'rxjs/operators';
 import { ConfirmDialogComponent, ConfirmDialogData } from '../../../../../shared/components/confirm-dialog/confirm-dialog.component';
+import { VentaTarjetaService } from '../../venta-tarjeta.service';
 import { FormatoQrPosService } from '../formato-qr-pos.service';
 import { DatosCupon, FormatoQrPos } from '../formato-qr-pos.model';
 import {
@@ -29,6 +30,8 @@ export interface EscanearCuponDialogData {
   monedaTerminalId?: number;
   monedaTerminalSimbolo?: string;
   decimalesPorMoneda?: DecimalesPorMoneda;
+  /** Necesaria para preguntarle al filial si el cupon ya fue usado. */
+  sucursalId?: number;
 }
 
 /**
@@ -58,7 +61,8 @@ export class EscanearCuponDialogComponent implements OnInit {
     @Inject(MAT_DIALOG_DATA) public data: EscanearCuponDialogData,
     public dialogRef: MatDialogRef<EscanearCuponDialogComponent>,
     private formatoQrPosService: FormatoQrPosService,
-    private matDialog: MatDialog
+    private matDialog: MatDialog,
+    private ventaTarjetaService: VentaTarjetaService
   ) {}
 
   /**
@@ -68,7 +72,24 @@ export class EscanearCuponDialogComponent implements OnInit {
    */
   avisoMonedaTerminal = '';
 
+  /** Mientras se consulta al filial si el cupon ya fue usado. */
+  verificando = false;
+
+  /**
+   * Formato de `data.monto`, calculado una sola vez. Con un `1.0-2` fijo un cobro de 50,00 R$ se
+   * mostraba como "50": el minimo de decimales es 0 y se comian los ceros. El cajero compara este
+   * numero contra el ticket del POS en una pantalla donde tambien hay guaranies, asi que perder
+   * los decimales invita a confundir la escala — justo el error que esta feature existe para
+   * evitar. Se precalcula porque el template no puede llamar funciones ni getters.
+   */
+  digitosMonto = '1.0-2';
+
   ngOnInit(): void {
+    const decimales = this.data.monedaCobroId != null
+      ? this.data.decimalesPorMoneda?.[this.data.monedaCobroId]
+      : undefined;
+    if (decimales != null) this.digitosMonto = `1.${decimales}-${decimales}`;
+
     if (
       this.data.monedaTerminalId != null &&
       this.data.monedaCobroId != null &&
@@ -127,6 +148,36 @@ export class EscanearCuponDialogComponent implements OnInit {
       return;
     }
 
+    // Cupon ya usado: bloqueo duro, y va ANTES del cruce porque los bloqueos preceden a las
+    // confirmaciones. Se pregunta al filial en vez de esperar al guardado: detectarlo alli dejaba
+    // al cajero enterandose con la venta ya registrada, el cupon descartado y el registro caido a
+    // PENDIENTE — habia que volver a cargarlo desde la lista. Aca todavia tiene el ticket en la
+    // mano.
+    this.verificando = true;
+    this.ventaTarjetaService
+      .onMotivoCuponNoUsable(datos.qrCrudo, datos.identificadorTransaccion, Number(this.data.sucursalId))
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (motivo) => {
+          this.verificando = false;
+          if (motivo) {
+            this.errorLectura = motivo;
+            this.cuponControl.setValue('', { emitEvent: false });
+            return;
+          }
+          this.continuarTrasChequeo(datos);
+        },
+        // Falla abierta a proposito: si no se pudo consultar (filial caido, red), NO se bloquea.
+        // La validacion de verdad corre igual al guardar; impedir el escaneo porque no se pudo
+        // preguntar seria peor que el problema que esto resuelve.
+        error: () => {
+          this.verificando = false;
+          this.continuarTrasChequeo(datos);
+        },
+      });
+  }
+
+  private continuarTrasChequeo(datos: DatosCupon): void {
     if (formatoCruzado(datos.formato, this.data.proveedorServicioId)) {
       this.confirmarCruce(datos);
       return;

--- a/src/app/modules/financiero/venta-tarjeta/venta-tarjeta.model.ts
+++ b/src/app/modules/financiero/venta-tarjeta/venta-tarjeta.model.ts
@@ -1,6 +1,15 @@
 export interface VentaTarjeta {
   id: number;
   sucursalId: number;
+
+  /**
+   * El CENTRAL devuelve los objetos `caja` / `venta`; el FILIAL devuelve los escalares
+   * `cajaId` / `ventaId`. Conviven porque las dos pantallas usan el mismo modelo: la lista del
+   * sidebar consulta al central y la del PDV al filial.
+   */
+  cajaId?: number;
+  ventaId?: number;
+
   caja?: { id: number };
   sucursal?: { id: number; nombre: string; };
   venta?: { id: number; totalGs: number; };

--- a/src/app/modules/financiero/venta-tarjeta/venta-tarjeta.service.ts
+++ b/src/app/modules/financiero/venta-tarjeta/venta-tarjeta.service.ts
@@ -4,6 +4,8 @@ import { map } from 'rxjs/operators';
 import { GenericCrudService } from '../../../generics/generic-crud.service';
 import { SaveVentaTarjetaGQL, VentaTarjetaResult } from './graphql/saveVentaTarjeta';
 import { CountVentasTarjetaSinRegistrarDesktopGQL } from './graphql/countVentasTarjetaSinRegistrar';
+import { MotivoCuponNoUsableGQL } from './graphql/motivoCuponNoUsable';
+import { FiltrarVentasTarjetaPorCajaGQL } from './graphql/filtrarVentasTarjetaPorCaja';
 import { CancelarVentaTarjetaPorVentaIdGQL } from './graphql/cancelarVentaTarjetaPorVentaId';
 import { FiltrarVentasTarjetaGQL } from './graphql/filtrarVentasTarjeta';
 import { ImprimirReporteVentaTarjetaGQL } from './graphql/imprimirReporteVentaTarjeta';
@@ -57,6 +59,8 @@ export class VentaTarjetaService {
     private genericService: GenericCrudService,
     private saveVentaTarjetaGQL: SaveVentaTarjetaGQL,
     private countVentasTarjetaGQL: CountVentasTarjetaSinRegistrarDesktopGQL,
+    private motivoCuponNoUsableGQL: MotivoCuponNoUsableGQL,
+    private filtrarVentasTarjetaPorCajaGQL: FiltrarVentasTarjetaPorCajaGQL,
     private cancelarVentaTarjetaGQL: CancelarVentaTarjetaPorVentaIdGQL,
     private filtrarVentasTarjetaGQL: FiltrarVentasTarjetaGQL,
     private imprimirReporteVentaTarjetaGQL: ImprimirReporteVentaTarjetaGQL,
@@ -97,6 +101,49 @@ export class VentaTarjetaService {
             cd?.formaPago?.descripcion === 'TARJETA' && cd.pago && !cd.vuelto && !cd.descuento
         ))
       );
+  }
+
+  /**
+   * Ventas con tarjeta de una caja, contra el FILIAL (`servidor = false`, tercer argumento).
+   *
+   * Local a proposito: el PDV tiene que poder operar sin internet, y `completarVentaTarjeta`
+   * corre igual contra el filial. Listar contra el central para despues completar contra el
+   * filial era incoherente, y ademas exponia las ventas de las otras sucursales.
+   */
+  /**
+   * Ventas con tarjeta de una caja, paginadas y filtradas. Contra el FILIAL.
+   *
+   * `cajaId` y `sucId` los acota el servidor, no el cliente: la pantalla no puede ver otra caja
+   * ni otra sucursal aunque se manipulen los filtros.
+   */
+  onFiltrarPorCaja(params: {
+    cajaId: number; sucId: number; estado?: string; terminalPosId?: number; monedaId?: number;
+    montoDesde?: number; montoHasta?: number; page?: number; size?: number;
+  }): Observable<PageInfo<VentaTarjeta>> {
+    return this.genericService.onCustomQuery(
+      this.filtrarVentasTarjetaPorCajaGQL,
+      params,
+      false,
+      null,
+      true
+    );
+  }
+
+  /**
+   * Motivo por el que el cupon no se puede usar, o null si esta libre. Contra el FILIAL.
+   *
+   * Es un ADELANTO del aviso, no la validacion: el backend vuelve a chequear al guardar y esa es
+   * la que manda. Por eso el que llama tiene que tratar un error de red como "seguir": bloquear
+   * el escaneo porque no se pudo consultar seria peor que el problema que resuelve.
+   */
+  onMotivoCuponNoUsable(qrCrudo: string, identificadorTransaccion: string, sucId: number): Observable<string> {
+    return this.genericService.onCustomQuery(
+      this.motivoCuponNoUsableGQL,
+      { qrCrudo, identificadorTransaccion, sucId },
+      false,
+      null,
+      true
+    );
   }
 
   onCountSinRegistrar(cajaId: number, sucId: number): Observable<number> {

--- a/src/app/modules/financiero/venta-tarjeta/ventas-tarjeta-caja-dialog/ventas-tarjeta-caja-dialog.component.html
+++ b/src/app/modules/financiero/venta-tarjeta/ventas-tarjeta-caja-dialog/ventas-tarjeta-caja-dialog.component.html
@@ -1,0 +1,131 @@
+<app-generic-list
+  [titulo]="'Ventas con tarjeta — caja ' + data.cajaId"
+  (filtrar)="onFilter()"
+  (resetFiltro)="onLimpiarFiltros()"
+  [isAdicionar]="false"
+  [data]="dataSource.data"
+  style="height: 100%"
+>
+  <div filtros>
+    <div fxLayout="row wrap" fxLayoutGap="12px" fxLayoutAlign="start center" style="padding: 8px 0">
+      <mat-form-field appearance="outline" fxFlex="18%">
+        <mat-label>Estado</mat-label>
+        <mat-select [formControl]="estadoControl">
+          <mat-option [value]="null">Todos</mat-option>
+          <mat-option *ngFor="let e of estados" [value]="e">{{ e }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" fxFlex="24%">
+        <mat-label>Terminal</mat-label>
+        <mat-select [formControl]="terminalPosIdControl">
+          <mat-option [value]="null">Todas</mat-option>
+          <mat-option *ngFor="let t of terminales" [value]="t.id">
+            {{ t.descripcion }} - {{ t.codigo }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" fxFlex="16%">
+        <mat-label>Moneda</mat-label>
+        <mat-select [formControl]="monedaIdControl">
+          <mat-option [value]="null">Todas</mat-option>
+          <mat-option *ngFor="let m of monedas" [value]="m.id">
+            {{ m.denominacion }} ({{ m.simbolo }})
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" fxFlex="15%">
+        <mat-label>Monto desde</mat-label>
+        <input matInput type="number" [formControl]="montoDesdeControl" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" fxFlex="15%">
+        <mat-label>Monto hasta</mat-label>
+        <input matInput type="number" [formControl]="montoHastaControl" />
+      </mat-form-field>
+    </div>
+  </div>
+
+  <div table fxFlex fxLayout="column" style="min-height: 0; height: 100%">
+    <div fxFlex style="overflow: auto; min-height: 0">
+      <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+
+        <ng-container matColumnDef="id">
+          <th mat-header-cell *matHeaderCellDef style="width: 8%">ID</th>
+          <td mat-cell *matCellDef="let item" style="width: 8%">{{ item.id }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="terminal">
+          <th mat-header-cell *matHeaderCellDef style="width: 28%">Terminal</th>
+          <td mat-cell *matCellDef="let item" style="width: 28%">
+            {{ item.terminalPos?.descripcion }} - {{ item.terminalPos?.codigo }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="monto">
+          <th mat-header-cell *matHeaderCellDef style="width: 18%">Cobrado</th>
+          <td mat-cell *matCellDef="let item" style="width: 18%">
+            {{ item.monto | number: item.digitosMoneda }}
+            <span class="simbolo">{{ item.simboloMoneda }}</span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="escaneado">
+          <th mat-header-cell *matHeaderCellDef style="width: 18%">Cupón</th>
+          <td mat-cell *matCellDef="let item" style="width: 18%">
+            <ng-container *ngIf="item.montoEscaneado != null; else sinCupon">
+              <span [class.diferencia]="item.montoEscaneado !== item.monto">
+                {{ item.montoEscaneado | number: item.digitosMoneda }}
+              </span>
+              <span class="simbolo">{{ item.simboloMoneda }}</span>
+            </ng-container>
+            <ng-template #sinCupon><span class="vacio">—</span></ng-template>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="estado">
+          <th mat-header-cell *matHeaderCellDef style="width: 16%">Estado</th>
+          <td mat-cell *matCellDef="let item" style="width: 16%">
+            <span
+              class="chip"
+              [class.chip-pendiente]="item.estado === 'PENDIENTE'"
+              [class.chip-completado]="item.estado === 'COMPLETADO'"
+              [class.chip-terminal]="item.estado === 'NO_COMPLETADO' || item.estado === 'CANCELADO'"
+            >{{ item.estado }}</span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="acciones">
+          <th mat-header-cell *matHeaderCellDef style="width: 12%"></th>
+          <td mat-cell *matCellDef="let item" style="width: 12%">
+            <mat-icon
+              *ngIf="item.estado === 'PENDIENTE'"
+              class="accion-registrar"
+              matTooltip="Registrar cupón"
+              (click)="onCompletar(item)"
+            >qr_code_scanner</mat-icon>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
+
+      <div *ngIf="!cargando && dataSource.data.length === 0" class="estado-vacio">
+        No hay ventas con tarjeta que coincidan con el filtro.
+      </div>
+    </div>
+
+    <mat-paginator
+      [pageSizeOptions]="[15, 25, 50, 100]"
+      [pageIndex]="pageIndex"
+      [pageSize]="pageSize"
+      (page)="handlePageEvent($event)"
+      [length]="selectedPageInfo?.getTotalElements"
+      showFirstLastButtons
+      style="width: 100%"
+    ></mat-paginator>
+  </div>
+</app-generic-list>

--- a/src/app/modules/financiero/venta-tarjeta/ventas-tarjeta-caja-dialog/ventas-tarjeta-caja-dialog.component.scss
+++ b/src/app/modules/financiero/venta-tarjeta/ventas-tarjeta-caja-dialog/ventas-tarjeta-caja-dialog.component.scss
@@ -1,0 +1,66 @@
+// styles.scss deja el mat-dialog-container con padding 0: si este bloque no pone el suyo, la
+// tabla y los filtros quedan pegados al borde del dialogo. Mismo valor que los otros dialogos
+// del modulo (escanear-cupon, registrar-venta-tarjeta) para que el conjunto se vea parejo.
+:host {
+  display: block;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 20px 24px 12px;
+}
+
+table {
+  width: 100%;
+
+  th,
+  td {
+    text-align: center;
+  }
+}
+
+.simbolo {
+  opacity: 0.7;
+  margin-left: 4px;
+}
+
+.vacio {
+  opacity: 0.4;
+}
+
+/** El cupon no coincide con lo cobrado: se registro con diferencia y conviene que salte a la vista. */
+.diferencia {
+  color: #ff9800;
+  font-weight: 500;
+}
+
+.chip {
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.chip-pendiente {
+  background-color: #ff9800;
+  color: #000;
+}
+
+.chip-completado {
+  background-color: #4caf50;
+  color: #fff;
+}
+
+.chip-terminal {
+  background-color: #616161;
+  color: #fff;
+}
+
+.accion-registrar {
+  cursor: pointer;
+  color: #4caf50;
+}
+
+.estado-vacio {
+  text-align: center;
+  padding: 32px 0;
+  opacity: 0.6;
+}

--- a/src/app/modules/financiero/venta-tarjeta/ventas-tarjeta-caja-dialog/ventas-tarjeta-caja-dialog.component.ts
+++ b/src/app/modules/financiero/venta-tarjeta/ventas-tarjeta-caja-dialog/ventas-tarjeta-caja-dialog.component.ts
@@ -1,0 +1,196 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatTableDataSource } from '@angular/material/table';
+import { PageEvent } from '@angular/material/paginator';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { PageInfo } from '../../../../app.component';
+import { MainService } from '../../../../main.service';
+import { Moneda } from '../../moneda/moneda.model';
+import { MonedaService } from '../../moneda/moneda.service';
+import { TerminalPos } from '../../terminal-pos/terminal-pos.model';
+import { TerminalPosService } from '../../terminal-pos/terminal-pos.service';
+import { VentaTarjeta } from '../venta-tarjeta.model';
+import { VentaTarjetaService } from '../venta-tarjeta.service';
+import { RegistrarVentaTarjetaDialogComponent } from '../qr-pos/registrar-venta-tarjeta-dialog/registrar-venta-tarjeta-dialog.component';
+import { TipoEntidad } from '../../../../generics/tipo-entidad.enum';
+
+export interface VentasTarjetaCajaDialogData {
+  cajaId: number;
+}
+
+/**
+ * Ventas con tarjeta de la caja abierta, para el cajero, desde el PDV (Utilitarios F1).
+ *
+ * Distinta de `ListVentaTarjetaComponent` a proposito:
+ *
+ * - **Consulta al FILIAL**, no al central. El PDV tiene que operar sin internet, y `completar()`
+ *   corre contra el filial de todas formas.
+ * - **El aislamiento sale por construccion**: la query exige `cajaId` y `sucId` del lado del
+ *   servidor, asi que no puede devolver datos de otra caja ni de otra sucursal aunque alguien
+ *   manipule los filtros.
+ * - **Paginada del lado del servidor.** Una caja puede acumular cientos de cobros en un turno;
+ *   traerlos todos para mostrar quince seria pagar por datos que nadie mira.
+ *
+ * La pantalla del sidebar sigue existiendo para auditar la red: son dos necesidades distintas.
+ */
+@UntilDestroy({ checkProperties: true })
+@Component({
+  selector: 'app-ventas-tarjeta-caja-dialog',
+  templateUrl: './ventas-tarjeta-caja-dialog.component.html',
+  styleUrls: ['./ventas-tarjeta-caja-dialog.component.scss'],
+})
+export class VentasTarjetaCajaDialogComponent implements OnInit {
+  dataSource = new MatTableDataSource<VentaTarjeta>([]);
+  displayedColumns = ['id', 'terminal', 'monto', 'escaneado', 'estado', 'acciones'];
+
+  estadoControl = new FormControl(null);
+  terminalPosIdControl = new FormControl(null);
+  monedaIdControl = new FormControl(null);
+  montoDesdeControl = new FormControl(null);
+  montoHastaControl = new FormControl(null);
+
+  estados = ['PENDIENTE', 'COMPLETADO', 'NO_COMPLETADO', 'CANCELADO'];
+  terminales: TerminalPos[] = [];
+  monedas: Moneda[] = [];
+
+  decimalesPorMoneda: { [id: number]: number } = {};
+  selectedPageInfo: PageInfo<VentaTarjeta>;
+  pageIndex = 0;
+  pageSize = 15;
+  cargando = true;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: VentasTarjetaCajaDialogData,
+    public dialogRef: MatDialogRef<VentasTarjetaCajaDialogComponent>,
+    private ventaTarjetaService: VentaTarjetaService,
+    private monedaService: MonedaService,
+    private terminalPosService: TerminalPosService,
+    private matDialog: MatDialog,
+    public mainService: MainService
+  ) {}
+
+  ngOnInit(): void {
+    // Todo contra el filial (`false`): esta pantalla tiene que funcionar sin internet.
+    this.monedaService.onGetAll(false).pipe(untilDestroyed(this)).subscribe({
+      next: (monedas) => {
+        this.monedas = monedas || [];
+        this.monedas.forEach((m) => (this.decimalesPorMoneda[Number(m.id)] = m.decimales ?? 0));
+        this.onGetData();
+      },
+      error: () => this.onGetData(),
+    });
+
+    this.terminalPosService.onGetAll(null, null, false).pipe(untilDestroyed(this)).subscribe({
+      next: (res) => (this.terminales = res || []),
+      error: () => (this.terminales = []),
+    });
+  }
+
+  onGetData(): void {
+    this.cargando = true;
+    const params: any = {
+      cajaId: this.data.cajaId,
+      sucId: Number(this.mainService.sucursalActual?.id),
+      page: this.pageIndex,
+      size: this.pageSize,
+    };
+    if (this.estadoControl.value) params.estado = this.estadoControl.value;
+    if (this.terminalPosIdControl.value) params.terminalPosId = Number(this.terminalPosIdControl.value);
+    if (this.monedaIdControl.value) params.monedaId = Number(this.monedaIdControl.value);
+    if (this.montoDesdeControl.value != null && this.montoDesdeControl.value !== '') {
+      params.montoDesde = Number(this.montoDesdeControl.value);
+    }
+    if (this.montoHastaControl.value != null && this.montoHastaControl.value !== '') {
+      params.montoHasta = Number(this.montoHastaControl.value);
+    }
+
+    this.ventaTarjetaService
+      .onFiltrarPorCaja(params)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: (res) => {
+          this.selectedPageInfo = res;
+          this.dataSource.data = (res?.getContent ?? []).map((item) => this.aFilaConMoneda(item));
+          this.cargando = false;
+        },
+        error: () => {
+          this.dataSource.data = [];
+          this.cargando = false;
+        },
+      });
+  }
+
+  onFilter(): void {
+    this.pageIndex = 0;
+    this.onGetData();
+  }
+
+  onLimpiarFiltros(): void {
+    this.estadoControl.setValue(null);
+    this.terminalPosIdControl.setValue(null);
+    this.monedaIdControl.setValue(null);
+    this.montoDesdeControl.setValue(null);
+    this.montoHastaControl.setValue(null);
+    this.pageIndex = 0;
+    this.onGetData();
+  }
+
+  handlePageEvent(event: PageEvent): void {
+    this.pageIndex = event.pageIndex;
+    this.pageSize = event.pageSize;
+    this.onGetData();
+  }
+
+  /**
+   * Apollo congela los resultados, asi que se clona antes de agregar los campos de display.
+   * Los decimales dependen de la moneda: Gs. no lleva ninguno y R$ lleva dos, asi que un `1.0-2`
+   * fijo mostraba "50 R$" en vez de "50,00 R$".
+   */
+  private aFilaConMoneda(item: VentaTarjeta): VentaTarjeta {
+    const moneda = item?.moneda ?? item?.terminalPos?.moneda;
+    const decimales = moneda?.decimales ?? 0;
+    return {
+      ...item,
+      simboloMoneda: moneda?.simbolo ?? 'Gs.',
+      digitosMoneda: `1.${decimales}-${decimales}`,
+    };
+  }
+
+  onCompletar(item: VentaTarjeta): void {
+    this.matDialog
+      .open(RegistrarVentaTarjetaDialogComponent, {
+        data: {
+          ventaTarjetaId: item.id,
+          sucursalId: item.sucursalId,
+          ventaId: item.ventaId,
+          qrPayload: {
+            sucursalId: item.sucursalId,
+            tipoEntidad: TipoEntidad.VENTA_TARJETA,
+            idOrigen: item.ventaId,
+            idCentral: item.ventaId,
+            componentToOpen: 'RegistroVentaTarjetaComponent',
+            data: (item.cajaId ?? '') + '|' + item.monto + '|' + item.id,
+            timestamp: Date.now(),
+          },
+          monto: item.monto,
+          monedaSimbolo: item.simboloMoneda,
+          terminalDescripcion: [item.terminalPos?.descripcion, item.terminalPos?.codigo]
+            .filter(Boolean)
+            .join(' - '),
+          proveedorServicioId: item.terminalPos?.proveedorServicio?.id,
+          decimalesPorMoneda: this.decimalesPorMoneda,
+          titulo: 'Completar venta con tarjeta',
+          segundos: 120,
+        },
+        disableClose: false,
+      })
+      .afterClosed()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.onGetData());
+  }
+
+  cerrar(): void {
+    this.dialogRef.close(null);
+  }
+}

--- a/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/pago-touch/pago-touch.component.ts
@@ -92,6 +92,7 @@ import { EscanearCuponDialogComponent, EscanearCuponDialogData } from "../../../
 import { esCobroTarjetaRegistrable } from "../../../../financiero/venta-tarjeta/qr-pos/cobro-tarjeta";
 import { cuponVencido, DecimalesPorMoneda, HORAS_ANTIGUEDAD_MAXIMA } from "../../../../financiero/venta-tarjeta/qr-pos/qr-pos-parser";
 import { DatosCupon } from "../../../../financiero/venta-tarjeta/qr-pos/formato-qr-pos.model";
+import { ConfirmDialogComponent, ConfirmDialogData } from "../../../../../shared/components/confirm-dialog/confirm-dialog.component";
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -502,7 +503,15 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
   setMoneda(moneda, openDialog?) {
     this.selectedMoneda = this.monedas.find((m) => m.denominacion == moneda);
     this.formGroup.controls.moneda.setValue(this.selectedMoneda.id);
-    if (openDialog == null) openDialog = true;
+    // El dialogo de billetes es una calculadora de CONTEO de efectivo: con TARJETA seleccionada
+    // no tiene nada que contar y solo estorba. La moneda se sigue seleccionando siempre (arriba
+    // de este guard) — lo unico que se condiciona es abrir el dialogo.
+    //
+    // Los call sites que pasan `false` explicito (teclas F1/F2/F3 y el replay de delivery) no
+    // entran aca y no cambian.
+    if (openDialog == null) {
+      openDialog = this.selectedFormaPago?.descripcion === "EFECTIVO";
+    }
     this.setFocusToValorInput();
     if (openDialog == true) {
       this.isDialogOpen = true;
@@ -687,6 +696,64 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   /**
+   * Pega el cupon a la linea. El identificador viaja en el propio CobroDetalleInput de ESTA linea
+   * (toInput() ya lo manda), asi que el vinculo cobro<->cupon queda grabado con el saveVenta,
+   * exacto y sin que nadie tenga que adivinarlo despues.
+   *
+   * Esto es lo que cierra el caso de dos tarjetas del MISMO monto en una venta: el backend no
+   * puede desempatarlas por monto, pero aca sabemos con certeza sobre que linea se escaneo,
+   * porque el dialogo se abrio parado en ella.
+   */
+  private aplicarCupon(item: CobroDetalle, datosCupon: DatosCupon): void {
+    item.datosCupon = datosCupon;
+    item.identificadorTransaccion = datosCupon.identificadorTransaccion;
+  }
+
+  /**
+   * Mismo dialogo y mismo texto que el completar desde la lista, para que la regla se comporte
+   * igual por las dos puertas.
+   *
+   * "Escanear otro" NO aplica el cupon y vuelve a abrir la lectura sobre la misma linea: el
+   * cajero rehace el escaneo sin perder la terminal ya elegida. Cancelar ahi deja la linea
+   * pendiente, que es el mismo camino que "Registrar mas tarde".
+   */
+  private confirmarDiferenciaCupon(
+    item: CobroDetalle,
+    datosCupon: DatosCupon,
+    avisos: string[]
+  ): void {
+    const data: ConfirmDialogData = {
+      title: 'El cupón no coincide con este cobro',
+      message:
+        `Este cobro es de ${Number(item.valor).toLocaleString('es-PY')} ` +
+        `${item.moneda?.simbolo || 'Gs.'} en ` +
+        `${[item.terminalPos?.descripcion, item.terminalPos?.codigo].filter(Boolean).join(' - ') || 'esta terminal'}, ` +
+        `pero ${avisos.join(' y ')}. ¿Es el cupón correcto?`,
+      confirmText: 'Registrar igual',
+      cancelText: 'Escanear otro',
+    };
+
+    this.isDialogOpen = true;
+    this.matDialog
+      .open(ConfirmDialogComponent, { data, width: '520px' })
+      .afterClosed()
+      .pipe(untilDestroyed(this))
+      .subscribe((confirmado) => {
+        this.isDialogOpen = false;
+        if (!confirmado) {
+          this.escanearTarjeta(item);
+          return;
+        }
+        this.aplicarCupon(item, datosCupon);
+        this.notificacionSnackbar.notification$.next({
+          color: NotificacionColor.warn,
+          texto: `Registrado con diferencia: ${avisos.join(' y ')}.`,
+          duracion: 6,
+        });
+      });
+  }
+
+  /**
    * Dispara el escaneo apenas se agrega una línea TARJETA — no al finalizar. Es lo que permite
    * mostrar el estado por línea (pendiente / registrada) en la tabla y ofrecer el ícono de QR
    * para reabrir. Si el flujo está deshabilitado, TARJETA queda como forma de pago normal.
@@ -721,6 +788,7 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
         monedaTerminalId: result.terminalPos.moneda?.id,
         monedaTerminalSimbolo: result.terminalPos.moneda?.simbolo,
         decimalesPorMoneda: this.decimalesPorMoneda,
+        sucursalId: Number(this.mainService.sucursalActual?.id),
       };
       this.matDialog.open(EscanearCuponDialogComponent, { data, disableClose: false })
         .afterClosed()
@@ -737,27 +805,35 @@ export class PagoTouchComponent implements OnInit, OnDestroy, AfterViewInit {
             });
             return;
           }
-          item.datosCupon = datosCupon;
-
-          // El identificador viaja en el propio CobroDetalleInput de ESTA línea (toInput() ya lo
-          // manda), así que el vínculo cobro↔cupón queda grabado con el saveVenta, exacto y sin
-          // que nadie tenga que adivinarlo después.
-          //
-          // Esto es lo que cierra el caso de dos tarjetas del MISMO monto en una venta: el
-          // backend no puede desempatarlas por monto, pero acá sabemos con certeza sobre qué
-          // línea se escaneó, porque el diálogo se abrió parado en ella.
-          item.identificadorTransaccion = datosCupon.identificadorTransaccion;
-
           const avisos: string[] = [];
-          if (datosCupon.monto != null && datosCupon.monto !== item.valor) {
-            avisos.push(`el cupón dice ${datosCupon.monto.toLocaleString('es-PY')} y se cobró ${item.valor.toLocaleString('es-PY')}`);
+          // `item.valor` esta tipado como number pero viene del formulario, donde es un string
+          // ("50.00"). Un `!==` entre 50 y "50.00" es siempre verdadero, asi que el aviso saltaba
+          // en TODOS los escaneos, incluso con montos identicos — y un aviso que sale siempre deja
+          // de leerse, que es peor que no tenerlo: cuando el cupon difiera de verdad, el cajero ya
+          // lo va a estar ignorando. Se compara el numero, no la representacion.
+          const valorCobrado = Number(item.valor);
+          if (datosCupon.monto != null && Number.isFinite(valorCobrado) && datosCupon.monto !== valorCobrado) {
+            avisos.push(`el cupón dice ${datosCupon.monto.toLocaleString('es-PY')} y se cobró ${valorCobrado.toLocaleString('es-PY')}`);
           }
           if (cuponVencido(datosCupon.fecha)) {
             avisos.push(`tiene más de ${HORAS_ANTIGUEDAD_MAXIMA} horas`);
           }
-          this.notificacionSnackbar.notification$.next(avisos.length
-            ? { color: NotificacionColor.warn, texto: `Cupón leído, pero ${avisos.join(' y ')}.`, duracion: 6 }
-            : { color: NotificacionColor.success, texto: 'Cupón leído correctamente.', duracion: 2 }
+
+          // Una diferencia se CONFIRMA, no se avisa. Es lo que ya hace el completar desde la
+          // lista (RegistrarVentaTarjetaDialogComponent) y lo que pide el manual §8.3: el caso
+          // mas comun es que el cajero tenga dos cupones parecidos en la mano y haya escaneado el
+          // que no era. Un snackbar de 6 segundos no lo hace mirar; un dialogo si.
+          //
+          // Aca es mas barato que en la lista: el cupon todavia vive en memoria y la venta no
+          // existe, asi que "Escanear otro" no tiene nada que deshacer.
+          if (avisos.length) {
+            this.confirmarDiferenciaCupon(item, datosCupon, avisos);
+            return;
+          }
+
+          this.aplicarCupon(item, datosCupon);
+          this.notificacionSnackbar.notification$.next(
+            { color: NotificacionColor.success, texto: 'Cupón leído correctamente.', duracion: 2 }
           );
         });
     });

--- a/src/app/modules/pdv/comercial/venta-touch/utilitarios-dialog/utilitarios-dialog.component.html
+++ b/src/app/modules/pdv/comercial/venta-touch/utilitarios-dialog/utilitarios-dialog.component.html
@@ -112,4 +112,23 @@
   >
     <p fxFlex style="width: 100%; text-align: center">Garantía y Devolución</p>
   </mat-card>
+
+  <mat-card
+    appearance="outlined"
+    fxFlex="15"
+    fxLayout="row"
+    fxLayoutAlign="start center"
+    *ngIf="puedeRegistrarCupones"
+    style="
+      width: 100%;
+      height: 100px;
+      padding: 5px;
+      background-color: #f44336;
+      text-align: center;
+      cursor: pointer;
+    "
+    (click)="ventasTarjeta()"
+  >
+    <p fxFlex style="width: 100%; text-align: center">Ventas con tarjeta</p>
+  </mat-card>
 </div>

--- a/src/app/modules/pdv/comercial/venta-touch/utilitarios-dialog/utilitarios-dialog.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/utilitarios-dialog/utilitarios-dialog.component.ts
@@ -14,6 +14,8 @@ import {
 import { UltimasVentasDialogComponent } from "../../../../operaciones/venta/ultimas-ventas-dialog/ultimas-ventas-dialog.component";
 import { GarantiaDevolucionDialogComponent } from "../../../venta-touch/garantia-devolucion-dialog/garantia-devolucion-dialog.component";
 import { VentaTouchService } from "../venta-touch.service";
+import { VentasTarjetaCajaDialogComponent } from "../../../../financiero/venta-tarjeta/ventas-tarjeta-caja-dialog/ventas-tarjeta-caja-dialog.component";
+import { ConfiguracionVentaTarjetaService } from "../../../../financiero/venta-tarjeta/configuracion-venta-tarjeta-dialog/configuracion-venta-tarjeta.service";
 export class UtilitariosDialogData {
   caja: PdvCaja;
 }
@@ -41,17 +43,45 @@ export interface UtilitariosResponse {
 export class UtilitariosDialogComponent implements OnInit {
   selectedCaja: PdvCaja;
   opcionesList: OpcionesData[] = []
+
+  /**
+   * El aviso del cierre de caja manda al cajero a "registrarlas escaneando el QR desde el PDV",
+   * pero la lista colgaba de sidebar > Reportes > Terminales POS > Lista: cuatro pasos y saliendo
+   * del PDV. El rol VENTA TARJETA COMPLETAR abrio el permiso; esto abre el camino.
+   *
+   * Se precalcula (el template no puede llamar funciones) y exige las tres condiciones: sin caja
+   * no hay nada que registrar, sin el flujo habilitado la pantalla no aplica, y sin el rol el
+   * usuario no puede completar. Se gatea la VISIBILIDAD y no solo el click: un boton que siempre
+   * se ve y a veces rechaza le ensena al cajero a probar suerte.
+   */
+  puedeRegistrarCupones = false;
   constructor(
     private ventaTouchService: VentaTouchService,
     @Inject(MAT_DIALOG_DATA) public data: UtilitariosDialogData,
     public dialogRef: MatDialogRef<UtilitariosDialogComponent>,
     public matDialog: MatDialog,
-    private mainService: MainService
+    private mainService: MainService,
+    private configuracionVentaTarjetaService: ConfiguracionVentaTarjetaService
   ) {
     if (data?.caja != null) this.selectedCaja = data.caja;
   }
 
   ngOnInit(): void {
+    const roles = this.mainService.usuarioActual?.roles || [];
+    const tieneRol =
+      roles.includes(ROLES.VENTA_TARJETA_COMPLETAR) || roles.includes(ROLES.ADMIN);
+
+    if (this.selectedCaja != null && tieneRol) {
+      // Contra el filial (false), igual que pago-touch: la caja se opera sin internet.
+      this.configuracionVentaTarjetaService
+        .onGetConfiguracion(false)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: (config) => (this.puedeRegistrarCupones = config?.habilitado === true),
+          error: () => (this.puedeRegistrarCupones = false),
+        });
+    }
+
     this.opcionesList = [
       {
         nombre: 'Test',
@@ -173,5 +203,30 @@ export class UtilitariosDialogComponent implements OnInit {
     this.matDialog.open(GarantiaDevolucionDialogComponent, {
       data: {},
     });
+  }
+
+  /**
+   * Se abre como dialogo y no como tab a proposito: el cajero llega aca en medio de una venta o
+   * justo antes de cerrar caja, y mandarlo a otra pestana lo saca del PDV.
+   *
+   * Muestra las de ESTA caja consultando al filial — no la lista del sidebar, que consulta al
+   * central: esa necesita internet y trae las ventas de todas las sucursales.
+   */
+  ventasTarjeta() {
+    this.matDialog
+      .open(VentasTarjetaCajaDialogComponent, {
+        data: { cajaId: this.selectedCaja?.id },
+        width: "85vw",
+        height: "80vh",
+        disableClose: false,
+        autoFocus: true,
+        restoreFocus: true,
+        panelClass: 'darkMode',
+      })
+      .afterClosed()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.dialogRef.close(null);
+      });
   }
 }


### PR DESCRIPTION
Dos features y tres fixes sobre el flujo de venta con tarjeta, **todo encontrado y validado probando a mano en alpha**. Ningún test automático habría encontrado ninguno de los tres defectos.

⚠️ **Requiere filial ≥ `5.0.0-alpha.19`** (GabFrank/franco-system-backend-filial#121, ya mergeado y desplegado en alpha).

## Los tres fixes

**1 · El aviso de monto distinto salía en TODOS los escaneos.** `item.valor` está tipado `number` pero viene del formulario, donde es un string: `50 !== "50.00"` es siempre verdadero. La prueba estaba en el propio mensaje — los dos lados pasan por `.toLocaleString('es-PY')` y el cobro imprimía `50.00` **con punto**, porque `String.prototype.toLocaleString` ignora el locale.

No corrompía datos, pero **un aviso que sale siempre deja de leerse**: cuando el cupón difiera de verdad, el cajero ya lo va a estar ignorando.

**2 · El diálogo del cupón mostraba `50 R$` en vez de `50,00 R$`.** La corrección de decimales por moneda se había aplicado a la lista pero este diálogo quedó afuera. No es sólo cosmético: el cajero compara contra el ticket del POS en una pantalla donde también hay guaraníes.

**3 · El diálogo de billetes se abría con cualquier forma de pago.** Con TARJETA no hay nada que contar. Auditado por un segundo agente antes de aplicar: se verificó que el diálogo **no** es la única vía para cargar el importe.

## Las dos features

**4 · Una diferencia ahora se CONFIRMA, no se avisa.** Mismo diálogo que el completar desde la lista, y lo que pide el manual §8.3. El caso más común es que el cajero tenga dos cupones parecidos en la mano y haya escaneado el que no era.

En el PDV es más barato que en la lista: el cupón vive en memoria y la venta no existe, así que *Escanear otro* no tiene nada que deshacer. Por eso el cupón se pega a la línea **después** de confirmar.

**5 · El cupón repetido se detecta al escanear.** Detectarlo en el `saveVenta` dejaba la venta registrada, el registro caído a `PENDIENTE` y el dato escaneado descartado — reproducido en alpha, venta 80048. **Falla abierta**: si no se puede consultar, no bloquea; la validación de verdad corre igual al guardar.

**6 · Acceso a ventas con tarjeta desde el PDV** (Utilitarios → F1). El aviso del cierre de caja mandaba al cajero a registrarlas "desde el PDV", pero la pantalla colgaba de sidebar → Reportes → Terminales POS → Lista: cuatro pasos, saliendo del PDV.

Es una vista distinta de la del sidebar a propósito: **consulta al filial** (el PDV opera sin internet, y `completar()` corre contra el filial igual), **paginada del lado del servidor** con filtros por estado, terminal, moneda y monto, y **aislada por construcción** — la query exige `cajaId` y `sucId` del lado del servidor.

## Verificación

`npm run check` (AOT): **0 errores**.

**8 pruebas manuales contra alpha**, con evidencia en base:

| # | Caso | Evidencia |
|---|---|---|
| 1-2 | Camino feliz Gs. y R$ | regs. 9, 10 |
| 3 | Moneda del registro, terminal sin moneda | reg. 11 |
| 4 | Pendientes creados y completados | regs. 12, 13 |
| 5 | Monto distinto avisa | reg. 14 |
| 6 | Moneda cruzada **bloquea** | sin registro |
| 7 | Cupón viejo **confirma** | sin registro |
| 8 | Dos tarjetas del mismo monto | regs. 16, 17 |

La 8 es la de mayor valor: confirma que el vínculo cupón↔línea sobrevive al refactor. Con dos cobros idénticos el backend no puede desempatarlos.

**Falta probar:** pago mixto, con factura legal, aviso en cierre de caja, y los gates del acceso nuevo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LA5TavPLQ2QmjeMyKc3csW
