### PR TITLE
feat(rrhh): forma de cobro en el legajo, filtro en el listado y nómina por ciudad

### DIFF
--- a/src/app/modules/personas/funcionarios/funcionario-input.model.ts
+++ b/src/app/modules/personas/funcionarios/funcionario-input.model.ts
@@ -19,6 +19,7 @@ export class FuncionarioInput {
   ipsActivo: boolean;
   numeroIps: string;
   fechaIngresoIps: string;
+  cobraBanco: boolean;
   cuentaBancaria: string;
   contactoEmergenciaNombre: string;
   contactoEmergenciaTelefono: string;

--- a/src/app/modules/personas/funcionarios/funcionario.model.ts
+++ b/src/app/modules/personas/funcionarios/funcionario.model.ts
@@ -32,6 +32,7 @@ export class Funcionario {
   ipsActivo: boolean;
   numeroIps: string;
   fechaIngresoIps: string;
+  cobraBanco: boolean;
   cuentaBancaria: string;
   contactoEmergenciaNombre: string;
   contactoEmergenciaTelefono: string;
@@ -55,6 +56,7 @@ export class Funcionario {
     input.ipsActivo = this.ipsActivo
     input.numeroIps = this.numeroIps
     input.fechaIngresoIps = dateToString(this.fechaIngresoIps ? new Date(this.fechaIngresoIps) : null, 'yyyy-MM-dd')
+    input.cobraBanco = this.cobraBanco
     input.cuentaBancaria = this.cuentaBancaria
     input.contactoEmergenciaNombre = this.contactoEmergenciaNombre
     input.contactoEmergenciaTelefono = this.contactoEmergenciaTelefono

--- a/src/app/modules/personas/funcionarios/funcionario.service.ts
+++ b/src/app/modules/personas/funcionarios/funcionario.service.ts
@@ -113,8 +113,8 @@ export class FuncionarioService {
     return this.genericCrud.onGetAll(this.preRegistroFuncionarios, page, size, servidor)
   }
 
-  onGetAllWithPage(page?, size?, id?, nombre?, sucursalIdList?, activo?, cargoId?, diarista?, fasePrueba?, servidor = true): Observable<PageInfo<Funcionario>> {
-    return this.genericCrud.onCustomQuery(this.funcionariosWithPage, { page, size, id, nombre, sucursalIdList, activo, cargoId, diarista, fasePrueba }, servidor);
+  onGetAllWithPage(page?, size?, id?, nombre?, sucursalIdList?, activo?, cargoId?, diarista?, fasePrueba?, cobraBanco?, servidor = true): Observable<PageInfo<Funcionario>> {
+    return this.genericCrud.onCustomQuery(this.funcionariosWithPage, { page, size, id, nombre, sucursalIdList, activo, cargoId, diarista, fasePrueba, cobraBanco }, servidor);
   }
 
   onGetFuncionarioPorPersona(id, servidor = true): Observable<Funcionario> {

--- a/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
+++ b/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
@@ -43,8 +43,8 @@ export const funcionariosQuery = gql`
 `;
 
 export const funcionariosWithPageQuery = gql`
-  query ($page: Int, $size: Int, $id: Int, $nombre: String, $sucursalIdList: [Int], $activo: Boolean, $cargoId: Int, $diarista: Boolean, $fasePrueba: Boolean){
-    data: funcionariosWithPage(page: $page, size: $size, id: $id, nombre: $nombre, sucursalIdList: $sucursalIdList, activo: $activo, cargoId: $cargoId, diarista: $diarista, fasePrueba: $fasePrueba) {
+  query ($page: Int, $size: Int, $id: Int, $nombre: String, $sucursalIdList: [Int], $activo: Boolean, $cargoId: Int, $diarista: Boolean, $fasePrueba: Boolean, $cobraBanco: Boolean){
+    data: funcionariosWithPage(page: $page, size: $size, id: $id, nombre: $nombre, sucursalIdList: $sucursalIdList, activo: $activo, cargoId: $cargoId, diarista: $diarista, fasePrueba: $fasePrueba, cobraBanco: $cobraBanco) {
         getTotalPages
         getTotalElements
         getNumberOfElements

--- a/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
+++ b/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
@@ -156,6 +156,7 @@ export const funcionarioQuery = gql`
       ipsActivo
       numeroIps
       fechaIngresoIps
+      cobraBanco
       cuentaBancaria
       contactoEmergenciaNombre
       contactoEmergenciaTelefono
@@ -283,6 +284,7 @@ export const saveFuncionario = gql`
       ipsActivo
       numeroIps
       fechaIngresoIps
+      cobraBanco
       cuentaBancaria
       contactoEmergenciaNombre
       contactoEmergenciaTelefono

--- a/src/app/modules/personas/funcionarios/list-funcioario/list-funcioario.component.html
+++ b/src/app/modules/personas/funcionarios/list-funcioario/list-funcioario.component.html
@@ -37,7 +37,7 @@
       </div>
     </div>
     <div fxLayout="row" fxLayoutGap="10px">
-      <div fxFlex="20%">
+      <div fxFlex="17%">
         <mat-form-field style="width: 100%">
           <mat-label>Estado</mat-label>
           <mat-select [formControl]="estadoControl" (selectionChange)="onFiltrar()">
@@ -47,7 +47,7 @@
           </mat-select>
         </mat-form-field>
       </div>
-      <div fxFlex="25%">
+      <div fxFlex="22%">
         <mat-form-field style="width: 100%">
           <mat-label>Cargo</mat-label>
           <mat-select [formControl]="cargoControl" (selectionChange)="onFiltrar()">
@@ -56,7 +56,7 @@
           </mat-select>
         </mat-form-field>
       </div>
-      <div fxFlex="20%">
+      <div fxFlex="17%">
         <mat-form-field style="width: 100%">
           <mat-label>Diarista</mat-label>
           <mat-select [formControl]="diaristaControl" (selectionChange)="onFiltrar()">
@@ -66,10 +66,20 @@
           </mat-select>
         </mat-form-field>
       </div>
-      <div fxFlex="20%">
+      <div fxFlex="17%">
         <mat-form-field style="width: 100%">
           <mat-label>Fase de prueba</mat-label>
           <mat-select [formControl]="fasePruebaControl" (selectionChange)="onFiltrar()">
+            <mat-option [value]="null">Todos</mat-option>
+            <mat-option [value]="true">Sí</mat-option>
+            <mat-option [value]="false">No</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+      <div fxFlex="17%">
+        <mat-form-field style="width: 100%">
+          <mat-label>Cobra por banco</mat-label>
+          <mat-select [formControl]="cobraBancoControl" (selectionChange)="onFiltrar()">
             <mat-option [value]="null">Todos</mat-option>
             <mat-option [value]="true">Sí</mat-option>
             <mat-option [value]="false">No</mat-option>

--- a/src/app/modules/personas/funcionarios/list-funcioario/list-funcioario.component.ts
+++ b/src/app/modules/personas/funcionarios/list-funcioario/list-funcioario.component.ts
@@ -61,6 +61,7 @@ export class ListFuncioarioComponent implements OnInit, AfterViewInit {
   cargoControl = new FormControl(null)     // cargoId
   diaristaControl = new FormControl(null)
   fasePruebaControl = new FormControl(null)
+  cobraBancoControl = new FormControl(null)
   cargoList: any[] = [];
 
   length = 25;
@@ -146,7 +147,8 @@ export class ListFuncioarioComponent implements OnInit, AfterViewInit {
       this.estadoControl.value,
       this.cargoControl.value,
       this.diaristaControl.value,
-      this.fasePruebaControl.value
+      this.fasePruebaControl.value,
+      this.cobraBancoControl.value
     ).pipe(untilDestroyed(this)).subscribe(res => {
       if (res != null) {
         this.selectedPageInfo = res;
@@ -163,6 +165,7 @@ export class ListFuncioarioComponent implements OnInit, AfterViewInit {
     this.cargoControl.setValue(null)
     this.diaristaControl.setValue(null)
     this.fasePruebaControl.setValue(null)
+    this.cobraBancoControl.setValue(null)
     this.onFiltrar()
   }
 

--- a/src/app/modules/rrhh/dashboard/dashboard-rrhh.component.html
+++ b/src/app/modules/rrhh/dashboard/dashboard-rrhh.component.html
@@ -61,13 +61,42 @@
       [matMenuTriggerFor]="reportesMenu"
     ></dash-quick-action>
     <mat-menu #reportesMenu="matMenu">
+      <ng-container *ngFor="let r of reportes">
+        <!-- La nómina abre submenú de ciudades; el resto dispara el reporte directo. -->
+        <button
+          mat-menu-item
+          *ngIf="r.accion === 'nomina'"
+          [matMenuTriggerFor]="nominaCiudadesMenu"
+        >
+          <mat-icon>{{ r.icon }}</mat-icon>
+          <span>{{ r.titulo }}</span>
+        </button>
+        <button
+          mat-menu-item
+          *ngIf="r.accion !== 'nomina'"
+          (click)="onReporte(r.accion)"
+        >
+          <mat-icon>{{ r.icon }}</mat-icon>
+          <span>{{ r.titulo }}</span>
+        </button>
+      </ng-container>
+    </mat-menu>
+    <mat-menu #nominaCiudadesMenu="matMenu">
+      <button mat-menu-item (click)="onReporteNomina(null, false, null)">
+        <mat-icon>public</mat-icon>
+        <span>Todas las ciudades</span>
+      </button>
       <button
         mat-menu-item
-        *ngFor="let r of reportes"
-        (click)="onReporte(r.accion)"
+        *ngFor="let c of ciudadesNomina"
+        (click)="onReporteNomina(c.id, false, c.descripcion)"
       >
-        <mat-icon>{{ r.icon }}</mat-icon>
-        <span>{{ r.titulo }}</span>
+        <mat-icon>location_city</mat-icon>
+        <span>{{ c.descripcion | titlecase }}</span>
+      </button>
+      <button mat-menu-item (click)="onReporteNomina(null, true, 'Sin ciudad asignada')">
+        <mat-icon>help_outline</mat-icon>
+        <span>Sin ciudad asignada</span>
       </button>
     </mat-menu>
   </div>

--- a/src/app/modules/rrhh/dashboard/dashboard-rrhh.component.ts
+++ b/src/app/modules/rrhh/dashboard/dashboard-rrhh.component.ts
@@ -20,6 +20,8 @@ import { NotificacionSnackbarService, NotificacionColor } from '../../../notific
 import { ListLiquidacionComponent } from '../liquidacion/list-liquidacion/list-liquidacion.component';
 import { ListValeComponent } from '../vale/list-vale/list-vale.component';
 import { ListPrestamoComponent } from '../prestamo/list-prestamo/list-prestamo.component';
+import { CiudadService } from '../../general/ciudad/ciudad.service';
+import { Ciudad } from '../../general/ciudad/ciudad.model';
 
 interface KpiVista {
   icon: string;
@@ -102,6 +104,10 @@ export class DashboardRrhhComponent implements OnInit, OnDestroy {
     { titulo: 'Aguinaldo del año', icon: 'card_giftcard', accion: 'aguinaldo' },
   ];
   generandoReporte = false;
+  // Submenu de la nomina del mes: Todas + una entrada por ciudad. La ciudad sale de la
+  // sucursal del funcionario (persona.ciudad no se carga), y "Sin ciudad asignada" junta
+  // a los que no tienen sucursal, para que la suma de los cortes de el total general.
+  ciudadesNomina: Ciudad[] = [];
 
   private readonly TOP_N = 5;
 
@@ -110,7 +116,8 @@ export class DashboardRrhhComponent implements OnInit, OnDestroy {
     private dashboardService: DashboardRrhhService,
     private reportesService: ReportesRrhhService,
     private reporteService: ReporteService,
-    private notificacion: NotificacionSnackbarService
+    private notificacion: NotificacionSnackbarService,
+    private ciudadService: CiudadService
   ) {}
 
   ngOnInit(): void {
@@ -119,6 +126,13 @@ export class DashboardRrhhComponent implements OnInit, OnDestroy {
     this.cargar();
     this.cargarSerie();
     this.cargarIncompletos();
+    this.cargarCiudades();
+  }
+
+  private cargarCiudades(): void {
+    this.ciudadService.getAllCiudades().pipe(takeUntil(this.destroy$)).subscribe(res => {
+      this.ciudadesNomina = res || [];
+    });
   }
 
   ngOnDestroy(): void {
@@ -382,6 +396,27 @@ export class DashboardRrhhComponent implements OnInit, OnDestroy {
 
   private abrir(component: any, title: string): void {
     this.tabService.addTab(new Tab(component, title, null, DashboardRrhhComponent));
+  }
+
+  /** Nómina del mes, opcionalmente acotada a una ciudad o a los que no tienen sucursal. */
+  onReporteNomina(ciudadId: number, sinCiudad: boolean, nombreCiudad: string): void {
+    if (!this.periodo) {
+      this.notificacion.notification$.next({
+        texto: 'Seleccione el período', color: NotificacionColor.warn, duracion: 3,
+      });
+      return;
+    }
+    const nombre = 'Nómina ' + this.periodo + (nombreCiudad ? ' - ' + nombreCiudad : '');
+    this.generandoReporte = true;
+    this.reportesService.onNominaMes(this.periodo, ciudadId, sinCiudad)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (base64: string) => {
+          this.generandoReporte = false;
+          this.mostrarPdf(nombre, base64);
+        },
+        error: () => (this.generandoReporte = false),
+      });
   }
 
   // ===== Reportes (mat-menu) =====

--- a/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.html
+++ b/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.html
@@ -146,7 +146,6 @@
     <mat-form-field *ngIf="cobraBanco" class="campo-ancho">
       <mat-label>Cuenta bancaria</mat-label>
       <input matInput [formControl]="cuentaBancariaControl" />
-      <mat-error *ngIf="cuentaBancariaControl.hasError('required')">La cuenta bancaria es obligatoria</mat-error>
     </mat-form-field>
   </mat-card>
 

--- a/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.html
+++ b/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.html
@@ -137,12 +137,16 @@
     </div>
   </mat-card>
 
-  <!-- Cuenta bancaria -->
+  <!-- Forma de cobro -->
   <mat-card class="seccion-card">
-    <dash-section-header icon="account_balance" title="Cuenta bancaria"></dash-section-header>
-    <mat-form-field class="campo-ancho">
+    <dash-section-header icon="account_balance" title="Forma de cobro"></dash-section-header>
+
+    <mat-slide-toggle [formControl]="cobraBancoControl">Cobra por banco</mat-slide-toggle>
+
+    <mat-form-field *ngIf="cobraBanco" class="campo-ancho">
       <mat-label>Cuenta bancaria</mat-label>
       <input matInput [formControl]="cuentaBancariaControl" />
+      <mat-error *ngIf="cuentaBancariaControl.hasError('required')">La cuenta bancaria es obligatoria</mat-error>
     </mat-form-field>
   </mat-card>
 

--- a/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.ts
+++ b/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.ts
@@ -68,7 +68,8 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
 
   // ---- Forma de cobro ----
   // Mismo patron que IPS: el toggle es el que clasifica, y solo cuando esta en true
-  // se habilita (y se exige) el numero de cuenta.
+  // se habilita el numero de cuenta. La cuenta no se exige: se puede marcar que cobra
+  // por banco y cargar el numero despues.
   cobraBancoControl = new FormControl(false);
   cuentaBancariaControl = new FormControl({ value: null, disabled: true });
 
@@ -152,12 +153,9 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
     this.cobraBanco = cobraBanco;
     if (cobraBanco) {
       this.cuentaBancariaControl.enable({ emitEvent: false });
-      this.cuentaBancariaControl.setValidators(Validators.required);
     } else {
       this.cuentaBancariaControl.disable({ emitEvent: false });
-      this.cuentaBancariaControl.clearValidators();
     }
-    this.cuentaBancariaControl.updateValueAndValidity({ emitEvent: false });
   }
 
   private cargarCatalogos(): void {
@@ -357,14 +355,6 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
 
     if (this.documentoControl.invalid || this.nombreControl.invalid || this.sucursalControl.invalid) {
       this.notificacion.openWarn('Complete los campos obligatorios: documento, nombre y sucursal.');
-      return;
-    }
-
-    // Clasificar a alguien como "cobra por banco" sin numero de cuenta deja el dato
-    // inservible para la nomina, que es justo lo que este flag viene a resolver.
-    this.cuentaBancariaControl.markAsTouched();
-    if (this.cobraBancoControl.value && this.cuentaBancariaControl.invalid) {
-      this.notificacion.openWarn('Ingrese la cuenta bancaria o desmarque "Cobra por banco".');
       return;
     }
 

--- a/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.ts
+++ b/src/app/modules/rrhh/legajo/informacion-general/informacion-general.component.ts
@@ -66,8 +66,11 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
   numeroIpsControl = new FormControl({ value: null, disabled: true });
   fechaIngresoIpsControl = new FormControl({ value: null, disabled: true });
 
-  // ---- Cuenta bancaria ----
-  cuentaBancariaControl = new FormControl(null);
+  // ---- Forma de cobro ----
+  // Mismo patron que IPS: el toggle es el que clasifica, y solo cuando esta en true
+  // se habilita (y se exige) el numero de cuenta.
+  cobraBancoControl = new FormControl(false);
+  cuentaBancariaControl = new FormControl({ value: null, disabled: true });
 
   // ---- Contacto de emergencia ----
   contactoEmergenciaNombreControl = new FormControl(null);
@@ -89,6 +92,7 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
   puedeSubirFoto = false;
   subiendoFoto = false;
   ipsActivo = false;
+  cobraBanco = false;
   fotoPerfilSrc = AVATAR_DEFAULT;
   hoy = new Date();
 
@@ -113,6 +117,7 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
     });
 
     this.ipsActivoControl.valueChanges.pipe(untilDestroyed(this)).subscribe(v => this.aplicarEstadoIps(!!v));
+    this.cobraBancoControl.valueChanges.pipe(untilDestroyed(this)).subscribe(v => this.aplicarEstadoCobraBanco(!!v));
 
     this.cargarCatalogos();
     this.cargarFuncionario();
@@ -141,6 +146,18 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
       this.numeroIpsControl.disable({ emitEvent: false });
       this.fechaIngresoIpsControl.disable({ emitEvent: false });
     }
+  }
+
+  private aplicarEstadoCobraBanco(cobraBanco: boolean): void {
+    this.cobraBanco = cobraBanco;
+    if (cobraBanco) {
+      this.cuentaBancariaControl.enable({ emitEvent: false });
+      this.cuentaBancariaControl.setValidators(Validators.required);
+    } else {
+      this.cuentaBancariaControl.disable({ emitEvent: false });
+      this.cuentaBancariaControl.clearValidators();
+    }
+    this.cuentaBancariaControl.updateValueAndValidity({ emitEvent: false });
   }
 
   private cargarCatalogos(): void {
@@ -193,6 +210,8 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
     this.numeroIpsControl.setValue(f.numeroIps);
     this.fechaIngresoIpsControl.setValue(f.fechaIngresoIps ? stringToLocalDate(f.fechaIngresoIps as any) : null);
 
+    this.cobraBancoControl.setValue(!!f.cobraBanco);
+    this.aplicarEstadoCobraBanco(!!f.cobraBanco);
     this.cuentaBancariaControl.setValue(f.cuentaBancaria);
     this.contactoEmergenciaNombreControl.setValue(f.contactoEmergenciaNombre);
     this.contactoEmergenciaTelefonoControl.setValue(f.contactoEmergenciaTelefono);
@@ -226,6 +245,7 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
     this.numeroIpsControl.reset();
     this.fechaIngresoIpsControl.reset();
 
+    this.cobraBancoControl.setValue(false);
     this.cuentaBancariaControl.reset();
     this.contactoEmergenciaNombreControl.reset();
     this.contactoEmergenciaTelefonoControl.reset();
@@ -340,6 +360,14 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
       return;
     }
 
+    // Clasificar a alguien como "cobra por banco" sin numero de cuenta deja el dato
+    // inservible para la nomina, que es justo lo que este flag viene a resolver.
+    this.cuentaBancariaControl.markAsTouched();
+    if (this.cobraBancoControl.value && this.cuentaBancariaControl.invalid) {
+      this.notificacion.openWarn('Ingrese la cuenta bancaria o desmarque "Cobra por banco".');
+      return;
+    }
+
     const persona = new Persona();
     if (this.personaActual != null) {
       Object.assign(persona, this.personaActual);
@@ -376,7 +404,8 @@ export class InformacionGeneralComponent implements OnInit, OnChanges {
       input.ipsActivo = this.ipsActivoControl.value;
       input.numeroIps = this.ipsActivoControl.value ? this.up(this.numeroIpsControl.value) : null;
       input.fechaIngresoIps = this.ipsActivoControl.value ? dateToString(this.fechaIngresoIpsControl.value, 'yyyy-MM-dd') : null;
-      input.cuentaBancaria = this.up(this.cuentaBancariaControl.value);
+      input.cobraBanco = this.cobraBancoControl.value;
+      input.cuentaBancaria = this.cobraBancoControl.value ? this.up(this.cuentaBancariaControl.value) : null;
       input.contactoEmergenciaNombre = this.up(this.contactoEmergenciaNombreControl.value);
       input.contactoEmergenciaTelefono = this.contactoEmergenciaTelefonoControl.value;
 

--- a/src/app/modules/rrhh/reportes/graphql/graphql-query.ts
+++ b/src/app/modules/rrhh/reportes/graphql/graphql-query.ts
@@ -1,7 +1,9 @@
 import gql from "graphql-tag";
 
 export const reporteNominaMesQuery = gql`
-  query ($periodo: String!) { data: reporteNominaMes(periodo: $periodo) }
+  query ($periodo: String!, $ciudadId: ID, $sinCiudad: Boolean) {
+    data: reporteNominaMes(periodo: $periodo, ciudadId: $ciudadId, sinCiudad: $sinCiudad)
+  }
 `;
 export const reporteResumenIpsQuery = gql`
   query ($periodo: String!) { data: reporteResumenIps(periodo: $periodo) }

--- a/src/app/modules/rrhh/reportes/reportes-rrhh.service.ts
+++ b/src/app/modules/rrhh/reportes/reportes-rrhh.service.ts
@@ -51,8 +51,9 @@ export class ReportesRrhhService {
     return this.genericService.onCustomQuery(this.reciboBonoGQL, { id, anchoMm, escpos }, servidor);
   }
 
-  onNominaMes(periodo: string, servidor = true): Observable<any> {
-    return this.genericService.onCustomQuery(this.nominaGQL, { periodo }, servidor);
+  /** ciudadId: solo esa ciudad. sinCiudad: solo los funcionarios sin sucursal asignada. */
+  onNominaMes(periodo: string, ciudadId: number = null, sinCiudad = false, servidor = true): Observable<any> {
+    return this.genericService.onCustomQuery(this.nominaGQL, { periodo, ciudadId, sinCiudad }, servidor);
   }
 
   onResumenIps(periodo: string, servidor = true): Observable<any> {


### PR DESCRIPTION
## Qué resuelve

La cuenta bancaria del legajo era un campo suelto que no permitía saber si el funcionario efectivamente cobra por transferencia, y no había forma de listar ni de sacar la nómina por ese criterio.

## Cambios

**Legajo → Información general**: la sección pasa a llamarse "Forma de cobro", con un toggle *Cobra por banco* que muestra y oculta el campo de cuenta bancaria, igual que el toggle de IPS con su número. Al apagar el toggle, la cuenta se manda en `null`. La cuenta **no** es obligatoria: se puede clasificar al funcionario ahora y cargar el número después.

**Listado de funcionarios**: filtro *Cobra por banco* con los mismos tres estados que Diarista (Todos / Sí / No), incluido en el reset. La fila de filtros pasa de cuatro a cinco campos, así que se reacomodaron los anchos.

**Dashboard RRHH → Reportes**: "Nómina del mes" deja de disparar el reporte directo y abre un submenú anidado con *Todas las ciudades*, una entrada por ciudad y *Sin ciudad asignada*, esta última para los funcionarios sin sucursal, que si no quedarían fuera de todos los cortes. El resto de los reportes del menú no cambia.

## Verificación

`npm run check` (build AOT) limpio, solo los warnings de CommonJS preexistentes.

Probado en la app corriendo contra el central:

- Filtro: Sí → 1, No → 487, Todos → 488. Cierra contra la base.
- Legajo, ida y vuelta completa: apagar el toggle guarda `cobra_banco = false` y limpia la cuenta; volver a prenderlo con el número lo persiste. Verificado por SQL en las dos direcciones.
- Submenú: generados los cortes *Todas*, *Salto del Guaira* y *Sin ciudad asignada*. Los totales cuadran contra SQL y contra el KPI "Nómina del mes" del propio dashboard.

## PRs relacionados

- Central: flag `cobra_banco`, filtro en `funcionariosWithPage` y `reporteNominaMes` por ciudad
- Filial: columna espejo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XXvRTPMCFLLkCzLVXLbfU