### PR TITLE
feat(gastos): columna de vuelto en la lista de gastos

### DIFF
--- a/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.html
+++ b/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.html
@@ -118,6 +118,20 @@
         </td>
       </ng-container>
 
+      <ng-container matColumnDef="vuelto">
+        <th mat-header-cell *matHeaderCellDef style="text-align: center">
+          Vuelto
+        </th>
+        <td
+          mat-cell
+          *matCellDef="let gasto"
+          [matTooltip]="gasto?.vueltoLabel"
+          style="text-align: center; white-space: nowrap"
+        >
+          {{ gasto?.vueltoLabel }}
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="caja">
         <th mat-header-cell *matHeaderCellDef style="text-align: center">
           Caja

--- a/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.ts
+++ b/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.ts
@@ -111,6 +111,13 @@ export class ListGastosComponent implements OnInit {
   }
 
   onFiltrar() {
+    const { pageIndex, pageSize } = this.paginationSubject.value;
+    // Filtrar desde una pagina > 1 dejaba la grilla parada en un indice que el
+    // nuevo resultado ya no tiene, y se veia vacia. Se vuelve a la primera.
+    if (pageIndex !== 0) {
+      this.paginationSubject.next({ pageIndex: 0, pageSize });
+      return;
+    }
     this.refetchSubject.next();
   }
 

--- a/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.ts
+++ b/src/app/modules/financiero/gastos/pages/list-gastos/list-gastos.component.ts
@@ -19,6 +19,9 @@ import { GastosDashboardComponent } from '../gastos-dashboard/gastos-dashboard.c
 import { MainService } from '../../../../../main.service';
 import { ROLES } from '../../../../personas/roles/roles.enum';
 
+/** Gasto de la grilla con el texto del vuelto ya resuelto (no se calcula desde el HTML). */
+export type GastoRow = Omit<Gasto, 'toInput' | 'toDetalleInputList'> & { vueltoLabel: string };
+
 @UntilDestroy()
 @Component({
   selector: 'app-list-gastos',
@@ -47,7 +50,7 @@ export class ListGastosComponent implements OnInit {
   
   displayedColumns = [
     'id', 'sucursal', 'caja', 'responsable', 'autorizadoPor', 'tipoGasto', 'estadoSolicitud', 'observacion',
-    'retiroGs', 'retiroRs', 'retiroDs', 'creadoEn', 'acciones'
+    'retiroGs', 'retiroRs', 'retiroDs', 'vuelto', 'creadoEn', 'acciones'
   ];
 
   // Incluye SERVIDOR (sucursal 0): ahi quedan los gastos pagados desde la caja mayor, que no
@@ -65,7 +68,7 @@ export class ListGastosComponent implements OnInit {
 
   public totalElements$ = new BehaviorSubject<number>(0);
 
-  public gastos$: Observable<Gasto[]> = combineLatest([
+  public gastos$: Observable<GastoRow[]> = combineLatest([
     this.refetchSubject,
     this.pagination$
   ]).pipe(
@@ -81,7 +84,7 @@ export class ListGastosComponent implements OnInit {
     tap(res => {
       if (res) this.totalElements$.next(res.getTotalElements);
     }),
-    map(res => res?.getContent || []),
+    map(res => (res?.getContent || []).map(g => this.toRow(g))),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
@@ -214,6 +217,32 @@ export class ListGastosComponent implements OnInit {
       return 'CANCELADO';
     }
     return gasto?.preGasto?.estadoEtiqueta || gasto?.preGasto?.estado || '-';
+  }
+
+  private toRow(gasto: Gasto): GastoRow {
+    return { ...gasto, vueltoLabel: this.buildVueltoLabel(gasto) };
+  }
+
+  /**
+   * Arma el texto de la columna Vuelto. Devuelve '-' cuando el gasto no tuvo
+   * vuelto en ninguna moneda. El monto va antes del simbolo: "10.000 Gs".
+   */
+  private buildVueltoLabel(gasto: Gasto): string {
+    const vueltoGs = Number(gasto?.vueltoGs ?? 0);
+    const vueltoRs = Number(gasto?.vueltoRs ?? 0);
+    const vueltoDs = Number(gasto?.vueltoDs ?? 0);
+    const parts: string[] = [];
+    if (vueltoGs > 0) parts.push(`${this.formatMonto(vueltoGs, 0)} Gs`);
+    if (vueltoRs > 0) parts.push(`${this.formatMonto(vueltoRs, 2)} Rs`);
+    if (vueltoDs > 0) parts.push(`${this.formatMonto(vueltoDs, 2)} Ds`);
+    return parts.length > 0 ? parts.join(' | ') : '-';
+  }
+
+  private formatMonto(amount: number, fractionDigits: number): string {
+    return new Intl.NumberFormat('es-PY', {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    }).format(amount);
   }
 
   getAutorizadoPor(gasto: Gasto): string {


### PR DESCRIPTION
## Qué cambia

**1. Columna "Vuelto" en la lista de gastos** (`feat`)

Nueva columna en Financiero → Lista de Gastos, ubicada después de Dólares. Muestra el vuelto por moneda (`40.000 Gs`, `10,00 Rs`, `10,00 Ds`, o combinadas con ` | ` si hubo en más de una) y un `-` cuando el gasto no tuvo vuelto en ninguna.

El texto se resuelve en el componente (`buildVueltoLabel`) y se adjunta a cada fila, en vez de llamarse desde el HTML — la regla de performance del CLAUDE.md sobre no invocar funciones desde el template.

Cambio **solo de frontend**: `Gasto.vueltoGs/Rs/Ds` ya existían en la entity del central y en `gasto.graphqls`, y `filterGastosQuery` ya los pedía. No hubo que tocar backend ni agregar migración.

**2. Volver a la primera página al filtrar** (`fix`)

Bug preexistente de la lista, independiente del vuelto: filtrar desde una página mayor a la primera mantenía el `pageIndex`, y si el resultado filtrado tenía menos páginas la grilla quedaba vacía hasta volver a mano a la página 1.

Van en commits separados para que cada uno entre en `develop` con su tipo.

## Verificación

- `npm run check` (build AOT producción): 0 errores TS.
- Probado en la app corriendo (central 8081 + filial 8082 + front), contra datos reales: filtrando por caja 5387, el gasto 7956 muestra `40.000 Gs` y los 7951–7955 muestran `-`. El salto a la página 1 al filtrar también verificado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHRYs7NvEf9ZVQMdQivwNr
