### PR TITLE
fix(release): quitar asarUnpack que rompe el empaquetado de electron-builder

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -5,7 +5,6 @@
     "repo": "frc-sistemas-integrados-angular"
   },
   "asar": true,
-  "asarUnpack": ["app/icons/**"],
   "directories": {
     "output": "release/"
   },


### PR DESCRIPTION
## Qué resuelve

Desde el merge de #271 (`fix/icono-bodega-franco`, v4.2.0-alpha.35) **ninguna release genera instaladores**: el job `build (ubuntu-latest)` de `Release` falla en *Build Electron* y el de Windows se cancela por fail-fast. Las releases `v4.2.0-alpha.35` a `alpha.41` quedaron publicadas **sin `FRC-Setup.exe`, `FRC.AppImage` ni `alpha.yml`**.

Error de CI:

```
⨯ .../dist/01.8c372d2fbbb9a5f6.png must be under .../app/  failedTask=build
```

## Causa

#271 agregó `"asarUnpack": ["app/icons/**"]` a `electron-builder.json`. Con `asarUnpack` definido, electron-builder 23.6 evalúa el patrón sobre **cada** archivo del asar (`asarUtil.ts` → `unpackPattern` → `getRelativePath`), y `getRelativePath` lanza para todo archivo que no esté bajo el appDir (`app/`) ni en `node_modules`: exactamente los que entran por `files: [{ from: "../dist" }]`. Falla con cualquier patrón, no solo con este.

El CI de PR no lo detectó porque solo corre `build:prod` y `electron:serve-tsc`, nunca `electron-builder`.

## Cambio

Se quita `asarUnpack`. No hace falta desempaquetar `app/icons`: `BrowserWindow.icon` y `Notification.icon` (`app/main.ts`) pasan por `nativeImage`, que lee desde dentro del asar. El resto de #271 (íconos, `main.ts`, favicon) queda igual.

## Cómo se probó

- Reproducido en local sobre `develop`: `npx electron-builder --linux dir --publish never` → mismo error y misma traza.
- Con el fix: empaqueta sin error; `asar list` de `app.asar` muestra `/main.js`, `/icons/logo.png`, `/index.html` y los assets de `dist`.
- `npm run check` (AOT) OK.

## Riesgo / auto-update

Bajo. No cambia `artifactName`, manifests ni `installer.nsh`. Al mergear, la próxima alpha vuelve a subir instaladores y `alpha.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QomEFZuNfUmp5nE1MtgV4U
