### PR TITLE
fix(rrhh): no ofrecer pagar una liquidacion con neto negativo

### DIFF
--- a/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.html
+++ b/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.html
@@ -92,13 +92,20 @@
       [value]="liq.totalNeto | number:'1.0-0'" label="Neto a pagar"></dash-stat-chip>
   </div>
 
-  <div class="pago" *ngIf="liq.estado === 'APROBADA' && puedePagar" fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
+  <div class="pago" *ngIf="liq.estado === 'APROBADA' && puedePagar && !netoNegativo" fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
     <mat-form-field fxFlex="280px">
       <mat-label>Caja Mayor (pago)</mat-label>
       <mat-select [formControl]="cajaControl">
         <mat-option *ngFor="let c of cajas" [value]="c.id">{{ c.nombre }}</mat-option>
       </mat-select>
     </mat-form-field>
+  </div>
+
+  <div class="aviso-neto-negativo" *ngIf="liq.estado === 'APROBADA' && netoNegativo"
+    fxLayout="row" fxLayoutGap="8px" fxLayoutAlign="start center">
+    <mat-icon color="warn">error_outline</mat-icon>
+    <span>Los descuentos superan a los haberes: el funcionario le debe a la empresa, no hay nada que pagar.
+      Corrija los items o cobre la diferencia por separado.</span>
   </div>
 
   <div class="acciones-footer" fxLayout="row" fxLayoutAlign="space-between center">
@@ -112,7 +119,10 @@
       <button mat-stroked-button *ngIf="liq.estado === 'APROBADA' || liq.estado === 'PAGADA'" (click)="onImprimirRecibo()">
         <mat-icon>visibility</mat-icon> Ver Recibo
       </button>
-      <button mat-raised-button color="primary" *ngIf="liq.estado === 'APROBADA' && puedePagar" (click)="onPagar()">Pagar</button>
+      <button mat-raised-button color="primary" *ngIf="liq.estado === 'APROBADA' && puedePagar"
+        [disabled]="netoNegativo"
+        matTooltip="Neto negativo: los descuentos superan a los haberes, no hay nada que pagar"
+        [matTooltipDisabled]="!netoNegativo" (click)="onPagar()">Pagar</button>
       <button mat-stroked-button color="warn" *ngIf="liq.estado === 'PAGADA' && puedePagar" (click)="onAnular()">Anular</button>
     </div>
   </div>

--- a/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.ts
+++ b/src/app/modules/rrhh/liquidacion/liquidacion-detalle-dialog/liquidacion-detalle-dialog.component.ts
@@ -64,6 +64,13 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
   puedeAprobar = false;
   puedePagar = false;
 
+  /**
+   * Neto negativo = los descuentos superan a los haberes, o sea que el funcionario le debe a
+   * la empresa: no hay nada que pagarle y el backend rechaza el pago. Se calcula al cargar la
+   * liquidacion y no en el HTML, por la regla de no llamar funciones desde el template.
+   */
+  netoNegativo = false;
+
   constructor(
     private tabService: TabService,
     private liquidacionService: LiquidacionService,
@@ -102,7 +109,7 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
     const liqId = id ?? this.liq?.id;
     if (liqId == null) { return; }
     this.liquidacionService.onGetById(liqId).pipe(untilDestroyed(this)).subscribe((res: LiquidacionSueldo) => {
-      if (res != null) { this.liq = res; }
+      if (res != null) { this.liq = res; this.netoNegativo = (this.liq?.totalNeto ?? 0) < 0; }
     });
     this.cargarItems(liqId);
   }
@@ -117,6 +124,7 @@ export class LiquidacionDetalleDialogComponent implements OnInit {
   private aplicar(res: any) {
     if (res != null) {
       this.liq = res;
+      this.netoNegativo = (this.liq?.totalNeto ?? 0) < 0;
       this.cargarItems();
     }
   }


### PR DESCRIPTION
## Qué resuelve

Un neto negativo significa que los descuentos superan a los haberes: el funcionario le debe a la empresa y **no hay nada que pagarle**. La pantalla de detalle de liquidación igual mostraba el selector de Caja Mayor y el botón **Pagar** habilitado, y hasta confirmaba con `¿Pagar el neto de -1000000?`.

Aceptar ese pago descuadraba la caja: el egreso salía con la cantidad negada y sacaba de la caja justamente la plata que había que cobrar. El detalle completo, en el PR del central.

## Cambios

`liquidacion-detalle-dialog`:

- Con neto negativo se **oculta** el selector de Caja Mayor (no tiene sentido elegir de dónde sale plata que no sale).
- El botón **Pagar** queda **deshabilitado**, con `matTooltip` que explica por qué.
- Aparece un aviso debajo de los totales: *"Los descuentos superan a los haberes: el funcionario le debe a la empresa, no hay nada que pagar. Corrija los ítems o cobre la diferencia por separado."*

El flag `netoNegativo` se calcula al cargar la liquidación (en `recargar()` y `aplicar()`), **no desde el HTML** — regla de performance del proyecto: nunca llamar funciones desde el template.

`MatTooltipModule` ya venía exportado por `MaterialModule`, no hizo falta tocar imports.

## Cómo probarlo

1. RRHH → Liquidaciones, buscar una liquidación **APROBADA** cuyo neto sea negativo (descuentos > haberes).
2. Abrir **Detalle**.
3. Verificar: sin selector de caja, **Pagar** deshabilitado con tooltip, aviso visible.
4. Regresión — abrir una liquidación APROBADA con neto positivo: el selector de caja y **Pagar** siguen habilitados, y el flujo pagar → anular funciona igual que antes.

Verificado en la app corriendo contra el central con el fix:

- Liquidación 2026-10, neto **-100.000** → botón deshabilitado + aviso ✓
- Liquidación #485, neto **+100.000** → pago 3.900.000 → 3.800.000; anulación → **3.900.000** ✓

`npm run check` (build AOT): exit 0, sólo los warnings CommonJS preexistentes.

## Impacto en DB

Ninguno.

## Impacto en rollback

Ninguno. Es sólo UX: el central rechaza el pago de todas formas, así que revertir este PR no reabre el agujero — sólo vuelve a ofrecer un botón que falla con error.

## Riesgo

**Bajo.** El cambio está acotado a un componente y sólo se activa cuando `totalNeto < 0`. El camino normal queda idéntico.

## Cross-repo

Va con **GabFrank/franco-system-backend-servidor#285** (misma rama `fix/rrhh-anulacion-neto-negativo`), que es donde está el fix real: la validación del pago y la anulación que no revertía. Este PR evita ofrecer una acción que el central va a rechazar; son independientes y se pueden mergear en cualquier orden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pzdw2BNooFrHGTd8UWictB