### PR TITLE
fix(transferencia): mostrar preparar para envio en modo central y al avanzar

### DIFF
--- a/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.html
+++ b/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.html
@@ -145,7 +145,7 @@
             Finalizar
           </button>
         </div>
-        <div fxFlex="15%" *ngIf="isPreTransferenciaOrigen && isOrigen">
+        <div fxFlex="15%" *ngIf="isPreTransferenciaOrigen && puedePrepararEnvio">
           <button style="width: 100%" mat-raised-button color="accent"
             (click)="onAvanzarEtapa('PREPARACION_MERCADERIA')" [disabled]="dataSource.data.length == 0">
             Preparar para envio

--- a/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
@@ -189,6 +189,8 @@ export class EditTransferenciaComponent implements OnInit {
 
   isOrigen = false;
   isDestino = false;
+  // Conectado al central la sucursal actual es la "SERVIDOR" (id 0), que nunca es el origen.
+  puedePrepararEnvio = false;
   isPesable = false;
   selection = new SelectionModel<TransferenciaItem>(true, []);
 
@@ -432,6 +434,10 @@ export class EditTransferenciaComponent implements OnInit {
             this.isDestino =
               this.selectedTransferencia?.sucursalDestino?.id ==
               this.mainService?.sucursalActual?.id;
+            this.puedePrepararEnvio =
+              this.isOrigen ||
+              this.mainService?.isServidor ||
+              this.mainService?.sucursalActual?.id == 0;
             this.onVerificarConfirmados();
             this.verificarEtapa();
           }

--- a/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
+++ b/src/app/modules/operaciones/transferencia/edit-transferencia/edit-transferencia.component.ts
@@ -384,6 +384,12 @@ export class EditTransferenciaComponent implements OnInit {
               this.selectedTransferencia.sucursalDestino =
                 saveTransferenciaRes.sucursalDestino;
               this.selectedTransferencia.id = saveTransferenciaRes.id;
+              // mat-tab recrea el componente al volver a la pestaña: con el id en tabData carga
+              // esta transferencia en vez de arrancar otra nueva.
+              if (this.data != null) {
+                this.data.tabData = { ...this.data.tabData, id: saveTransferenciaRes.id };
+              }
+              this.actualizarPermisosPorSucursal();
               this.tabService.changeCurrentTabName(
                 "Transferencia " + this.selectedTransferencia.id
               );
@@ -411,9 +417,8 @@ export class EditTransferenciaComponent implements OnInit {
       });
   }
 
-  cargarDatos() {
+  cargarDatos(id = this.data?.tabData?.["id"]) {
     // this.cargandoService.openDialog(false, "Cargando datos");
-    let id = this.data.tabData["id"];
     if (id != null) {
       this.transferenciaService
         .onGetTransferencia(id)
@@ -428,21 +433,29 @@ export class EditTransferenciaComponent implements OnInit {
               this.pageSize = this.paginator.pageSizeOptions[1];
             }, 0);
             this.getTransferenciaItemList();
-            this.isOrigen =
-              this.selectedTransferencia?.sucursalOrigen?.id ==
-              this.mainService?.sucursalActual?.id;
-            this.isDestino =
-              this.selectedTransferencia?.sucursalDestino?.id ==
-              this.mainService?.sucursalActual?.id;
-            this.puedePrepararEnvio =
-              this.isOrigen ||
-              this.mainService?.isServidor ||
-              this.mainService?.sucursalActual?.id == 0;
+            this.actualizarPermisosPorSucursal();
             this.onVerificarConfirmados();
             this.verificarEtapa();
           }
         });
     }
