### PR TITLE
fix(rrhh): avisar en el egreso que los bonos pendientes se anulan

### DIFF
--- a/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.html
+++ b/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.html
@@ -5,8 +5,14 @@
   <!-- Egresar hace más de lo que su nombre sugiere, y desde acá no se deshace. -->
   <div class="consecuencias">
     Además se le <b>quita el acceso al sistema</b>, se le pone el <b>crédito en cero</b> y su cliente
-    vuelve a <b>NORMAL</b>, también sin crédito. El crédito no queda guardado en ningún lado:
-    para restaurarlo hay que volver a cargarlo a mano.
+    vuelve a <b>NORMAL</b>, también sin crédito.
+  </div>
+
+  <!-- El finiquito no paga bonos: lo pendiente se anula acá. Ver issue #276 del central. -->
+  <div class="consecuencias">
+    También se <b>anulan sus bonos pendientes</b> y se <b>apaga su bono recurrente</b>, si tiene:
+    el finiquito no paga bonos. Al revertir el egreso el crédito vuelve solo, pero
+    <b>los bonos no</b>: hay que volver a cargarlos a mano.
   </div>
 
   <mat-form-field style="width: 100%">

--- a/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.html
+++ b/src/app/modules/rrhh/legajo/revertir-egreso-dialog/revertir-egreso-dialog.component.html
@@ -21,6 +21,12 @@
     <b>{{ creditoActualTexto }}</b> y hay que volver a cargarlo a mano.
   </p>
 
+  <!-- La reversa no rehace lo que el egreso anuló en bonos: ver issue #276 del central. -->
+  <p class="alerta">
+    Los <b>bonos que el egreso anuló</b> y el <b>bono recurrente que apagó</b> no se restauran:
+    si corresponde que los vuelva a cobrar, hay que cargarlos de nuevo desde la pantalla de Bonos.
+  </p>
+
   <mat-form-field style="width: 100%">
     <mat-label>Crédito a restaurar</mat-label>
     <input matInput type="number" [formControl]="creditoControl" required />


### PR DESCRIPTION
PR hermano de GabFrank/franco-system-backend-servidor#294 (issue #276 del central). Sin ese backend desplegado, el aviso describe algo que todavía no pasa.

## Qué resuelve

El central ahora anula los bonos sin liquidar y apaga el bono recurrente al egresar, porque el finiquito no paga bonos. El diálogo de egreso solo hablaba del acceso, el crédito y el tipo de cliente: quien egresaba no tenía cómo saber que también se estaba cancelando plata pendiente.

## Qué cambia

**Diálogo de egreso** — bloque nuevo, mismo estilo que el que ya estaba:

> También se **anulan sus bonos pendientes** y se **apaga su bono recurrente**, si tiene: el finiquito no paga bonos. Al revertir el egreso el crédito vuelve solo, pero **los bonos no**: hay que volver a cargarlos a mano.

**Diálogo de revertir egreso** — la contracara:

> Los **bonos que el egreso anuló** y el **bono recurrente que apagó** no se restauran: si corresponde que los vuelva a cobrar, hay que cargarlos de nuevo desde la pantalla de Bonos.

**Además**, se saca del aviso de egreso la frase que decía que el crédito no queda guardado en ningún lado. Es falsa desde que existe el histórico de egreso —el diálogo de reversión lo ofrece precargado— y contradecía al aviso nuevo, que distingue justamente entre lo que vuelve solo y lo que no.

Solo texto: no cambia ningún comportamiento, servicio ni query.

## Cómo probarlo

1. RRHH → Personal → Funcionarios → legajo de un funcionario activo → **Egresar**: el diálogo muestra los dos bloques de consecuencias.
2. Legajo de un funcionario ya egresado → **Revertir egreso**: aparece el aviso de que los bonos no se restauran.

Ambos diálogos verificados en la app corriendo, sin ejecutar el egreso ni la reversión.

## Impacto

- **Auto-update:** ninguno. No toca `installer.nsh`, `electron-builder.json` ni manifests.
- **GraphQL:** ninguno. No consume campos nuevos.
- **Riesgo:** bajo — dos plantillas HTML.

## Verificación

`npm run check` (AOT de producción) → exit code 0, cero errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWt857ee4NRkZffjAovb7y