### PR TITLE
feat(gastos): observacion obligatoria y consultas livianas de funcionario

### DIFF
--- a/src/app/modules/financiero/gastos/dialogs/adicionar-gasto-dialog/adicionar-gasto-dialog.component.html
+++ b/src/app/modules/financiero/gastos/dialogs/adicionar-gasto-dialog/adicionar-gasto-dialog.component.html
@@ -72,7 +72,11 @@
         <div #retiro fxFlex fxLayout="row">
           <mat-form-field style="width: 100%">
             <mat-label>Observación</mat-label>
-            <input #obs type="text" matInput [formControl]="observacionControl" (keyup.enter)="gs.select()" />
+            <input #obs type="text" matInput required [formControl]="observacionControl"
+              (keyup.enter)="gs.select()" />
+            <mat-error *ngIf="observacionControl.hasError('required')">
+              La observación es obligatoria
+            </mat-error>
           </mat-form-field>
         </div>
         <div fxFlex fxLayout="row" style="width: 100%" fxLayoutGap="10px">
@@ -138,7 +142,8 @@
           <app-boton #guardarBtn (clickEvent)="isVuelto != true ? onGuardar() : onSaveVuelto()" [disableExpression]="
               selectedResponsable == null ||
               selectedTipoGasto == null ||
-              autorizado != true
+              autorizado != true ||
+              observacionControl.invalid
             " color="accent" nombre="Guardar">
           </app-boton>
         </div>

--- a/src/app/modules/financiero/gastos/dialogs/adicionar-gasto-dialog/adicionar-gasto-dialog.component.ts
+++ b/src/app/modules/financiero/gastos/dialogs/adicionar-gasto-dialog/adicionar-gasto-dialog.component.ts
@@ -6,7 +6,7 @@ import {
   OnInit,
   ViewChild,
 } from "@angular/core";
-import { FormControl } from "@angular/forms";
+import { FormControl, Validators } from "@angular/forms";
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { MatStepper } from "@angular/material/stepper";
 import { MatTableDataSource } from "@angular/material/table";
@@ -62,6 +62,7 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
   autorizadoPorInput: ElementRef;
   @ViewChild("guaraniVueltoGs", { static: false })
   guaraniVueltoGsInput: ElementRef;
+  @ViewChild("obs", { static: false }) observacionInput: ElementRef;
   @ViewChild("stepper", { static: false }) stepper: MatStepper;
   @ViewChild("responsableInput", { read: MatAutocompleteTrigger, static: false })
   responsableAutocomplete: MatAutocompleteTrigger;
@@ -106,7 +107,7 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
   responsableControl = new FormControl();
   tipoGastoControl = new FormControl();
   autorizadoPorControl = new FormControl();
-  observacionControl = new FormControl();
+  observacionControl = new FormControl(null, Validators.required);
   guaraniControl = new FormControl(0);
   realControl = new FormControl(0);
   dolarControl = new FormControl(0);