+  }
+
+  /**
+   * Lo que depende de la sucursal actual. Una transferencia recien creada no pasa por cargarDatos,
+   * asi que tambien se recalcula al guardar las sucursales y al avanzar de etapa.
+   */
+  private actualizarPermisosPorSucursal(): void {
+    this.isOrigen =
+      this.selectedTransferencia?.sucursalOrigen?.id ==
+      this.mainService?.sucursalActual?.id;
+    this.isDestino =
+      this.selectedTransferencia?.sucursalDestino?.id ==
+      this.mainService?.sucursalActual?.id;
+    this.puedePrepararEnvio =
+      this.isOrigen ||
+      this.mainService?.isServidor ||
+      this.mainService?.sucursalActual?.id == 0;
   }
 
   getTransferenciaItemList() {
@@ -522,7 +535,12 @@ export class EditTransferenciaComponent implements OnInit {
   }
 
   onRefresh() {
-    this.ngOnInit();
+    // Recien creada, la pestaña no trae id en tabData: ngOnInit la reiniciaria como transferencia nueva.
+    if (this.selectedTransferencia?.id != null) {
+      this.cargarDatos(this.selectedTransferencia.id);
+    } else {
+      this.ngOnInit();
+    }
   }
 
   verificarEtapa() {
@@ -1205,6 +1223,7 @@ export class EditTransferenciaComponent implements OnInit {
       .subscribe((res) => {
         if (res) {
           this.selectedTransferencia.etapa = etapa;
+          this.actualizarPermisosPorSucursal();
           this.verificarEtapa();
           if (etapa == EtapaTransferencia.PRE_TRANSFERENCIA_CREACION) {
             this.selectedTransferencia.estado = TransferenciaEstado.EN_ORIGEN;


### PR DESCRIPTION
## Qué resuelve

En la gestión de transferencias, el botón **Preparar para envio** no aparecía en dos casos:

1. **Conectado al central.** El botón exigía que la sucursal actual fuera la de origen, pero en modo central la sucursal actual es SERVIDOR (id 0), que nunca es el origen. Ahora también se muestra conectado al central. El backend no valida la sucursal en `avanzarEtapaTransferencia`, solo que la etapa avance.
2. **En una transferencia recién creada.** `isOrigen`, `isDestino` y `puedePrepararEnvio` solo se calculaban en `cargarDatos()`, que no se ejecuta para una transferencia nueva. Al avanzar a `PRE_TRANSFERENCIA_ORIGEN` el botón seguía oculto hasta cerrar y volver a abrir la pestaña (pasaba también en modo sucursal).

Además, **Actualizar** en una transferencia recién creada abría el diálogo de selección de sucursales: volvía a `ngOnInit()` y la pestaña no tenía id en `tabData`.

## Cambios

Todo en `edit-transferencia.component.ts` y `.html`:

- El flag nuevo `puedePrepararEnvio` es verdadero si la sucursal actual es la de origen o si la app está conectada al central.
- `actualizarPermisosPorSucursal()` recalcula los flags al cargar la transferencia, al guardar las sucursales y al avanzar de etapa.
- `onRefresh()` recarga la transferencia por su id si ya existe.
- Al guardar las sucursales, el id queda en `tabData`, porque `mat-tab` recrea el componente al volver a la pestaña.

Los botones que exigen ser el destino (Iniciar Recepción y el Finalizar de recepción) no se tocaron.

## Cómo probar

Con el desktop conectado al central:

1. Transferencias → Nueva Transferencia, elegir origen y destino.
2. Agregar un producto, asignar solicitante y apretar **Finalizar** → Sí.
3. Sin salir de la pestaña, tiene que aparecer **Preparar para envio**.
4. Apretar **Actualizar**: recarga la misma transferencia, sin abrir el diálogo de sucursales.
5. Cambiar a otra pestaña y volver: se mantiene la misma transferencia con el botón visible.

Verificado en Chrome contra el central y el filial de `develop` (transferencias 51343 antes del cambio y 51344 después) y con `npm run check` (0 errores).

## Riesgo

Bajo. Solo cambia la visibilidad del botón y cómo recarga la pantalla de edición de transferencias. No hay cambios de backend, schema GraphQL ni DB.

## Impacto en auto-update

Ninguno: no toca `installer.nsh`, `electron-builder.json` ni los manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Um6vwEBqKK8CnMxY2HDz3e
