### PR TITLE
fix(pdv): facturar las ventas de Cobro Rápido (F8)

### DIFF
--- a/src/app/modules/pdv/comercial/venta-touch/venta-touch.component.ts
+++ b/src/app/modules/pdv/comercial/venta-touch/venta-touch.component.ts
@@ -1286,7 +1286,12 @@ export class VentaTouchComponent implements OnInit, OnDestroy, AfterViewInit {
     facturaLegalId?: number
   ): Observable<Venta> {
     if (facturar == null) {
-      facturar = ticket == true;
+      // Solo el Cobro Rapido + Ticket (F11) pide factura explicita. Para el Cobro
+      // Rapido a secas (F8) hay que mandar null, NO false: el filial interpreta
+      // facturar=false como "el frontend ya emitio una factura manual" y saltea la
+      // facturacion silenciosa, dejando la venta sin comprobante. Con null cae en la
+      // rama de facturaCountDown y factura como corresponde.
+      facturar = ticket == true ? true : null;
     }
     if (this.isDelivery) venta.delivery = this.selectedDelivery;
     if (this.modoConsulta) return;


### PR DESCRIPTION
## Problema

El **Cobro Rápido (F8)** no genera factura, pese a que la filial tiene `facturaCountDown=0` (facturar el 100%).

`onTicketClick()` se llama sin argumento desde el botón "Cobro Rápido (F8)", así que `ticket` queda `undefined` y `onSaveVenta` derivaba:

```ts
facturar = ticket == true;   // → false
```

Desde el commit 68ec909 del filial (*"vincular FacturaLegal manual a la Venta y evitar duplicados"*, 2026-07-16), el backend interpreta ese `false` como "el frontend ya emitió una factura manual" y saltea la facturación silenciosa:

```java
} else if (facturar != null && !facturar) {
    // El frontend ya generó una factura manual para esta venta...
} else if (facturaCountDown == 0) {
```

Antes de ese commit el `false` caía en `facturaCountDown == 0` y facturaba. Es una regresión, no un bug de configuración.

## Evidencia (filial 1, `172.25.1.1`)

Config verificada en el servidor: `facturaCountDown=0` tanto en `/opt/frc-filial/application.properties` como en el env del proceso (`FACTURACOUNTDOWN=0`). La config está bien; el problema es el código.

Ventas de Cobro Rápido vs. facturadas, por semana:

| semana | cobro rápido | facturadas |
|---|---|---|
| 2026-07-06 | 1768 | 1768 |
| 2026-07-13 | 1873 | 1873 |
| **2026-07-20** | 2160 | **202** |
| 2026-07-27 | 3110 | 51 |
| 2026-09-07 | 508 | 14 |

Últimos 7 días, por origen de la venta:

| Origen | Ventas | Facturadas | % |
|---|---|---|---|
| Cobro Rápido (`forma_pago` = EFECTIVO) | 1777 | 40 | **2.3%** |
| Diálogo de pago (F12) | 2897 | 2630 | 90.8% |
| Venta a crédito | 267 | 0 | 0% |

El ~2.3% que sí factura son las ventas por **CR + Ticket (F11)**, que sí manda `ticket=true`.

## Solución

Mandar `null` en vez de `false` cuando no hubo factura manual, para que el backend caiga en la rama de `facturaCountDown`:

```ts
facturar = ticket == true ? true : null;
```

- **F8** → `null` → factura silenciosa ✅
- **F11** → `true` (necesario: el backend hace unboxing de `facturar` en `pdvId != null && facturar`, un `null` ahí sería NPE)
- **Factura manual** → sigue mandando `false` explícito desde `!response?.facturado`, así que la línea `if (facturar == null)` ni se ejecuta y no se duplica

## Verificación

`npm run check` (build AOT de producción): exit 0, sin errores.

Probado en la app corriendo (central 8081 + filial 8082 perfil `dev` + `npm start`), los cuatro caminos:

| Caso | Venta | `forma_pago_id` | Facturas | Nº |
|---|---|---|---|---|
| **Cobro Rápido (F8)** | 79203 | 1 | **1** | 14383 |
| CR + Ticket (F11) | 79204 | 1 | 1 | 14384 |
| F12 → Finalizar | 79205 | null | 1 | 14385 |
| **F12 → Finalizar con Factura** | 79206 | null | **1** | 14386 |

`max_facturas_por_venta = 1` en todos los casos: ningún duplicado. Los cuatro DE se generaron con su CDC.

## Nota de despliegue

El fix es solo del frontend, así que las filiales quedan afectadas hasta que se despliegue la nueva versión del desktop en cada terminal. Si hace falta cerrar el agujero sin esperar ese despliegue, habría que tocar también el filial (exigir que la rama `facturar == false` verifique además que exista una `FacturaLegal` vinculada a la venta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBuBbgcGuEEECjJZjpzwT1
