### PR TITLE
feat(clientes): columna nro convenio en la lista de clientes

### DIFF
--- a/src/app/modules/personas/clientes/list-clientes/list-clientes.component.html
+++ b/src/app/modules/personas/clientes/list-clientes/list-clientes.component.html
@@ -87,6 +87,15 @@
         </td>
       </ng-container>
 
+      <ng-container matColumnDef="nroConvenio">
+        <th mat-header-cell *matHeaderCellDef style="text-align: center">
+          Nro convenio
+        </th>
+        <td mat-cell *matCellDef="let cliente" style="text-align: center">
+          {{ cliente?.persona?.id }}
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="nombre">
         <th mat-header-cell *matHeaderCellDef style="text-align: center">
           Nombre

--- a/src/app/modules/personas/clientes/list-clientes/list-clientes.component.ts
+++ b/src/app/modules/personas/clientes/list-clientes/list-clientes.component.ts
@@ -51,6 +51,7 @@ export class ListClientesComponent implements OnInit {
     "select",
     "id",
     "tipo",
+    "nroConvenio",
     "nombre",
     "credito",
     "saldo",


### PR DESCRIPTION
## Qué resuelve
Agrega la columna **Nro convenio** en *Lista de clientes*, entre **Tipo** y **Nombre**. Muestra el `persona.id` del cliente (ej.: Diego Paulinho Amarilla Mercado → 5455).

La query `clienteConFiltros` ya traía `persona.id`, así que no hay cambios de backend ni de GraphQL.

## Cómo probar
1. Abrir *Personas → Lista de clientes* y buscar (con o sin filtro de tipo).
2. Verificar que la columna **Nro convenio** aparece entre Tipo y Nombre, centrada, con el id de persona de cada cliente.

`npm run check` (AOT) pasa sin errores.

## Riesgo
Bajo: solo agrega una columna de lectura (2 archivos, +10 líneas).

## Impacto en auto-update
Ninguno (no toca `installer.nsh`, `electron-builder.json` ni manifests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011F4QKV8em1wKJCovuvqUqy