### PR TITLE
feat(rrhh): mostrar los dias a descontar al programar vacaciones

### DIFF
--- a/src/app/commons/core/utils/dateUtils.ts
+++ b/src/app/commons/core/utils/dateUtils.ts
@@ -292,3 +292,26 @@ export function formatearFecha(event: any): any {
 
   return input; // Update the form control without emitting an event
 }
+
+/**
+ * Cuenta los días del rango [desde, hasta] (ambos inclusive) salteando los domingos.
+ *
+ * Acá se trabaja de lunes a sábado y el domingo es día libre, así que un período de
+ * vacaciones de 12 días abarca 13 o 14 días de calendario según cuántos domingos
+ * caigan adentro. Espeja el conteo del backend (`VacacionPeriodoCalculator`), que es
+ * el que manda: esto es solo para previsualizar el descuento antes de enviar.
+ *
+ * Devuelve 0 si el rango es nulo o está invertido.
+ */
+export function contarDiasSinDomingo(desde: Date, hasta: Date): number {
+  if (!desde || !hasta) { return 0; }
+  const fin = fechaCalendarioLocal(hasta);
+  const cursor = fechaCalendarioLocal(desde);
+  if (fin < cursor) { return 0; }
+  let dias = 0;
+  while (cursor <= fin) {
+    if (cursor.getDay() !== 0) { dias++; }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return dias;
+}

--- a/src/app/modules/rrhh/vacacion/gestion-vacacion-dialog/gestion-vacacion-dialog.component.html
+++ b/src/app/modules/rrhh/vacacion/gestion-vacacion-dialog/gestion-vacacion-dialog.component.html
@@ -18,7 +18,20 @@
         <mat-datepicker-toggle matSuffix [for]="dp2"></mat-datepicker-toggle>
         <mat-datepicker #dp2></mat-datepicker>
       </mat-form-field>
-      <button mat-raised-button color="primary" [disabled]="desdeControl.invalid || hastaControl.invalid" (click)="onSolicitar()">Solicitar</button>
+      <button mat-raised-button color="primary" [disabled]="desdeControl.invalid || hastaControl.invalid || diasADescontar < 1 || diasADescontar > disponibles" (click)="onSolicitar()">Solicitar</button>
+    </div>
+
+    <div class="preview-dias" *ngIf="desdeControl.value && hastaControl.value">
+      <ng-container *ngIf="diasADescontar > 0; else sinDiasHabiles">
+        Días a descontar: <b>{{ diasADescontar }}</b>
+        <span class="detalle">(no se cuentan los domingos)</span>
+        <span class="excedido" *ngIf="diasADescontar > disponibles">
+          — supera los {{ disponibles }} días disponibles
+        </span>
+      </ng-container>
+      <ng-template #sinDiasHabiles>
+        <span class="excedido">El rango no contiene ningún día laborable</span>
+      </ng-template>
     </div>
 
     <table mat-table [dataSource]="periodos" class="mat-elevation-z1 tabla">

--- a/src/app/modules/rrhh/vacacion/gestion-vacacion-dialog/gestion-vacacion-dialog.component.scss
+++ b/src/app/modules/rrhh/vacacion/gestion-vacacion-dialog/gestion-vacacion-dialog.component.scss
@@ -4,6 +4,13 @@
 
   .resumen { font-size: 14px; }
   .seccion { margin-top: 8px; h3 { margin: 6px 0; } }
+  .preview-dias {
+    margin-top: 2px;
+    font-size: 13px;
+
+    .detalle { opacity: 0.7; margin-left: 4px; }
+    .excedido { color: #ef5350; }
+  }
   .tabla { width: 100%; margin-top: 8px; text-align: center; }
   th.mat-header-cell, td.mat-cell { text-align: center; padding: 4px 8px; }
 }

--- a/src/app/modules/rrhh/vacacion/gestion-vacacion-dialog/gestion-vacacion-dialog.component.ts
+++ b/src/app/modules/rrhh/vacacion/gestion-vacacion-dialog/gestion-vacacion-dialog.component.ts
@@ -3,7 +3,7 @@ import { FormControl, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatTableDataSource } from '@angular/material/table';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { dateToString } from '../../../../commons/core/utils/dateUtils';
+import { contarDiasSinDomingo, dateToString } from '../../../../commons/core/utils/dateUtils';
 import { MainService } from '../../../../main.service';
 import { NotificacionSnackbarService, NotificacionColor } from '../../../../notificacion-snackbar.service';
 import { Vacacion, VacacionPeriodo, VacacionVenta } from '../vacacion.model';
@@ -23,6 +23,8 @@ export class GestionVacacionDialogComponent implements OnInit {
 
   vacacion: Vacacion;
   disponibles = 0;
+  /** Dias que descuenta el rango elegido; se recalcula al cambiar los datepickers. */
+  diasADescontar = 0;
 
   periodosColumns = ['fechaDesde', 'fechaHasta', 'diasUsados', 'estado', 'acciones'];
   ventasColumns = ['dias', 'monto', 'fecha', 'estado', 'acciones'];
@@ -48,7 +50,21 @@ export class GestionVacacionDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.puedeAprobar = this.mainService.tieneAlgunRol(['RRHH APROBAR']);
+    this.desdeControl.valueChanges.pipe(untilDestroyed(this))
+      .subscribe(() => this.recalcularDiasADescontar());
+    this.hastaControl.valueChanges.pipe(untilDestroyed(this))
+      .subscribe(() => this.recalcularDiasADescontar());
     this.cargar();
+  }
+
+  /**
+   * Previsualiza cuantos dias del saldo consume el rango elegido. Los domingos son dia
+   * libre y no descuentan, asi que 12 dias de vacaciones abarcan 13 o 14 de calendario:
+   * sin este numero a la vista, el usuario solo se enteraba al recibir el rechazo del
+   * server. El backend sigue siendo el que manda; esto es solo el preview.
+   */
+  private recalcularDiasADescontar() {
+    this.diasADescontar = contarDiasSinDomingo(this.desdeControl.value, this.hastaControl.value);
   }
 
   cargar() {

--- a/src/app/modules/rrhh/vacacion/list-vacacion/list-vacacion.component.html
+++ b/src/app/modules/rrhh/vacacion/list-vacacion/list-vacacion.component.html
@@ -3,7 +3,7 @@
   (filtrar)="onFiltrar()" (resetFiltro)="onResetFiltro()">
 
   <div filtros fxLayout="row wrap" fxLayoutGap="10px" style="width: 100%">
-    <div fxFlex="320px">
+    <div fxFlex="368px">
       <app-select-funcionario
         [funcionarioId]="funcionarioControl.value"
         (idSelected)="funcionarioControl.setValue($event)">


### PR DESCRIPTION
Complementa GabFrank/franco-system-backend-servidor#280 (fix del cálculo) — este PR es solo la parte de UI y **no cierra** el issue.

## Qué resuelve

El diálogo de gestión de vacaciones mandaba `desde`/`hasta` sin decir cuántos días consumía el rango, así que el usuario se enteraba recién al recibir el rechazo del server. Como los domingos son día libre y no descuentan saldo, 12 días de vacaciones abarcan 13 o 14 de calendario y el número no es evidente al elegir las fechas.

## Cambios

- **`contarDiasSinDomingo`** en `commons/core/utils/dateUtils.ts` — espeja el conteo del backend (`VacacionPeriodoCalculator`), que sigue siendo el que valida; esto es solo preview.
- **`gestion-vacacion-dialog`** muestra debajo de los datepickers *"Días a descontar: N (no se cuentan los domingos)"*, recalculado al cambiar cualquiera de las dos fechas vía `valueChanges` (sin llamar funciones desde el HTML). Avisa en rojo si supera el saldo disponible o si el rango no tiene ningún día laborable, y deshabilita **Solicitar** en esos casos.
- **`list-vacacion`**: el filtro de funcionario pasa de 320px a 368px (+15%) — los nombres completos no entraban.

## Cómo probarlo

**RRHH → Beneficios → Vacaciones**, gestionar un funcionario con 12 días disponibles:

1. Cargar **08/09/2026 → 21/09/2026** → debe mostrar *"Días a descontar: 12"* y habilitar Solicitar.
2. Ampliar el rango hasta pasarse del saldo → el texto se pone rojo con *"supera los N días disponibles"* y Solicitar queda deshabilitado.

Ojo al tipear a mano: los datepickers de la app parsean en `M/D/YYYY` aunque muestren en `d/M/yyyy` (comportamiento preexistente, no tocado en este PR). Con el calendario no aplica.

## Riesgo

**Bajo.** Solo UI, sin cambios de schema GraphQL ni de servicios. `npm run check` (AOT) en verde.

## Impacto en auto-update

Ninguno — no toca `installer.nsh`, `electron-builder.json` ni los manifests YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKCYBA6kiMEPLjFt3akz5s