### PR TITLE
fix(rrhh): no ofrecer funcionarios inactivos al cargar un bono

### DIFF
--- a/src/app/modules/rrhh/bono/edit-bono-dialog/edit-bono-dialog.component.html
+++ b/src/app/modules/rrhh/bono/edit-bono-dialog/edit-bono-dialog.component.html
@@ -8,6 +8,7 @@
   <form [formGroup]="formGroup" fxLayout="column" fxLayoutGap="12px">
     <app-select-funcionario
       [funcionarioId]="funcionarioControl.value"
+      [soloActivos]="true"
       (idSelected)="funcionarioControl.setValue($event)">
     </app-select-funcionario>
     <span class="error-funcionario" *ngIf="funcionarioControl.touched && funcionarioControl.hasError('required')">

--- a/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.html
+++ b/src/app/modules/rrhh/legajo/egresar-funcionario-dialog/egresar-funcionario-dialog.component.html
@@ -8,7 +8,8 @@
     vuelve a <b>NORMAL</b>, también sin crédito.
   </div>
 
-  <!-- El finiquito no paga bonos: lo pendiente se anula acá. Ver issue #276 del central. -->
+  <!-- El finiquito no paga bonos: lo pendiente se anula al quedar inactivo, venga por el
+       camino que venga. Ver issues #276 y #295 del central. -->
   <div class="consecuencias">
     También se <b>anulan sus bonos pendientes</b> y se <b>apaga su bono recurrente</b>, si tiene:
     el finiquito no paga bonos. Al revertir el egreso el crédito vuelve solo, pero

--- a/src/app/shared/components/search-list-dialog/search-list-dialog.component.ts
+++ b/src/app/shared/components/search-list-dialog/search-list-dialog.component.ts
@@ -49,6 +49,11 @@ export class SearchListtDialogData {
   searchFieldName?: string;
   textHint?: string;
   fallbackToLocal?: boolean = false;
+  /**
+   * Predicado opcional para descartar filas que no se deben poder elegir en esta pantalla
+   * (ej. funcionarios inactivos al cargar un bono). Sin filtro, la lista no cambia.
+   */
+  filtro?: (item: any) => boolean;
   /** Texto del boton de confirmacion en modo multiple. Default: 'Aplicar filtro' */
   labelAceptar?: string;
 }
@@ -302,11 +307,12 @@ export class SearchListDialogComponent implements OnInit, AfterViewInit {
 
   private procesarResultados(res: any): void {
     if (res != null) {
+      const filtrar = (filas: any[]) => this.data?.filtro ? (filas || []).filter(this.data.filtro) : (filas || []);
       if (this.data?.paginator == true) {
         this.selectedPageInfo = res;
-        this.dataSource.data = this.selectedPageInfo?.getContent || [];
+        this.dataSource.data = filtrar(this.selectedPageInfo?.getContent);
       } else {
-        this.dataSource.data = res || [];
+        this.dataSource.data = filtrar(res);
       }
       if (typeof (this.dataSource as any)._updateChangeSubscription === 'function') {
         (this.dataSource as any)._updateChangeSubscription();

--- a/src/app/shared/components/select-funcionario/select-funcionario.component.ts
+++ b/src/app/shared/components/select-funcionario/select-funcionario.component.ts
@@ -35,6 +35,11 @@ export class SelectFuncionarioComponent implements OnInit, OnChanges {
   @Input() titulo = 'Funcionario';
   @Input() funcionarioId: number;
   @Input() disabled = false;
+  /**
+   * Deja fuera del buscador a los funcionarios dados de baja. Por default siguen apareciendo:
+   * hay pantallas (liquidacion final, legajo) que justamente trabajan sobre egresados.
+   */
+  @Input() soloActivos = false;
 
   @Output() idSelected = new EventEmitter<number>();
   @Output() funcionarioSelected = new EventEmitter<Funcionario>();
@@ -81,7 +86,8 @@ export class SelectFuncionarioComponent implements OnInit, OnChanges {
         { id: 'nickname', nombre: 'Usuario', width: '20%' }
       ],
       query: this.searchFuncionario,
-      fallbackToLocal: true
+      fallbackToLocal: true,
+      filtro: this.soloActivos ? (f: Funcionario) => f?.activo !== false : undefined
     };
     this.dialog.open(SearchListDialogComponent, {
       data: data,


### PR DESCRIPTION
Lado desktop de las issues #296 y #295 del central. Continúa #290, que ya está mergeado.

**PR hermano:** GabFrank/franco-system-backend-servidor#297 (rama `fix/rrhh-anular-bonos-al-inactivar`). El central, además, rechaza el alta de un bono para un inactivo.

## Qué resuelve

El buscador de funcionarios del diálogo de Bonos devolvía a todos, egresados incluidos. Un bono cargado a alguien que ya se fue quedaba pendiente para siempre: el finiquito no paga bonos y la liquidación mensual saltea a los inactivos.

## Qué cambia

- **`search-list-dialog`**: nuevo campo opcional `filtro`, un predicado aplicado en `procesarResultados`. Sin filtro la lista no cambia, así que el resto de las pantallas que usan el diálogo quedan igual.
- **`app-select-funcionario`**: nuevo input `soloActivos`, **apagado por default**. Lo usan 16 pantallas y algunas (liquidación final, legajo) trabajan justamente sobre egresados.
- **Diálogo de Bonos**: prende `soloActivos`.
- **Aviso de egreso**: solo se actualiza un comentario HTML. La anulación ya no depende del botón Egresar sino de que el funcionario quede inactivo (#295). El texto visible no cambia.

Editar un bono existente de alguien que ya egresó **sigue mostrando su nombre**: la precarga del selector busca por id, sin pasar por el filtro.

## Cómo probarlo

1. RRHH → Beneficios → Bonos → **+ Adicionar** → buscar funcionario.
2. Buscar a alguien inactivo: **no aparece**.
3. Buscar a alguien activo: aparece y se puede elegir.

Verificado en la app corriendo: un inactivo real (CLAUDELINO, id 111) no aparece; PRUEBA 1 (activo) sí.

## Impacto

- **Auto-update:** ninguno. No toca `installer.nsh`, `electron-builder.json` ni manifests.
- **GraphQL:** ninguno. Usa el campo `activo` que la query de búsqueda ya traía.
- **Riesgo:** bajo. El filtro es opt-in.

## Verificación

`npm run check` (AOT de producción) → **0 errores**, sobre `develop` actualizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWt857ee4NRkZffjAovb7y
