### PR TITLE
feat(transferencia): generar QR desde la lista y cerrarlo al escanearse

### DIFF
--- a/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
@@ -1211,24 +1211,41 @@ export class EditTransferenciaComponent implements OnInit {
       componentToOpen: "EditTransferenciaComponent",
     };
     this.isDialogOpen = true;
-    this.matDialog
-      .open(QrCodeComponent, {
-        data: {
-          codigo: codigo,
-          nombre: "Transferencia",
-          imprimir: true,
-        },
-      })
-      .afterClosed()
+    let transferenciaId = this.selectedTransferencia.id;
+    let qrDialogRef = this.matDialog.open(QrCodeComponent, {
+      data: {
+        codigo: codigo,
+        nombre: "Transferencia",
+        imprimir: true,
+      },
+    });
+
+    // Cierra el diálogo solo cuando el móvil escanea este QR. El aviso llega
+    // por subscription desde el central; se filtra por transferencia y
+    // sucursal porque el canal es único para todos los desktops conectados.
+    let escaneoSub = this.transferenciaService
+      .qrEscaneadoSub()
+      .pipe(untilDestroyed(this))
       .subscribe((res) => {
-        this.isDialogOpen = false;
-        if (res == "imprimir") {
-          this.transferenciaService.onImprimirTransferencia(
-            this.selectedTransferencia.id,
-            true
-          );
+        if (
+          res != null &&
+          +res.transferenciaId == +transferenciaId &&
+          +res.sucursalId == +this.mainService.sucursalActual.id
+        ) {
+          qrDialogRef.close();
         }
       });
+
+    qrDialogRef.afterClosed().subscribe((res) => {
+      escaneoSub.unsubscribe();
+      this.isDialogOpen = false;
+      if (res == "imprimir") {
+        this.transferenciaService.onImprimirTransferencia(
+          transferenciaId,
+          true
+        );
+      }
+    });
   }
 
   onOpenTimeLine() {

--- a/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
+++ b/src/app/modules/operaciones/transferencia/graphql/graphql-query.ts
@@ -1454,3 +1454,12 @@ export const alertasTransferenciaItemsQuery = gql`
   }
 `;
 
+
+export const transferenciaQrEscaneadoSubQuery = gql`
+  subscription transferenciaQrEscaneadoSub {
+    data: transferenciaQrEscaneadoSub {
+      transferenciaId
+      sucursalId
+    }
+  }
+`;

--- a/src/app/modules/operaciones/transferencia/graphql/transferenciaQrEscaneadoSub.ts
+++ b/src/app/modules/operaciones/transferencia/graphql/transferenciaQrEscaneadoSub.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { Subscription } from 'apollo-angular';
+import { transferenciaQrEscaneadoSubQuery } from './graphql-query';
+
+export interface TransferenciaQrEscaneadoUpdate {
+  transferenciaId: number;
+  sucursalId: number;
+}
+
+export interface Response {
+  data: TransferenciaQrEscaneadoUpdate;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TransferenciaQrEscaneadoSubGQL extends Subscription<Response> {
+  document = transferenciaQrEscaneadoSubQuery;
+}

--- a/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.html
+++ b/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.html
@@ -200,6 +200,9 @@
             <button mat-menu-item (click)="onImprimir(transferencia.id)">
               Imprimir
             </button>
+            <button mat-menu-item (click)="onQrClick(transferencia)">
+              Generar QR
+            </button>
             <button mat-menu-item (click)="onDelete(transferencia, i)" style="color: red">
               Eliminar
             </button>

--- a/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/list-transferencia/list-transferencia.component.ts
@@ -41,6 +41,11 @@ import {
   SearchListtDialogData,
 } from "../../../../shared/components/search-list-dialog/search-list-dialog.component";
 import { UsuarioSearchGQL } from "../../../personas/usuarios/graphql/usuarioSearch";
+import { TipoEntidad } from "./../../../../generics/tipo-entidad.enum";
+import {
+  QrCodeComponent,
+  QrData,
+} from "./../../../../shared/qr-code/qr-code.component";
 import { Usuario } from "../../../personas/usuarios/usuario.model";
 
 @UntilDestroy()
@@ -372,6 +377,46 @@ export class ListTransferenciaComponent implements OnInit {
 
   onImprimir(id) {
     this.transferenciaService.onImprimirTransferencia(id);
+  }
+
+  onQrClick(transferencia: TransferenciaView) {
+    let codigo: QrData = {
+      sucursalId: this.mainService.sucursalActual.id,
+      tipoEntidad: TipoEntidad.TRANSFERENCIA,
+      idOrigen: transferencia.id,
+      idCentral: transferencia.id,
+      componentToOpen: "EditTransferenciaComponent",
+    };
+    let qrDialogRef = this.matDialog.open(QrCodeComponent, {
+      data: {
+        codigo: codigo,
+        nombre: "Transferencia",
+        imprimir: true,
+      },
+    });
+
+    // Cierra el diálogo solo cuando el móvil escanea este QR. El aviso llega
+    // por subscription desde el central; se filtra por transferencia y
+    // sucursal porque el canal es único para todos los desktops conectados.
+    let escaneoSub = this.transferenciaService
+      .qrEscaneadoSub()
+      .pipe(untilDestroyed(this))
+      .subscribe((res) => {
+        if (
+          res != null &&
+          +res.transferenciaId == +transferencia.id &&
+          +res.sucursalId == +this.mainService.sucursalActual.id
+        ) {
+          qrDialogRef.close();
+        }
+      });
+
+    qrDialogRef.afterClosed().subscribe((res) => {
+      escaneoSub.unsubscribe();
+      if (res == "imprimir") {
+        this.onImprimir(transferencia.id);
+      }
+    });
   }
 
   isAllSelected() {

--- a/src/app/modules/operaciones/transferencia/transferencia.service.ts
+++ b/src/app/modules/operaciones/transferencia/transferencia.service.ts
@@ -40,6 +40,7 @@ import { Persona } from '../../personas/persona/persona.model';
 import { GetHojaRutaPorFechaGQL } from './graphql/getHojaRutaPorFecha';
 import { GetHojaRutaPorFechaPageGQL } from './graphql/getHojaRutaPorFechaPage';
 import { AlertasTransferenciaItemsGQL } from './graphql/alertasTransferenciaItems';
+import { TransferenciaQrEscaneadoSubGQL } from './graphql/transferenciaQrEscaneadoSub';
 import { DesconfirmarTransferenciaItemGQL } from './graphql/desconfirmarTransferenciaItem';
 
 @UntilDestroy({ checkProperties: true })
@@ -81,8 +82,20 @@ export class TransferenciaService {
     private getHojaRutaPorFecha: GetHojaRutaPorFechaGQL,
     private getHojaRutaPorFechaPage: GetHojaRutaPorFechaPageGQL,
     private alertasTransferenciaItemsGQL: AlertasTransferenciaItemsGQL,
-    private desconfirmarTransferenciaItemGQL: DesconfirmarTransferenciaItemGQL
+    private desconfirmarTransferenciaItemGQL: DesconfirmarTransferenciaItemGQL,
+    private transferenciaQrEscaneadoSub: TransferenciaQrEscaneadoSubGQL
   ) { }
+
+  /**
+   * Avisa cuando alguien escaneó el QR de una transferencia desde el móvil.
+   *
+   * Emite una sola vez y completa —así resuelve `onCustomSub`—, que es
+   * justo lo que hace falta para cerrar el diálogo del QR: después del
+   * primer escaneo ya no hay nada que escuchar.
+   */
+  qrEscaneadoSub() {
+    return this.genericCrudService.onCustomSub(this.transferenciaQrEscaneadoSub, null, true, false);
+  }
 
   onImprimirTransferencia(id, ticket?, servidor = true) {
     this.genericCrudService.onCustomQuery(this.imprimirTransferencia, {


### PR DESCRIPTION
Parte 2 de 3. Depende del central: **mergear primero** `GabFrank/franco-system-backend-servidor#282`, que agrega la subscription que esto consume. Sin eso el botón genera el QR igual, pero el diálogo no se cierra solo.

La tercera parte es `GabFrank/frc-mobile-pwa`, rama del mismo nombre.

## Qué resuelve

Para pasarle una transferencia al móvil había que abrirla primero: el botón de QR vivía solo adentro. Ahora está también en el menú de la fila, junto a Editar e Imprimir.

Y los dos diálogos —el de la lista y el de adentro— se cierran solos cuando el móvil escanea, en vez de quedar abiertos hasta que alguien los cierre a mano.

## Detalles

- El QR de la lista usa el mismo código que el de adentro (`TRANSFERENCIA-{sucursal}-{id}`, con `componentToOpen: EditTransferenciaComponent`), así que lo que se escanea abre la misma pantalla que hoy y los clientes móviles existentes lo parsean igual.
- El aviso llega por `transferenciaQrEscaneadoSub`. Se filtra por transferencia **y** sucursal porque el canal es único para todos los desktops conectados.
- La subscription se corta en `afterClosed()`, así no queda escuchando después de cerrar el diálogo.
- Se mantiene el botón Imprimir del diálogo, que en la lista dispara la impresión de esa fila.

## Verificación

- `npm run check` (build AOT) sin errores; los warnings de CommonJS (canvg, luxon, leaflet, exceljs) son preexistentes.
- Probado en la app corriendo contra el central de esta rama: se genera el QR desde la lista, se escanea con la PWA y el diálogo se cierra solo. Probado con cámara y con carga manual del código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)