@@ -203,7 +204,7 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
         if (res != null && res.length != 0) {
           this.autorizadoPorTimer = setTimeout(() => {
             this.funcionarioService
-              .onFuncionarioSearch(res, false)
+              .onFuncionarioSearchSimple(res, false)
               .pipe(untilDestroyed(this))
               .subscribe((response) => {
                 this.autorizadoPorList = response;
@@ -276,7 +277,7 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
     if (this.responsableControl.valid) {
       if (isNaN(this.responsableControl.value) == false) {
         this.funcionarioService
-          .onGetFuncionarioPorPersona(this.responsableControl.value, false)
+          .onGetFuncionarioPorPersonaSimple(this.responsableControl.value, false)
           .subscribe((res) => {
             if (res != null) {
               this.onResponsableSelect(res);
@@ -292,7 +293,7 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
 
   onSearchFuncionarioPorNombre() {
     this.funcionarioService
-      .onFuncionarioSearch(this.responsableControl.value, false)
+      .onFuncionarioSearchSimple(this.responsableControl.value, false)
       .pipe(untilDestroyed(this))
       .subscribe((response) => {
         this.responsableList = response;
@@ -512,6 +513,16 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
 
   onGuardar() {
     if (this.isVuelto == false) {
+      const observacion = (this.observacionControl.value ?? "").toString().trim();
+      if (observacion.length == 0) {
+        this.observacionControl.setValue(null);
+        this.observacionControl.markAsTouched();
+        this.notificacionService.openWarn("La observación es obligatoria");
+        setTimeout(() => {
+          this.observacionInput?.nativeElement?.focus();
+        }, 0);
+        return;
+      }
       if (this.selectedResponsable != null && this.verficarValores()) {
         this.dialogService
           .confirm("Confirmar valores de gasto", null, null, [
@@ -533,7 +544,7 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
               gasto.responsable = this.selectedResponsable;
               gasto.tipoGasto = this.selectedTipoGasto;
               gasto.autorizadoPor = this.selectedAutorizadoPor;
-              gasto.observacion = this.observacionControl.value;
+              gasto.observacion = observacion;
               gasto.retiroGs = this.guaraniControl.value;
               gasto.retiroRs = this.realControl.value;
               gasto.retiroDs = this.dolarControl.value;
@@ -651,7 +662,7 @@ export class AdicionarGastoDialogComponent implements OnInit, OnDestroy {
     this.responsableControl.setValue(null);
     this.tipoGastoControl.setValue(null);
     this.autorizadoPorControl.setValue(null);
-    this.observacionControl.setValue(null);
+    this.observacionControl.reset(null);
     this.guaraniControl.setValue(0);
     this.realControl.setValue(0);
     this.dolarControl.setValue(0);

--- a/src/app/modules/financiero/retiro/adicionar-retiro-dialog/adicionar-retiro-dialog.component.ts
+++ b/src/app/modules/financiero/retiro/adicionar-retiro-dialog/adicionar-retiro-dialog.component.ts
@@ -135,7 +135,7 @@ export class AdicionarRetiroDialogComponent implements OnInit, OnDestroy, AfterV
     if (this.responsableControl.valid) {
       if (isNaN(this.responsableControl.value) == false) {
         this.funcionarioService
-          .onGetFuncionarioPorPersona(this.responsableControl.value, false)
+          .onGetFuncionarioPorPersonaSimple(this.responsableControl.value, false)
           .subscribe((res) => {
             if (res != null) {
               this.onResponsableSelect(res);
@@ -151,7 +151,7 @@ export class AdicionarRetiroDialogComponent implements OnInit, OnDestroy, AfterV
 
   onResponsableSearchByTexto() {
     this.funcionarioService
-      .onFuncionarioSearch(this.responsableControl.value, false)
+      .onFuncionarioSearchSimple(this.responsableControl.value, false)
       .pipe(untilDestroyed(this))
       .subscribe((response) => {
         this.funcionarioList = response;

--- a/src/app/modules/personas/funcionarios/funcionario.service.ts
+++ b/src/app/modules/personas/funcionarios/funcionario.service.ts
@@ -23,6 +23,8 @@ import { FuncionariosWithPageGQL } from './graphql/funcionarios-with-page';
 import { PageInfo } from '../../../app.component';
 import { FuncionarioPorPersonaIdGQL } from './graphql/funcionarioPorPersonaId';
 import { FuncionarioByIdGQL } from './graphql/funcionarioById';
+import { FuncionarioSearchSimpleGQL } from './graphql/funcionarioSearchSimple';
+import { FuncionarioPorPersonaIdSimpleGQL } from './graphql/funcionarioPorPersonaIdSimple';
 
 @UntilDestroy({ checkProperties: true })
 @Injectable({
@@ -43,7 +45,9 @@ export class FuncionarioService {
     private preRegistroFuncionarios: PreRegistroFuncionariosGQL,
     private funcionariosWithPage: FuncionariosWithPageGQL,
     private funcionarioPorPersona: FuncionarioPorPersonaIdGQL,
-    private funcionarioById: FuncionarioByIdGQL
+    private funcionarioById: FuncionarioByIdGQL,
+    private searchFuncionarioSimple: FuncionarioSearchSimpleGQL,
+    private funcionarioPorPersonaSimple: FuncionarioPorPersonaIdSimpleGQL
   ) { }
 
   onGetAllFuncionarios(page?, size?, servidor = true): Observable<Funcionario[]> {
@@ -119,5 +123,15 @@ export class FuncionarioService {
 
   onGetFuncionarioPorPersona(id, servidor = true): Observable<Funcionario> {
     return this.genericCrud.onGetById(this.funcionarioPorPersona, id, null, null, servidor);
+  }
+
+  // Busquedas livianas para autocompletes (id + persona). Usarlas cuando la consulta
+  // va contra la filial: la version completa pide horario, que solo existe en el central.
+  onFuncionarioSearchSimple(texto: string, servidor = true): Observable<any> {
+    return this.genericCrud.onCustomQuery(this.searchFuncionarioSimple, { texto }, servidor);
+  }
+
+  onGetFuncionarioPorPersonaSimple(id, servidor = true): Observable<Funcionario> {
+    return this.genericCrud.onGetById(this.funcionarioPorPersonaSimple, id, null, null, servidor);
   }
 }

--- a/src/app/modules/personas/funcionarios/graphql/funcionarioPorPersonaIdSimple.ts
+++ b/src/app/modules/personas/funcionarios/graphql/funcionarioPorPersonaIdSimple.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { Funcionario } from '../funcionario.model';
+import { funcionarioPorPersonaSimpleQuery } from './graphql-query';
+
+export interface Response {
+  data: Funcionario;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FuncionarioPorPersonaIdSimpleGQL extends Query<Response> {
+  document = funcionarioPorPersonaSimpleQuery;
+}

--- a/src/app/modules/personas/funcionarios/graphql/funcionarioSearchSimple.ts
+++ b/src/app/modules/personas/funcionarios/graphql/funcionarioSearchSimple.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Query } from 'apollo-angular';
+import { Funcionario } from '../funcionario.model';
+import { funcionariosSearchSimple } from './graphql-query';
+
+export interface Response {
+  data: Funcionario[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FuncionarioSearchSimpleGQL extends Query<Response> {
+  document = funcionariosSearchSimple;
+}

--- a/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
+++ b/src/app/modules/personas/funcionarios/graphql/graphql-query.ts
@@ -138,6 +138,37 @@ export const funcionariosSearch = gql`
   }
 `;
 
+// Version liviana del buscador y del lookup por persona: solo lo que necesita un
+// autocomplete (id + persona). No pide horario ni datos de RRHH, por eso se puede
+// usar contra la filial, donde administrativo.horario no se replica.
+export const funcionariosSearchSimple = gql`
+  query ($texto: String) {
+    data: funcionariosSearch(texto: $texto) {
+      id
+      nickname
+      activo
+      persona {
+        id
+        nombre
+      }
+    }
+  }
+`;
+
+export const funcionarioPorPersonaSimpleQuery = gql`
+  query ($id: ID!) {
+    data: funcionarioPorPersona(id: $id) {
+      id
+      nickname
+      activo
+      persona {
+        id
+        nombre
+      }
+    }
+  }
+`;
+
 export const funcionarioQuery = gql`
   query ($id: ID!) {
     data: funcionario(id: $id) {


### PR DESCRIPTION
## Qué resuelve

**1. La observación del gasto pasa a ser obligatoria** (`adicionar-gasto-dialog`). `Validators.required` en el control, `mat-error`, el botón **Guardar** deshabilitado mientras esté vacío y un corte en `onGuardar()` que además recorta el texto, para que no entre una observación de puros espacios.

El modo **Vuelto** y **Ver** no se ven afectados: ahí `cargarDatos()` deshabilita el control, y un control disabled reporta `invalid == false`, así que ni el botón se bloquea ni `onSaveVuelto()` pasa por la validación nueva. El retiro de solicitudes autorizadas tampoco cambia: ese gasto se arma en `gasto.service.ts:257` con `observacion = preGasto.descripcion`, que ya viene cargada.

La validación equivalente del lado servidor va en el PR del backend filial (GabFrank/franco-system-backend-filial#126).

**2. `EntityNotFoundException: Unable to find Horario with id N` en el log del filial.** Las queries de funcionario piden `horario { ... }`, pero `administrativo.horario` no se replica a las filiales — el marcado de horarios se usa solo en el central — mientras que `personas.funcionario` sí. Resultado: `horario_id` apunta a una fila que en la filial no existe y el backend revienta al inicializar el proxy lazy. Son 19 funcionarios en la base local, 17 de ellos con `horario_id = 6`.

Se agregan dos consultas livianas — `funcionariosSearchSimple` y `funcionarioPorPersonaSimpleQuery`, solo `id`, `nickname`, `activo` y `persona { id nombre }`, que es todo lo que muestran los autocompletes — y pasan a usarlas las 5 llamadas que van contra la filial (3 en el diálogo de gastos, 2 en el de retiro).

**Por qué no alcanzaba con sacar `horario` de las queries existentes:** `Funcionario.toInput()` (`funcionario.model.ts:54`) arma `horarioId` desde `this.horario?.id`. El diálogo de alta/edición de funcionario carga por `funcionarioPorPersona` y después guarda, así que dejar de pedir el horario mandaría `horarioId: null` y **borraría la asignación de horario** del funcionario. Por eso las queries completas quedan intactas para el central y las livianas son aparte.

## Cómo probarlo

- Gastos → alta de gasto: el botón Guardar arranca deshabilitado y el campo Observación muestra el error al salir vacío.
- Guardar con observación cargada: sin cambios respecto de hoy.
- Vuelto y Ver sobre un gasto existente: siguen funcionando aunque el gasto no tenga observación.
- Autocomplete de responsable en gastos y en retiro: sin `EntityNotFoundException` en el log del filial.

## Riesgo

Bajo. No toca el schema GraphQL ni agrega dependencias. El único cambio de comportamiento intencional es el rechazo del gasto sin observación. Sin impacto en auto-update (no se tocó `installer.nsh`, `electron-builder.json` ni los manifests).

## Verificación

`npm run check` (AOT, ya rebaseado sobre `origin/develop`) → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZedJvY1geZhxHpR5rNSgR